### PR TITLE
Add Mach port OCP.1 transport backend for fast local IPC

### DIFF
--- a/Examples/OCADevice/DeviceApp.swift
+++ b/Examples/OCADevice/DeviceApp.swift
@@ -97,6 +97,12 @@ public enum DeviceApp {
     #endif
     let webSocketEndpoint = try await Ocp1WSDeviceEndpoint(address: listenAddress.data)
     #endif
+    #if canImport(Darwin)
+    let machPortEndpoint = try await Ocp1MachPortDeviceEndpoint(
+      serviceName: "com.padl.OCADevice",
+      device: device
+    )
+    #endif
 
     class MyBooleanActuator: SwiftOCADevice.OcaBooleanActuator {
       override open class var classID: OcaClassID { OcaClassID(parent: super.classID, 65280) }
@@ -197,6 +203,12 @@ public enum DeviceApp {
       taskGroup.addTask {
         print("Starting OCP.1 WebSocket endpoint \(webSocketEndpoint)...")
         try await webSocketEndpoint.run()
+      }
+      #endif
+      #if canImport(Darwin)
+      taskGroup.addTask {
+        print("Starting OCP.1 Mach port endpoint \(machPortEndpoint)...")
+        try await machPortEndpoint.run()
       }
       #endif
       try await taskGroup.next()

--- a/Package.swift
+++ b/Package.swift
@@ -123,7 +123,7 @@ PlatformTargets = []
 let CommonPackageDependencies: [Package.Dependency] = [
   .package(url: "https://github.com/apple/swift-async-algorithms", from: "1.0.0"),
   .package(url: "https://github.com/apple/swift-log", from: "1.6.2"),
-  .package(url: "https://github.com/apple/swift-system", from: "1.2.1"),
+  .package(url: "https://github.com/apple/swift-system", from: "1.6.4"),
   .package(url: "https://github.com/apple/swift-atomics", from: "1.2.0"),
   .package(url: "https://github.com/PADL/SocketAddress", from: "0.4.5"),
   .package(url: "https://github.com/lhoward/AsyncExtensions", from: "0.9.0"),
@@ -161,6 +161,7 @@ let CommonTargets: [Target] = [
     ] + PlatformTargetDependencies,
     swiftSettings: [
       .enableExperimentalFeature("StrictConcurrency"),
+      .enableExperimentalFeature("Extern"),
     ]
   ),
   .target(

--- a/Sources/SwiftOCA/OCP.1/Backend/Ocp1MachPortConnection.swift
+++ b/Sources/SwiftOCA/OCP.1/Backend/Ocp1MachPortConnection.swift
@@ -1,0 +1,173 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(Darwin)
+
+import Darwin.Mach
+import Foundation
+
+/// OCP.1 connection using Mach ports for fast local IPC between processes.
+///
+/// The connection discovers the device via a bootstrap service name, performs
+/// a handshake to exchange dedicated send/receive ports, then exchanges OCP.1
+/// PDUs as Mach messages.
+public final class Ocp1MachPortConnection: Ocp1Connection {
+  private let serviceName: String
+
+  /// send right to the device's per-controller receive port
+  private var serverPort: mach_port_t = mach_port_t(0)
+  /// our local receive port handle
+  private var clientHandle: Ocp1MachPortHandle?
+  /// serial queue for blocking mach_msg receive calls
+  private var receiveQueue: DispatchQueue?
+
+  public init(
+    serviceName: String,
+    options: Ocp1ConnectionOptions = Ocp1ConnectionOptions()
+  ) {
+    self.serviceName = serviceName
+    super.init(options: options)
+  }
+
+  override public nonisolated var connectionPrefix: String {
+    "\(OcaMachPortConnectionPrefix)/\(serviceName)"
+  }
+
+  override public var heartbeatTime: Duration {
+    .seconds(1)
+  }
+
+  override public var isDatagram: Bool {
+    true
+  }
+
+  override public func connectDevice() async throws {
+    // 1. Look up the device's listener port via bootstrap
+    let listenerPort = try Ocp1MachPortBootstrap.lookUp(serviceName: serviceName)
+    defer { Ocp1MachPortHandle.deallocateSendRight(listenerPort) }
+
+    // 2. Allocate our receive port
+    let handle = try Ocp1MachPortHandle.allocateReceivePort()
+
+    // 3. Create a send right to transfer to the device
+    let clientSendRight = try handle.makeSendRight()
+
+    // 4. Send connect message with our port, using a temporary reply port
+    let replyHandle = try Ocp1MachPortHandle.allocateReceivePort()
+
+    do {
+      try handle.sendConnect(
+        to: listenerPort,
+        replyPort: replyHandle.port,
+        transferPort: clientSendRight
+      )
+    } catch {
+      replyHandle.destroy()
+      handle.destroy()
+      throw error
+    }
+
+    // 5. Wait for connectReply with timeout
+    let timeoutMs = mach_msg_timeout_t(options.connectionTimeout.asMilliseconds)
+    let replyEnvelope: Ocp1MachPortEnvelope
+    do {
+      replyEnvelope = try replyHandle.receive(timeout: timeoutMs)
+    } catch {
+      replyHandle.destroy()
+      handle.destroy()
+      throw error
+    }
+    replyHandle.destroy()
+
+    guard replyEnvelope.kind == .connectReply,
+          replyEnvelope.transferredPort != mach_port_t(0)
+    else {
+      replyEnvelope.dispose()
+      handle.destroy()
+      throw Ocp1Error.notConnected
+    }
+
+    // 6. Commit state — handshake succeeded
+    clientHandle = handle
+    serverPort = replyEnvelope.transferredPort
+
+    // 7. Create the receive queue for blocking mach_msg
+    receiveQueue = DispatchQueue(label: "com.padl.SwiftOCA.machReceive.\(serviceName)")
+
+    try await super.connectDevice()
+  }
+
+  override public func disconnectDevice() async throws {
+    // best-effort disconnect notification
+    if serverPort != mach_port_t(0) {
+      try? clientHandle?.sendDisconnect(to: serverPort)
+      Ocp1MachPortHandle.deallocateSendRight(serverPort)
+      serverPort = mach_port_t(0)
+    }
+
+    receiveQueue = nil
+
+    clientHandle?.destroy()
+    clientHandle = nil
+
+    try await super.disconnectDevice()
+  }
+
+  override public func read(_ length: Int) async throws -> Data {
+    guard let handle = clientHandle, let queue = receiveQueue else {
+      throw Ocp1Error.notConnected
+    }
+    return try await withCheckedThrowingContinuation { continuation in
+      queue.async {
+        do {
+          while true {
+            let envelope = try handle.receive()
+            switch envelope.kind {
+            case .data:
+              continuation.resume(returning: envelope.payload)
+              return
+            case .disconnect:
+              continuation.resume(throwing: Ocp1Error.notConnected)
+              return
+            case .connectReply, .connect:
+              envelope.dispose()
+              continue
+            }
+          }
+        } catch {
+          continuation.resume(throwing: error)
+        }
+      }
+    }
+  }
+
+  override public func write(_ data: Data) async throws -> Int {
+    guard serverPort != mach_port_t(0), let handle = clientHandle else {
+      throw Ocp1Error.notConnected
+    }
+    try handle.sendData(data, to: serverPort)
+    return data.count
+  }
+}
+
+private extension Duration {
+  var asMilliseconds: Int64 {
+    let (seconds, attoseconds) = components
+    return seconds * 1000 + attoseconds / 1_000_000_000_000_000
+  }
+}
+
+#endif

--- a/Sources/SwiftOCA/OCP.1/Backend/Ocp1MachPortSupport.swift
+++ b/Sources/SwiftOCA/OCP.1/Backend/Ocp1MachPortSupport.swift
@@ -1,0 +1,638 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(Darwin)
+
+import Darwin.Mach
+import Foundation
+import Synchronization
+import SystemPackage
+
+// OcaMachPortConnectionPrefix is defined in Ocp1Connection.swift
+
+// MARK: - Swift equivalents of Mach macros
+
+private let _MACH_PORT_NULL = mach_port_t(0)
+
+private func _MACH_MSGH_BITS(
+  _ remote: mach_msg_bits_t,
+  _ local: mach_msg_bits_t
+) -> mach_msg_bits_t {
+  remote | (local << 8)
+}
+
+private let _MACH_MSGH_BITS_COMPLEX = mach_msg_bits_t(0x80000000)
+private let _MAX_TRAILER_SIZE = MemoryLayout<mach_msg_max_trailer_t>.size
+
+// MARK: - Transport message kinds
+
+package enum Ocp1MachPortMessageID: mach_msg_id_t {
+  case connect = 1
+  case connectReply = 2
+  case data = 3
+  case disconnect = 4
+}
+
+// MARK: - Inline vs OOL threshold
+
+/// Payloads up to this size are sent inline in the Mach message body,
+/// avoiding the VM mapping overhead of OOL descriptors. Larger payloads
+/// use OOL with virtual copy.
+private let _inlineThreshold = 4096
+
+// MARK: - Mach message structures for send/receive
+
+// -- OOL (out-of-line) data messages for large payloads --
+
+private struct Ocp1MachOOLDataMessageSend {
+  var header: mach_msg_header_t
+  var body: mach_msg_body_t
+  var payload: mach_msg_ool_descriptor_t
+
+  init(
+    remotePort: mach_port_t,
+    localPort: mach_port_t,
+    id: Ocp1MachPortMessageID,
+    address: UnsafeRawPointer,
+    size: Int
+  ) {
+    header = mach_msg_header_t()
+    header.msgh_bits = _MACH_MSGH_BITS(
+      mach_msg_bits_t(MACH_MSG_TYPE_COPY_SEND),
+      localPort != _MACH_PORT_NULL ? mach_msg_bits_t(MACH_MSG_TYPE_MAKE_SEND) : 0
+    ) | _MACH_MSGH_BITS_COMPLEX
+    header.msgh_size = mach_msg_size_t(MemoryLayout<Self>.size)
+    header.msgh_remote_port = remotePort
+    header.msgh_local_port = localPort
+    header.msgh_id = id.rawValue
+
+    body = mach_msg_body_t()
+    body.msgh_descriptor_count = 1
+
+    payload = mach_msg_ool_descriptor_t()
+    payload.address = UnsafeMutableRawPointer(mutating: address)
+    payload.size = mach_msg_size_t(size)
+    payload.deallocate = 0
+    payload.copy = mach_msg_copy_options_t(MACH_MSG_VIRTUAL_COPY)
+    payload.type = mach_msg_descriptor_type_t(MACH_MSG_OOL_DESCRIPTOR)
+  }
+}
+
+private struct Ocp1MachOOLDataMessageReceive {
+  var header: mach_msg_header_t
+  var body: mach_msg_body_t
+  var payload: mach_msg_ool_descriptor_t
+  var trailer: mach_msg_max_trailer_t
+
+  init() {
+    header = mach_msg_header_t()
+    body = mach_msg_body_t()
+    payload = mach_msg_ool_descriptor_t()
+    trailer = mach_msg_max_trailer_t()
+  }
+}
+
+// -- Port transfer messages --
+
+private struct Ocp1MachPortTransferMessageSend {
+  var header: mach_msg_header_t
+  var body: mach_msg_body_t
+  var port: mach_msg_port_descriptor_t
+
+  init(
+    remotePort: mach_port_t,
+    id: Ocp1MachPortMessageID,
+    transferPort: mach_port_t
+  ) {
+    header = mach_msg_header_t()
+    header.msgh_bits = _MACH_MSGH_BITS(
+      mach_msg_bits_t(MACH_MSG_TYPE_COPY_SEND),
+      0
+    ) | _MACH_MSGH_BITS_COMPLEX
+    header.msgh_size = mach_msg_size_t(MemoryLayout<Self>.size)
+    header.msgh_remote_port = remotePort
+    header.msgh_local_port = _MACH_PORT_NULL
+    header.msgh_id = id.rawValue
+
+    body = mach_msg_body_t()
+    body.msgh_descriptor_count = 1
+
+    port = mach_msg_port_descriptor_t()
+    port.name = transferPort
+    port.disposition = mach_msg_type_name_t(MACH_MSG_TYPE_MOVE_SEND)
+    port.type = mach_msg_descriptor_type_t(MACH_MSG_PORT_DESCRIPTOR)
+  }
+}
+
+private struct Ocp1MachConnectMessageSend {
+  var header: mach_msg_header_t
+  var body: mach_msg_body_t
+  var port: mach_msg_port_descriptor_t
+
+  init(
+    remotePort: mach_port_t,
+    replyPort: mach_port_t,
+    transferPort: mach_port_t
+  ) {
+    header = mach_msg_header_t()
+    header.msgh_bits = _MACH_MSGH_BITS(
+      mach_msg_bits_t(MACH_MSG_TYPE_COPY_SEND),
+      mach_msg_bits_t(MACH_MSG_TYPE_MAKE_SEND)
+    ) | _MACH_MSGH_BITS_COMPLEX
+    header.msgh_size = mach_msg_size_t(MemoryLayout<Self>.size)
+    header.msgh_remote_port = remotePort
+    header.msgh_local_port = replyPort
+    header.msgh_id = Ocp1MachPortMessageID.connect.rawValue
+
+    body = mach_msg_body_t()
+    body.msgh_descriptor_count = 1
+
+    port = mach_msg_port_descriptor_t()
+    port.name = transferPort
+    port.disposition = mach_msg_type_name_t(MACH_MSG_TYPE_MOVE_SEND)
+    port.type = mach_msg_descriptor_type_t(MACH_MSG_PORT_DESCRIPTOR)
+  }
+}
+
+private struct Ocp1MachPortTransferMessageReceive {
+  var header: mach_msg_header_t
+  var body: mach_msg_body_t
+  var port: mach_msg_port_descriptor_t
+  var trailer: mach_msg_max_trailer_t
+
+  init() {
+    header = mach_msg_header_t()
+    body = mach_msg_body_t()
+    port = mach_msg_port_descriptor_t()
+    trailer = mach_msg_max_trailer_t()
+  }
+}
+
+// MARK: - Received envelope
+
+package struct Ocp1MachPortEnvelope: Sendable {
+  package let kind: Ocp1MachPortMessageID
+  package let payload: Data
+  package let transferredPort: mach_port_t
+  package let replyPort: mach_port_t
+
+  /// Deallocate any port rights carried by this envelope. Call when
+  /// discarding an envelope whose rights are not otherwise consumed.
+  package func dispose() {
+    Ocp1MachPortHandle.deallocateSendRight(transferredPort)
+    Ocp1MachPortHandle.deallocateSendRight(replyPort)
+  }
+}
+
+// MARK: - Mach port handle wrapper
+
+/// Manages a Mach receive right. Send rights to remote ports are tracked
+/// separately by callers (and cleaned up via `deallocateSendRight`).
+package final class Ocp1MachPortHandle: Sendable {
+  package let port: mach_port_t
+  private let destroyed = Mutex(false)
+
+  private init(port: mach_port_t) {
+    self.port = port
+  }
+
+  /// Allocate a new receive right using swift-system's `Mach.Port`,
+  /// then take ownership of the raw name for use with `mach_msg`.
+  package static func allocateReceivePort() throws -> Ocp1MachPortHandle {
+    let receiveRight = Mach.Port<Mach.ReceiveRight>()
+    let name = receiveRight.unguardAndRelinquish()
+    // set queue limit
+    var limits = mach_port_limits_t(mpl_qlimit: 64)
+    _ = withUnsafeMutablePointer(to: &limits) { limitsPtr in
+      limitsPtr.withMemoryRebound(
+        to: integer_t.self,
+        capacity: MemoryLayout<mach_port_limits_t>.size / MemoryLayout<integer_t>.size
+      ) { intPtr in
+        mach_port_set_attributes(
+          mach_task_self_,
+          name,
+          MACH_PORT_LIMITS_INFO,
+          intPtr,
+          mach_msg_type_number_t(
+            MemoryLayout<mach_port_limits_t>.size / MemoryLayout<integer_t>.size
+          )
+        )
+      }
+    }
+    return Ocp1MachPortHandle(port: name)
+  }
+
+  /// Create a send right for this receive port. Caller is responsible
+  /// for deallocating via `deallocateSendRight` or transferring via a
+  /// Mach message with `MACH_MSG_TYPE_MOVE_SEND`.
+  package func makeSendRight() throws -> mach_port_t {
+    let kr = mach_port_insert_right(
+      mach_task_self_,
+      port,
+      port,
+      mach_msg_type_name_t(MACH_MSG_TYPE_MAKE_SEND)
+    )
+    guard kr == KERN_SUCCESS else {
+      throw Ocp1Error.status(.deviceError)
+    }
+    return port
+  }
+
+  // MARK: - Sending
+
+  package func sendData(_ data: Data, to remotePort: mach_port_t) throws {
+    try data.withUnsafeBytes { buffer in
+      guard let baseAddress = buffer.baseAddress else { return }
+      if buffer.count <= _inlineThreshold {
+        try _sendDataInline(baseAddress, count: buffer.count, to: remotePort)
+      } else {
+        try _sendDataOOL(baseAddress, count: buffer.count, to: remotePort)
+      }
+    }
+  }
+
+  private func _sendDataInline(
+    _ baseAddress: UnsafeRawPointer,
+    count: Int,
+    to remotePort: mach_port_t
+  ) throws {
+    let headerSize = MemoryLayout<mach_msg_header_t>.size
+    let rawSize = headerSize + count
+    // Mach messages must be naturally aligned (multiple of 4 bytes)
+    let totalSize = (rawSize + 3) & ~3
+    let buffer = UnsafeMutableRawPointer.allocate(
+      byteCount: totalSize,
+      alignment: MemoryLayout<mach_msg_header_t>.alignment
+    )
+    defer { buffer.deallocate() }
+
+    buffer.initializeMemory(as: UInt8.self, repeating: 0, count: totalSize)
+
+    let hdr = buffer.assumingMemoryBound(to: mach_msg_header_t.self)
+    hdr.pointee.msgh_bits = _MACH_MSGH_BITS(
+      mach_msg_bits_t(MACH_MSG_TYPE_COPY_SEND),
+      0
+    )
+    hdr.pointee.msgh_size = mach_msg_size_t(rawSize)
+    hdr.pointee.msgh_remote_port = remotePort
+    hdr.pointee.msgh_local_port = _MACH_PORT_NULL
+    hdr.pointee.msgh_id = Ocp1MachPortMessageID.data.rawValue
+
+    buffer.advanced(by: headerSize).copyMemory(from: baseAddress, byteCount: count)
+
+    let kr = mach_msg(
+      hdr,
+      MACH_SEND_MSG,
+      mach_msg_size_t(totalSize),
+      0,
+      _MACH_PORT_NULL,
+      MACH_MSG_TIMEOUT_NONE,
+      _MACH_PORT_NULL
+    )
+    guard kr == MACH_MSG_SUCCESS else {
+      throw Ocp1Error.pduSendingFailed
+    }
+  }
+
+  private func _sendDataOOL(
+    _ baseAddress: UnsafeRawPointer,
+    count: Int,
+    to remotePort: mach_port_t
+  ) throws {
+    var msg = Ocp1MachOOLDataMessageSend(
+      remotePort: remotePort,
+      localPort: _MACH_PORT_NULL,
+      id: .data,
+      address: baseAddress,
+      size: count
+    )
+    let kr = withUnsafeMutablePointer(to: &msg) { msgPtr in
+      msgPtr.withMemoryRebound(to: mach_msg_header_t.self, capacity: 1) { hdr in
+        mach_msg(
+          hdr,
+          MACH_SEND_MSG,
+          mach_msg_size_t(MemoryLayout<Ocp1MachOOLDataMessageSend>.size),
+          0,
+          _MACH_PORT_NULL,
+          MACH_MSG_TIMEOUT_NONE,
+          _MACH_PORT_NULL
+        )
+      }
+    }
+    guard kr == MACH_MSG_SUCCESS else {
+      throw Ocp1Error.pduSendingFailed
+    }
+  }
+
+  package func sendConnect(
+    to remotePort: mach_port_t,
+    replyPort: mach_port_t,
+    transferPort: mach_port_t
+  ) throws {
+    var msg = Ocp1MachConnectMessageSend(
+      remotePort: remotePort,
+      replyPort: replyPort,
+      transferPort: transferPort
+    )
+    let kr = withUnsafeMutablePointer(to: &msg) { msgPtr in
+      msgPtr.withMemoryRebound(to: mach_msg_header_t.self, capacity: 1) { hdr in
+        mach_msg(
+          hdr,
+          MACH_SEND_MSG,
+          mach_msg_size_t(MemoryLayout<Ocp1MachConnectMessageSend>.size),
+          0,
+          _MACH_PORT_NULL,
+          MACH_MSG_TIMEOUT_NONE,
+          _MACH_PORT_NULL
+        )
+      }
+    }
+    guard kr == MACH_MSG_SUCCESS else {
+      throw Ocp1Error.pduSendingFailed
+    }
+  }
+
+  package func sendPortTransfer(
+    to remotePort: mach_port_t,
+    id: Ocp1MachPortMessageID,
+    transferPort: mach_port_t
+  ) throws {
+    var msg = Ocp1MachPortTransferMessageSend(
+      remotePort: remotePort,
+      id: id,
+      transferPort: transferPort
+    )
+    let kr = withUnsafeMutablePointer(to: &msg) { msgPtr in
+      msgPtr.withMemoryRebound(to: mach_msg_header_t.self, capacity: 1) { hdr in
+        mach_msg(
+          hdr,
+          MACH_SEND_MSG,
+          mach_msg_size_t(MemoryLayout<Ocp1MachPortTransferMessageSend>.size),
+          0,
+          _MACH_PORT_NULL,
+          MACH_MSG_TIMEOUT_NONE,
+          _MACH_PORT_NULL
+        )
+      }
+    }
+    guard kr == MACH_MSG_SUCCESS else {
+      throw Ocp1Error.pduSendingFailed
+    }
+  }
+
+  package func sendDisconnect(to remotePort: mach_port_t) throws {
+    var header = mach_msg_header_t()
+    header.msgh_bits = _MACH_MSGH_BITS(
+      mach_msg_bits_t(MACH_MSG_TYPE_COPY_SEND),
+      0
+    )
+    header.msgh_size = mach_msg_size_t(MemoryLayout<mach_msg_header_t>.size)
+    header.msgh_remote_port = remotePort
+    header.msgh_local_port = _MACH_PORT_NULL
+    header.msgh_id = Ocp1MachPortMessageID.disconnect.rawValue
+
+    let kr = withUnsafeMutablePointer(to: &header) { hdr in
+      mach_msg(
+        hdr,
+        MACH_SEND_MSG,
+        mach_msg_size_t(MemoryLayout<mach_msg_header_t>.size),
+        0,
+        _MACH_PORT_NULL,
+        MACH_MSG_TIMEOUT_NONE,
+        _MACH_PORT_NULL
+      )
+    }
+    guard kr == MACH_MSG_SUCCESS else {
+      throw Ocp1Error.pduSendingFailed
+    }
+  }
+
+  // MARK: - Receiving
+
+  /// Receive a message with no timeout (blocks indefinitely).
+  package func receive() throws -> Ocp1MachPortEnvelope {
+    try _receive(timeout: MACH_MSG_TIMEOUT_NONE, options: 0)
+  }
+
+  /// Receive a message with a timeout in milliseconds.
+  /// Throws `Ocp1Error.responseTimeout` if the timeout expires.
+  package func receive(timeout: mach_msg_timeout_t) throws -> Ocp1MachPortEnvelope {
+    try _receive(timeout: timeout, options: MACH_RCV_TIMEOUT)
+  }
+
+  private func _receive(
+    timeout: mach_msg_timeout_t,
+    options: mach_msg_option_t
+  ) throws -> Ocp1MachPortEnvelope {
+    let headerSize = MemoryLayout<mach_msg_header_t>.size
+    let bufferSize = max(
+      MemoryLayout<Ocp1MachOOLDataMessageReceive>.size,
+      MemoryLayout<Ocp1MachPortTransferMessageReceive>.size,
+      headerSize + _inlineThreshold + _MAX_TRAILER_SIZE
+    )
+    let alignment = MemoryLayout<mach_msg_header_t>.alignment
+    let buffer = UnsafeMutableRawPointer.allocate(
+      byteCount: bufferSize,
+      alignment: alignment
+    )
+    defer { buffer.deallocate() }
+    buffer.initializeMemory(as: UInt8.self, repeating: 0, count: bufferSize)
+
+    let hdr = buffer.assumingMemoryBound(to: mach_msg_header_t.self)
+    let kr = mach_msg(
+      hdr,
+      MACH_RCV_MSG | MACH_RCV_LARGE | options,
+      0,
+      mach_msg_size_t(bufferSize),
+      port,
+      timeout,
+      _MACH_PORT_NULL
+    )
+
+    if kr == MACH_RCV_TIMED_OUT {
+      throw Ocp1Error.responseTimeout
+    }
+    guard kr == MACH_MSG_SUCCESS else {
+      throw Ocp1Error.notConnected
+    }
+
+    guard let kind = Ocp1MachPortMessageID(rawValue: hdr.pointee.msgh_id) else {
+      mach_msg_destroy(hdr)
+      throw Ocp1Error.invalidMessageType
+    }
+
+    let replyPort = hdr.pointee.msgh_remote_port
+    let isComplex = (hdr.pointee.msgh_bits & _MACH_MSGH_BITS_COMPLEX) != 0
+
+    switch kind {
+    case .data:
+      if isComplex {
+        let msg = buffer.load(as: Ocp1MachOOLDataMessageReceive.self)
+        guard msg.body.msgh_descriptor_count == 1,
+              msg.payload.type == mach_msg_descriptor_type_t(MACH_MSG_OOL_DESCRIPTOR)
+        else {
+          mach_msg_destroy(hdr)
+          throw Ocp1Error.invalidMessageType
+        }
+        let payload: Data
+        if let address = msg.payload.address, msg.payload.size > 0 {
+          payload = Data(bytes: address, count: Int(msg.payload.size))
+          vm_deallocate(
+            mach_task_self_,
+            vm_address_t(bitPattern: address),
+            vm_size_t(msg.payload.size)
+          )
+        } else {
+          payload = Data()
+        }
+        return Ocp1MachPortEnvelope(
+          kind: .data,
+          payload: payload,
+          transferredPort: _MACH_PORT_NULL,
+          replyPort: replyPort
+        )
+      } else {
+        let msgSize = Int(hdr.pointee.msgh_size)
+        let payloadSize = msgSize - headerSize
+        let payload: Data
+        if payloadSize > 0 {
+          payload = Data(bytes: buffer.advanced(by: headerSize), count: payloadSize)
+        } else {
+          payload = Data()
+        }
+        return Ocp1MachPortEnvelope(
+          kind: .data,
+          payload: payload,
+          transferredPort: _MACH_PORT_NULL,
+          replyPort: replyPort
+        )
+      }
+
+    case .connect, .connectReply:
+      guard isComplex else {
+        throw Ocp1Error.invalidMessageType
+      }
+      let msg = buffer.load(as: Ocp1MachPortTransferMessageReceive.self)
+      guard msg.body.msgh_descriptor_count == 1,
+            msg.port.type == mach_msg_descriptor_type_t(MACH_MSG_PORT_DESCRIPTOR)
+      else {
+        mach_msg_destroy(hdr)
+        throw Ocp1Error.invalidMessageType
+      }
+      return Ocp1MachPortEnvelope(
+        kind: kind,
+        payload: Data(),
+        transferredPort: msg.port.name,
+        replyPort: replyPort
+      )
+
+    case .disconnect:
+      return Ocp1MachPortEnvelope(
+        kind: .disconnect,
+        payload: Data(),
+        transferredPort: _MACH_PORT_NULL,
+        replyPort: replyPort
+      )
+    }
+  }
+
+  // MARK: - Lifecycle
+
+  /// Destroy the receive right (and any coalesced send rights).
+  package func destroy() {
+    let shouldDestroy = destroyed.withLock { destroyed -> Bool in
+      guard !destroyed else { return false }
+      destroyed = true
+      return true
+    }
+    if shouldDestroy {
+      mach_port_destroy(mach_task_self_, port)
+    }
+  }
+
+  /// Deallocate a send right obtained via `makeSendRight()` or received
+  /// in a Mach message port descriptor.
+  package static func deallocateSendRight(_ port: mach_port_t) {
+    guard port != _MACH_PORT_NULL else { return }
+    mach_port_deallocate(mach_task_self_, port)
+  }
+
+  deinit {
+    destroy()
+  }
+}
+
+// MARK: - Bootstrap API imports (not exposed to Swift by the Darwin overlay)
+
+@_extern(c, "bootstrap_look_up")
+private func _bootstrap_look_up(
+  _ bp: mach_port_t,
+  _ serviceName: UnsafePointer<CChar>,
+  _ sp: UnsafeMutablePointer<mach_port_t>
+) -> kern_return_t
+
+@_extern(c, "bootstrap_register")
+private func _bootstrap_register(
+  _ bp: mach_port_t,
+  _ serviceName: UnsafePointer<CChar>,
+  _ sp: mach_port_t
+) -> kern_return_t
+
+@_extern(c, "bootstrap_check_in")
+private func _bootstrap_check_in(
+  _ bp: mach_port_t,
+  _ serviceName: UnsafePointer<CChar>,
+  _ sp: UnsafeMutablePointer<mach_port_t>
+) -> kern_return_t
+
+// MARK: - Bootstrap helpers
+
+// bootstrap_port is a global mutable var in the Mach headers, which triggers
+// concurrency warnings in Swift 6. It is effectively read-only after process init.
+@_extern(c, "bootstrap_port")
+private nonisolated(unsafe) var _bootstrapPort: mach_port_t
+
+package enum Ocp1MachPortBootstrap {
+  package static func lookUp(serviceName: String) throws -> mach_port_t {
+    var port = mach_port_t()
+    let kr = _bootstrap_look_up(_bootstrapPort, serviceName, &port)
+    guard kr == KERN_SUCCESS else {
+      throw Ocp1Error.notConnected
+    }
+    return port
+  }
+
+  package static func register(
+    serviceName: String,
+    port: mach_port_t
+  ) throws {
+    let kr = _bootstrap_register(_bootstrapPort, serviceName, port)
+    guard kr == KERN_SUCCESS else {
+      throw Ocp1Error.status(.deviceError)
+    }
+  }
+
+  package static func checkIn(serviceName: String) throws -> mach_port_t {
+    var port = mach_port_t()
+    let kr = _bootstrap_check_in(_bootstrapPort, serviceName, &port)
+    guard kr == KERN_SUCCESS else {
+      throw Ocp1Error.status(.deviceError)
+    }
+    return port
+  }
+}
+
+#endif

--- a/Sources/SwiftOCA/OCP.1/Ocp1Connection.swift
+++ b/Sources/SwiftOCA/OCP.1/Ocp1Connection.swift
@@ -75,6 +75,9 @@ public let OcaSecureTcpConnectionPrefix = "ocasec/tcp"
 public let OcaWebSocketTcpConnectionPrefix = "ocaws/tcp"
 public let OcaLocalConnectionPrefix = "oca/local"
 public let OcaDatagramProxyConnectionPrefix = "oca/dg-proxy"
+#if canImport(Darwin)
+public let OcaMachPortConnectionPrefix = "oca/mach"
+#endif
 
 public struct Ocp1ConnectionFlags: OptionSet, Sendable {
   public static let automaticReconnect = Ocp1ConnectionFlags(rawValue: 1 << 0)

--- a/Sources/SwiftOCADevice/OCP.1/Backend/MachPort/Ocp1MachPortController.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/MachPort/Ocp1MachPortController.swift
@@ -1,0 +1,118 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(Darwin)
+
+import AsyncExtensions
+import Darwin.Mach
+import Foundation
+@_spi(SwiftOCAPrivate)
+import SwiftOCA
+
+actor Ocp1MachPortController: Ocp1ControllerInternal {
+  nonisolated var flags: OcaControllerFlags { .supportsLocking }
+  nonisolated var connectionPrefix: String { OcaMachPortConnectionPrefix }
+
+  var lastMessageReceivedTime = ContinuousClock.recentPast
+  var lastMessageSentTime = ContinuousClock.recentPast
+  var heartbeatTime = Duration.seconds(0) {
+    didSet {
+      heartbeatTimeDidChange(from: oldValue)
+    }
+  }
+
+  var keepAliveTask: Task<(), Error>?
+
+  weak var endpoint: Ocp1MachPortDeviceEndpoint?
+  var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()
+
+  /// our dedicated receive port for this controller session
+  private let receiveHandle: Ocp1MachPortHandle
+  /// send right to the client's receive port
+  private let clientSendPort: mach_port_t
+  private let _messages: AsyncThrowingStream<Ocp1MessageList, Error>
+
+  nonisolated let identifier: String
+
+  init(
+    endpoint: Ocp1MachPortDeviceEndpoint,
+    receiveHandle: Ocp1MachPortHandle,
+    clientSendPort: mach_port_t,
+    identifier: String
+  ) {
+    self.endpoint = endpoint
+    self.receiveHandle = receiveHandle
+    self.clientSendPort = clientSendPort
+    self.identifier = identifier
+
+    let (stream, continuation) = AsyncThrowingStream<Ocp1MessageList, Error>.makeStream()
+    _messages = stream
+
+    let handle = receiveHandle
+    DispatchQueue(
+      label: "com.padl.SwiftOCADevice.machReceive"
+    ).async {
+      do {
+        while true {
+          let envelope = try handle.receive()
+          switch envelope.kind {
+          case .data:
+            let messageList = try Ocp1MessageList(messagePduData: envelope.payload)
+            continuation.yield(messageList)
+          case .disconnect:
+            continuation.finish(throwing: Ocp1Error.notConnected)
+            return
+          case .connect, .connectReply:
+            envelope.dispose()
+          }
+        }
+      } catch {
+        continuation.finish(throwing: error)
+      }
+    }
+  }
+
+  var messages: AnyAsyncSequence<Ocp1MessageList> {
+    _messages.eraseToAnyAsyncSequence()
+  }
+
+  func sendOcp1EncodedData(_ data: Data) async throws {
+    try receiveHandle.sendData(data, to: clientSendPort)
+  }
+
+  func close() throws {
+    try? receiveHandle.sendDisconnect(to: clientSendPort)
+    Ocp1MachPortHandle.deallocateSendRight(clientSendPort)
+    receiveHandle.destroy()
+  }
+}
+
+extension Ocp1MachPortController: Equatable {
+  nonisolated static func == (
+    lhs: Ocp1MachPortController,
+    rhs: Ocp1MachPortController
+  ) -> Bool {
+    lhs.receiveHandle.port == rhs.receiveHandle.port
+  }
+}
+
+extension Ocp1MachPortController: Hashable {
+  nonisolated func hash(into hasher: inout Hasher) {
+    hasher.combine(receiveHandle.port)
+  }
+}
+
+#endif

--- a/Sources/SwiftOCADevice/OCP.1/Backend/MachPort/Ocp1MachPortDeviceEndpoint.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/MachPort/Ocp1MachPortDeviceEndpoint.swift
@@ -1,0 +1,177 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(Darwin)
+
+import AsyncExtensions
+import Darwin.Mach
+import Foundation
+import Logging
+@_spi(SwiftOCAPrivate)
+import SwiftOCA
+
+/// OCP.1 device endpoint using Mach ports for fast local IPC.
+///
+/// Registers a bootstrap service name and listens for incoming Mach port
+/// connections. Each connecting controller gets a dedicated pair of ports
+/// for bidirectional OCP.1 PDU exchange.
+@OcaDevice
+public final class Ocp1MachPortDeviceEndpoint: OcaDeviceEndpointPrivate, CustomStringConvertible {
+  typealias ControllerType = Ocp1MachPortController
+
+  let timeout: Duration
+  let device: OcaDevice
+  let logger: Logger
+  nonisolated(unsafe) var enableMessageTracing = false
+
+  public var controllers: [OcaController] {
+    _controllers
+  }
+
+  private let serviceName: String
+  private var listenerHandle: Ocp1MachPortHandle?
+  private var _controllers = [Ocp1MachPortController]()
+  private var nextControllerID = 0
+
+  public init(
+    serviceName: String,
+    timeout: Duration = OcaDevice.DefaultTimeout,
+    device: OcaDevice = OcaDevice.shared,
+    logger: Logger = Logger(
+      label: "com.padl.SwiftOCADevice.Ocp1MachPortDeviceEndpoint"
+    )
+  ) async throws {
+    self.serviceName = serviceName
+    self.timeout = timeout
+    self.device = device
+    self.logger = logger
+
+    try await device.add(endpoint: self)
+  }
+
+  public nonisolated var description: String {
+    "\(type(of: self))(serviceName: \(serviceName))"
+  }
+
+  public func run() async throws {
+    let handle = try Ocp1MachPortHandle.allocateReceivePort()
+    listenerHandle = handle
+
+    try Ocp1MachPortBootstrap.register(
+      serviceName: serviceName,
+      port: handle.port
+    )
+
+    logger.info("started \(type(of: self)) on \(serviceName)")
+
+    do {
+      try await listenForControllers(on: handle)
+    } catch {
+      logger.critical("server error for \(serviceName): \(error)")
+      handle.destroy()
+      listenerHandle = nil
+      throw error
+    }
+
+    try await device.remove(endpoint: self)
+  }
+
+  private func listenForControllers(on listenerHandle: Ocp1MachPortHandle) async throws {
+    let acceptStream = AsyncThrowingStream<Ocp1MachPortEnvelope, Error> { continuation in
+      DispatchQueue(
+        label: "com.padl.SwiftOCADevice.machAccept"
+      ).async {
+        do {
+          while true {
+            let envelope = try listenerHandle.receive()
+            continuation.yield(envelope)
+          }
+        } catch {
+          continuation.finish(throwing: error)
+        }
+      }
+    }
+
+    try await withThrowingDiscardingTaskGroup { group in
+      for try await envelope in acceptStream {
+        guard envelope.kind == .connect,
+              envelope.transferredPort != mach_port_t(0)
+        else {
+          envelope.dispose()
+          continue
+        }
+
+        let clientSendPort = envelope.transferredPort
+        let replyPort = envelope.replyPort
+
+        // Allocate a dedicated controller receive port and create a send
+        // right to transfer to the client via the connectReply.
+        let controllerHandle: Ocp1MachPortHandle
+        let controllerSendRight: mach_port_t
+        do {
+          controllerHandle = try Ocp1MachPortHandle.allocateReceivePort()
+          controllerSendRight = try controllerHandle.makeSendRight()
+        } catch {
+          Ocp1MachPortHandle.deallocateSendRight(clientSendPort)
+          Ocp1MachPortHandle.deallocateSendRight(replyPort)
+          logger.warning("failed to allocate controller port: \(error)")
+          continue
+        }
+
+        do {
+          try controllerHandle.sendPortTransfer(
+            to: replyPort,
+            id: .connectReply,
+            transferPort: controllerSendRight
+          )
+        } catch {
+          Ocp1MachPortHandle.deallocateSendRight(clientSendPort)
+          Ocp1MachPortHandle.deallocateSendRight(replyPort)
+          controllerHandle.destroy()
+          logger.warning("failed to send connectReply: \(error)")
+          continue
+        }
+
+        // Deallocate the reply port send right — no longer needed
+        Ocp1MachPortHandle.deallocateSendRight(replyPort)
+
+        let controllerID = nextControllerID
+        nextControllerID += 1
+
+        let controller = Ocp1MachPortController(
+          endpoint: self,
+          receiveHandle: controllerHandle,
+          clientSendPort: clientSendPort,
+          identifier: "mach-\(controllerID)"
+        )
+
+        group.addTask {
+          await controller.handle(for: self)
+        }
+      }
+    }
+  }
+
+  func add(controller: ControllerType) async {
+    _controllers.append(controller)
+  }
+
+  func remove(controller: ControllerType) async {
+    _controllers.removeAll(where: { $0 == controller })
+  }
+}
+
+#endif

--- a/Tests/SwiftOCADeviceTests/MachPortConnectionTests.swift
+++ b/Tests/SwiftOCADeviceTests/MachPortConnectionTests.swift
@@ -1,0 +1,339 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(Darwin)
+
+@testable @_spi(SwiftOCAPrivate) import SwiftOCA
+@testable @_spi(SwiftOCAPrivate) import SwiftOCADevice
+@preconcurrency import XCTest
+
+private func uniqueServiceName(_ test: String) -> String {
+  "com.padl.SwiftOCA.test.machport.\(ProcessInfo.processInfo.processIdentifier).\(test).\(UInt32.random(in: 0...UInt32.max))"
+}
+
+@OcaConnection
+private func makeMachPortConnection(
+  serviceName: String
+) -> Ocp1MachPortConnection {
+  Ocp1MachPortConnection(
+    serviceName: serviceName,
+    options: Ocp1ConnectionOptions(flags: .refreshDeviceTreeOnConnection)
+  )
+}
+
+final class MachPortConnectionTests: XCTestCase {
+  func testMachPortConnectDisconnect() async throws {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+
+    let serviceName = uniqueServiceName("connectDisconnect")
+    let endpoint = try await Ocp1MachPortDeviceEndpoint(
+      serviceName: serviceName,
+      device: device
+    )
+    let endpointTask = Task { try await endpoint.run() }
+    defer { endpointTask.cancel() }
+
+    try await Task.sleep(for: .milliseconds(100))
+
+    let connection = await makeMachPortConnection(serviceName: serviceName)
+    try await connection.connect()
+
+    let connected = await connection.isConnected
+    XCTAssertTrue(connected, "Mach port connection should be connected")
+
+    let deviceManagerONo = await connection.deviceManager.objectNumber
+    XCTAssertEqual(deviceManagerONo, OcaDeviceManagerONo)
+
+    try await connection.disconnect()
+  }
+
+  func testMachPortRoundTrip() async throws {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+
+    let serviceName = uniqueServiceName("roundTrip")
+    let endpoint = try await Ocp1MachPortDeviceEndpoint(
+      serviceName: serviceName,
+      device: device
+    )
+    let endpointTask = Task { try await endpoint.run() }
+    defer { endpointTask.cancel() }
+
+    try await Task.sleep(for: .milliseconds(100))
+
+    let connection = await makeMachPortConnection(serviceName: serviceName)
+    try await connection.connect()
+
+    // Verify OCA command round-trip via device manager
+    let deviceManagerONo = await connection.deviceManager.objectNumber
+    XCTAssertEqual(deviceManagerONo, OcaDeviceManagerONo)
+
+    // Verify we can query the network manager too
+    let networkManagerONo = await connection.networkManager.objectNumber
+    XCTAssertEqual(networkManagerONo, OcaNetworkManagerONo)
+
+    // Verify actual OCA command round-trip
+    let members = try await connection.rootBlock.resolveActionObjects()
+    XCTAssertFalse(members.isEmpty, "Root block should have action objects")
+
+    try await connection.disconnect()
+  }
+
+  func testMachPortControllerCleanup() async throws {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+
+    let serviceName = uniqueServiceName("controllerCleanup")
+    let endpoint = try await Ocp1MachPortDeviceEndpoint(
+      serviceName: serviceName,
+      timeout: .seconds(3),
+      device: device
+    )
+    let endpointTask = Task { try await endpoint.run() }
+    defer { endpointTask.cancel() }
+
+    try await Task.sleep(for: .milliseconds(100))
+
+    let connection = await makeMachPortConnection(serviceName: serviceName)
+    try await connection.connect()
+
+    let controllers = await endpoint.controllers
+    XCTAssertEqual(controllers.count, 1)
+
+    try await connection.disconnect()
+
+    try await Task.sleep(for: .seconds(1))
+    let controllersAfterDisconnect = await endpoint.controllers
+    XCTAssertEqual(
+      controllersAfterDisconnect.count, 0,
+      "Server controller was not cleaned up after Mach port client disconnected"
+    )
+  }
+
+  func testMachPortMultipleConnections() async throws {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+
+    let serviceName = uniqueServiceName("multipleConnections")
+    let endpoint = try await Ocp1MachPortDeviceEndpoint(
+      serviceName: serviceName,
+      device: device
+    )
+    let endpointTask = Task { try await endpoint.run() }
+    defer { endpointTask.cancel() }
+
+    try await Task.sleep(for: .milliseconds(100))
+
+    let connection1 = await makeMachPortConnection(serviceName: serviceName)
+    let connection2 = await makeMachPortConnection(serviceName: serviceName)
+
+    try await connection1.connect()
+    try await connection2.connect()
+
+    let controllers = await endpoint.controllers
+    XCTAssertEqual(controllers.count, 2, "Should have two controllers for two connections")
+
+    // Verify both connections can issue OCA commands
+    let ono1 = await connection1.deviceManager.objectNumber
+    let ono2 = await connection2.deviceManager.objectNumber
+    XCTAssertEqual(ono1, ono2)
+
+    try await connection1.disconnect()
+    try await connection2.disconnect()
+  }
+
+  func testMachPortConnectToNonexistentService() async throws {
+    let connection = await makeMachPortConnection(
+      serviceName: uniqueServiceName("nonexistent")
+    )
+    do {
+      try await connection.connect()
+      XCTFail("Should have thrown when connecting to nonexistent service")
+    } catch {
+      // expected — bootstrap lookup should fail
+    }
+  }
+
+  func testMachPortRepeatedConnectDisconnect() async throws {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+
+    let serviceName = uniqueServiceName("repeatedConnectDisconnect")
+    let endpoint = try await Ocp1MachPortDeviceEndpoint(
+      serviceName: serviceName,
+      device: device
+    )
+    let endpointTask = Task { try await endpoint.run() }
+    defer { endpointTask.cancel() }
+
+    try await Task.sleep(for: .milliseconds(100))
+
+    for _ in 0..<5 {
+      let connection = await makeMachPortConnection(serviceName: serviceName)
+      try await connection.connect()
+
+      let connected = await connection.isConnected
+      XCTAssertTrue(connected)
+
+      let ono = await connection.deviceManager.objectNumber
+      XCTAssertEqual(ono, OcaDeviceManagerONo)
+
+      try await connection.disconnect()
+      try await Task.sleep(for: .milliseconds(50))
+    }
+
+    try await Task.sleep(for: .seconds(1))
+    let controllers = await endpoint.controllers
+    XCTAssertEqual(
+      controllers.count, 0,
+      "All controllers should be cleaned up after repeated connect/disconnect"
+    )
+  }
+
+  func testMachPortVsTCPLatency() async throws {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+
+    // Add 50 actuators to stress-test round-trips
+    var actuators = [SwiftOCADevice.OcaBooleanActuator]()
+    for i in 0..<50 {
+      let actuator = try await SwiftOCADevice.OcaBooleanActuator(
+        objectNumber: OcaONo(20000 + i),
+        role: "Actuator-\(i)",
+        deviceDelegate: device
+      )
+      actuators.append(actuator)
+    }
+
+    let iterations = 10
+
+    // --- Mach port ---
+    let machServiceName = uniqueServiceName("perfMach")
+    let machEndpoint = try await Ocp1MachPortDeviceEndpoint(
+      serviceName: machServiceName,
+      device: device
+    )
+    let machEndpointTask = Task { try await machEndpoint.run() }
+    defer { machEndpointTask.cancel() }
+    try await Task.sleep(for: .milliseconds(100))
+
+    let machConnection = await makeMachPortConnection(serviceName: machServiceName)
+    try await machConnection.connect()
+
+    // warm up
+    _ = await machConnection.rootBlock.getJsonValue(flags: [])
+    let machStart = ContinuousClock.now
+    for _ in 0..<iterations {
+      _ = await machConnection.rootBlock.getJsonValue(flags: [])
+    }
+    let machElapsed = ContinuousClock.now - machStart
+    try await machConnection.disconnect()
+
+    // --- TCP (CFSocket) ---
+    var listenAddress = sockaddr_in()
+    listenAddress.sin_family = sa_family_t(AF_INET)
+    listenAddress.sin_addr.s_addr = UInt32(0x7F00_0001).bigEndian
+    listenAddress.sin_port = 0
+    listenAddress.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+    let addressData = withUnsafeBytes(of: listenAddress) { Data($0) }
+
+    let tcpEndpoint = try await Ocp1FlyingSocksStreamDeviceEndpoint(
+      address: addressData,
+      device: device
+    )
+    let socket = try await tcpEndpoint.preparePoolAndSocket()
+    let port: UInt16 = try {
+      let addr = try socket.sockname()
+      switch addr {
+      case let .ip4(_, port): return port
+      case let .ip6(_, port): return port
+      default: throw Ocp1Error.notConnected
+      }
+    }()
+    let tcpEndpointTask = Task { try await tcpEndpoint._run(on: socket, pool: tcpEndpoint.pool) }
+    defer { tcpEndpointTask.cancel() }
+    try await Task.sleep(for: .milliseconds(100))
+
+    var clientAddr = sockaddr_in()
+    clientAddr.sin_family = sa_family_t(AF_INET)
+    clientAddr.sin_addr.s_addr = UInt32(0x7F00_0001).bigEndian
+    clientAddr.sin_port = port.bigEndian
+    clientAddr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+    let clientAddrData = withUnsafeBytes(of: clientAddr) { Data($0) }
+
+    let tcpConnection = try await {
+      @OcaConnection in
+      try Ocp1CFSocketTCPConnection(
+        deviceAddress: clientAddrData,
+        options: Ocp1ConnectionOptions(flags: .refreshDeviceTreeOnConnection)
+      )
+    }()
+    try await tcpConnection.connect()
+
+    // warm up
+    _ = await tcpConnection.rootBlock.getJsonValue(flags: [])
+    let tcpStart = ContinuousClock.now
+    for _ in 0..<iterations {
+      _ = await tcpConnection.rootBlock.getJsonValue(flags: [])
+    }
+    let tcpElapsed = ContinuousClock.now - tcpStart
+    try await tcpConnection.disconnect()
+
+    // cleanup
+    for actuator in actuators {
+      try await device.rootBlock.delete(actionObject: actuator)
+    }
+
+    let machMs = Double(machElapsed.components.seconds) * 1000.0
+      + Double(machElapsed.components.attoseconds) / 1e15
+    let tcpMs = Double(tcpElapsed.components.seconds) * 1000.0
+      + Double(tcpElapsed.components.attoseconds) / 1e15
+
+    print("Mach port: \(iterations) iterations in \(String(format: "%.1f", machMs))ms (\(String(format: "%.2f", machMs / Double(iterations)))ms/iter)")
+    print("TCP:       \(iterations) iterations in \(String(format: "%.1f", tcpMs))ms (\(String(format: "%.2f", tcpMs / Double(iterations)))ms/iter)")
+    print("Speedup:   \(String(format: "%.1f", tcpMs / machMs))x")
+  }
+
+  func testMachPortEndpointCancellation() async throws {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+
+    let serviceName = uniqueServiceName("endpointCancellation")
+    let endpoint = try await Ocp1MachPortDeviceEndpoint(
+      serviceName: serviceName,
+      device: device
+    )
+    let endpointTask = Task { try await endpoint.run() }
+
+    try await Task.sleep(for: .milliseconds(100))
+
+    let connection = await makeMachPortConnection(serviceName: serviceName)
+    try await connection.connect()
+
+    let connected = await connection.isConnected
+    XCTAssertTrue(connected)
+
+    // Cancel the endpoint — this should tear down the server side
+    endpointTask.cancel()
+    try await Task.sleep(for: .milliseconds(500))
+
+    // Client should detect disconnection on next operation
+    try await connection.disconnect()
+  }
+}
+
+#endif


### PR DESCRIPTION
Implements a Mach port-based OCP.1 transport for inter-process communication on macOS/iOS, using bootstrap service names for discovery and dedicated per-controller port pairs for bidirectional PDU exchange.

New files:
- Ocp1MachPortSupport: low-level Mach port wrapper, message framing, bootstrap API shims
- Ocp1MachPortConnection: client-side connection (Ocp1Connection subclass)
- Ocp1MachPortController: device-side controller actor
- Ocp1MachPortDeviceEndpoint: device-side endpoint with listener loop
- MachPortConnectionTests: connect/disconnect, round-trip, cleanup, and multiple connection tests

Amp-Thread-ID: https://ampcode.com/threads/T-019d5c0a-04c4-7148-b962-6de8ecd013be