### PR TITLE
add TLS support for OCP.1

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Packages
         run: |
           apt-get update
-          apt-get install -y liburing-dev libavahi-compat-libdnssd-dev libavahi-client-dev
+          apt-get install -y liburing-dev libavahi-compat-libdnssd-dev libavahi-client-dev libssl-dev
       - name: Checkout
         uses: actions/checkout@v4
       - name: Version

--- a/Documentation/TLS.md
+++ b/Documentation/TLS.md
@@ -1,0 +1,303 @@
+SwiftOCA TLS / DTLS
+===================
+
+SwiftOCA implements both OCP.1 secure transports on Apple platforms (via `Network.framework`) and Linux (via OpenSSL):
+
+- **`ocasec/tcp`** — TLS-secured stream transport
+- **`ocasec/udp`** — DTLS-secured datagram transport
+
+The same `Ocp1TLSCredential` / `Ocp1TLSTrustRoots` types drive both backends and both transports. The public connection / endpoint types are exposed as platform-agnostic typealiases:
+
+| Role                 | Typealias                          | Apple                              | Linux                                |
+| :---                 | :---                               | :---                               | :---                                 |
+| Controller (TLS)     | `Ocp1TLSStreamConnection`          | `Ocp1NWSecureTCPConnection`        | `Ocp1OpenSSLConnection`              |
+| Controller (DTLS)    | `Ocp1TLSDatagramConnection`        | `Ocp1NWSecureUDPConnection`        | `Ocp1OpenSSLDTLSConnection`          |
+| Device (TLS)         | `Ocp1TLSStreamDeviceEndpoint`      | `Ocp1NWSecureTCPDeviceEndpoint`    | `Ocp1OpenSSLStreamDeviceEndpoint`    |
+| Device (DTLS)        | `Ocp1TLSDatagramDeviceEndpoint`    | `Ocp1NWSecureUDPDeviceEndpoint`    | `Ocp1OpenSSLDTLSDeviceEndpoint`      |
+
+For the over-the-wire protocol, AES70-2024 §11.2.4 mandates `TLS_DHE_PSK_WITH_AES_128_CBC_SHA` over TLS 1.2 with the PSK identity hint `OCA-PSK` (exposed as `OcaPreSharedKeyIdentityHint`). SwiftOCA always advertises the AES70-mandated suite for wire-compatibility with strict AES70 peers, but offers it alongside (and prefers) modern AEAD suites — TLS 1.3 / DTLS 1.3 external PSK and TLS 1.2 DHE-PSK-AEAD — whenever the peer supports them. The exact ordering (mandated suite first vs. AEAD suites first) differs slightly between the Apple (`Network.framework`) and Linux (OpenSSL) backends; both backends honour server cipher preference, so a SwiftOCA device drives the negotiated suite regardless of which backend the controller uses.
+
+## Credentials
+
+`Ocp1TLSCredential` is the input both sides supply at handshake time:
+
+```swift
+public enum Ocp1TLSCredential: Sendable {
+  case preSharedKey(identity: String, key: Data)
+  case preSharedKeyProvider(identity: String, provider: any OcaPreSharedKeyProvider)
+  case identity(SecIdentity)                            // Apple only
+  case certificateFile(certPath: String, keyPath: String)
+  case certificatePEM(certificate: Data, privateKey: Data)
+  case pkcs12(data: Data, password: String?)
+}
+```
+
+A controller passes exactly one credential to the connection initializer. A device may pass a single _server_ credential (typically a cert) and, in addition, register any number of PSKs with the device's `OcaSecurityManager` — see [Server-side PSK](#server-side-psk-via-ocasecuritymanager) below.
+
+`.preSharedKey` is the AES70 baseline; the key bytes live in the credential value (and, on Apple, additionally in `DispatchData` that Network.framework retains). `.preSharedKeyProvider` is the keychain-friendly variant: it carries only an identity, and the TLS backend reads key bytes on demand through the provider's `withPreSharedKey(forIdentity:_:)` closure so the caller can hold the bytes in storage of its choice (mlocked memory, hardware enclave, etc.). The `.certificateFile` / `.certificatePEM` / `.pkcs12` (and Apple-only `.identity`) variants exist for deployments that prefer X.509 mutual authentication or for interop with non-AES70 TLS peers.
+
+## Trust roots
+
+When the peer presents a certificate, SwiftOCA verifies it against an explicit anchor set rather than the system trust store by default. Set `trustRoots:` (or `clientCertificateTrustRoots:` on the device side) to point at a private CA bundle:
+
+```swift
+public enum Ocp1TLSTrustRoots: Sendable {
+  case caFile(String)
+  case caData(Data)
+}
+```
+
+Passing `nil` falls back to platform behaviour — `SSL_CTX_set_default_verify_paths` on Linux, `Network.framework`'s default evaluation on Apple. For PSK-only deployments, trust roots are not consulted; the shared secret authenticates the peer.
+
+## Peer identity
+
+Once a handshake completes, each `OcaController` exposes a `peerIdentity: OcaPeerIdentity` snapshot. Use this — not `controllerFlags.hasTransportLayerSecurity` — for any per-principal ACL decision:
+
+```swift
+public enum OcaPeerIdentity: Sendable, Hashable {
+  case preSharedKey(identity: String)
+  case certificate(subject: String, fingerprint: String)
+  case anonymous
+}
+```
+
+`.preSharedKey` carries the identity the peer sent in the TLS handshake (cleartext on the wire — never put secret material in an identity). `.certificate` carries the verified leaf's subject summary plus its lower-case-hex SHA-256 fingerprint; the fingerprint is the recommended ACL key because DN equality can be defeated by reissue against an unchanged public key. `.anonymous` covers plaintext transports and TLS connections built with `.disableCertificateVerification`; reject it for any privileged operation. `hasTransportLayerSecurity` only proves *some* trusted peer is on the wire — not which.
+
+On Apple, PSK identities are not exposed by `sec_protocol_metadata`'s public API, so PSK handshakes there currently surface as `.anonymous` on the server side. The Linux backend captures both PSK and cert identities. Apple's TCP path additionally surfaces `.certificate(...)` for cert handshakes via the `.ready`-time TLS metadata.
+
+## Controller (client) usage
+
+```swift
+import SwiftOCA
+
+let credential: Ocp1TLSCredential = .preSharedKey(
+  identity: OcaPreSharedKeyIdentityHint,
+  key: pskBytes // 32 bytes recommended
+)
+
+let connection = try Ocp1TLSStreamConnection(
+  deviceAddress: addressData,
+  credential: credential,
+  hostname: "device.local",         // SNI + cert hostname verification
+  trustRoots: .caFile("/etc/ssl/private-ca.pem"),
+  options: Ocp1ConnectionOptions(flags: [.automaticReconnect])
+)
+
+try await connection.connect()
+```
+
+`hostname:` is used for SNI on both platforms and for cert hostname verification. On Apple, supplying a hostname also overrides `NWEndpoint` to use `.name`-based resolution so the system can compare it against the cert's Subject Alternative Names; on Linux it drives `SSL_set1_host` + `SSL_set_tlsext_host_name`. With PSK credentials, `hostname:` is optional (no cert is exchanged).
+
+### Disabling verification
+
+For development against a self-signed cert, set `disableCertificateVerification` on `Ocp1ConnectionFlags`:
+
+```swift
+let options = Ocp1ConnectionOptions(flags: [.disableCertificateVerification])
+```
+
+This bypasses chain validation _and_ hostname verification on both platforms. Do not ship this enabled — every connect logs a `.critical` audit line so a flag accidentally copied from an example surfaces loudly.
+
+## Device (server) usage
+
+The device-side endpoint accepts at most one server credential, plus optional trust roots used to authenticate connecting controllers (mTLS):
+
+```swift
+import SwiftOCADevice
+
+let endpoint = try await Ocp1TLSStreamDeviceEndpoint(
+  port: 65010,
+  credential: .certificateFile(
+    certPath: "/etc/ssl/device.crt",
+    keyPath:  "/etc/ssl/device.key"
+  ),
+  clientCertificateTrustRoots: .caFile("/etc/ssl/client-ca.pem")
+)
+try await endpoint.run()
+```
+
+The endpoint advertises `OcaControllerFlags.hasTransportLayerSecurity` and registers a Bonjour `_ocasec._tcp.` service (`OcaNetworkAdvertisingServiceType.tcpSecure`).
+
+### Server-side PSK via `OcaSecurityManager`
+
+`OcaSecurityManager` is the device's PSK store. Register identities during device bring-up via `loadPreSharedKey(identity:key:)`:
+
+```swift
+if let security = await device.securityManager {
+  try security.loadPreSharedKey(
+    identity: OcaPreSharedKeyIdentityHint,
+    key: pskBytes
+  )
+}
+let endpoint = try await Ocp1TLSStreamDeviceEndpoint(port: 65010)
+try await endpoint.run()
+```
+
+The OCA `AddPreSharedKey` / `ChangePreSharedKey` / `DeletePreSharedKey` command handlers exist on `OcaSecurityManager` but the manager's `ensureWritable` currently rejects all writes with `.notImplemented` pending an admin-role authz design. PSK additions today therefore go through `loadPreSharedKey` from process code, not over the wire.
+
+When the endpoint starts it captures the security manager as an `OcaPreSharedKeyProvider`. The Linux (OpenSSL) backend queries the provider on each handshake's PSK callback, so a `loadPreSharedKey` call after the endpoint has started takes effect on the next handshake without an endpoint restart. The Apple (Network.framework) backend snapshots the configured identities once at listener creation — additions after that point require an endpoint restart, because `NWListener` doesn't expose a way to mutate the PSK list after binding.
+
+`OcaPreSharedKeyProvider` is also a public protocol; applications that store PSKs outside `OcaSecurityManager` can supply their own provider via the `.preSharedKeyProvider` credential or by replacing the security manager with a custom subclass.
+
+### mTLS and PSK coexistence
+
+`clientCertificateTrustRoots:` enables mutual TLS for certificate-based handshakes. Importantly it does _not_ preclude PSK: PSK clients are authenticated by the shared secret and bypass the `SSL_VERIFY_PEER` requirement at handshake time. The two are independent authentication paths registered against the same TLS context. A controller without a registered PSK identity must present a cert that chains to one of `clientCertificateTrustRoots`; a PSK controller is admitted without presenting a cert.
+
+## TLS 1.3 external PSK (Linux)
+
+On Linux, SwiftOCA wires both TLS 1.2 PSK (`SSL_CTX_set_psk_{server,client}_callback`) and TLS 1.3 external PSK (`SSL_CTX_set_psk_{find,use}_session_callback`, RFC 8446 §4.2.11) simultaneously, so the peer's preference wins:
+
+- Linux ↔ Linux: negotiates TLS 1.3 + `TLS_CHACHA20_POLY1305_SHA256`.
+- Apple ↔ Apple: negotiates TLS 1.3 + `TLS_AES_128_GCM_SHA256` (Network.framework default).
+- Either side ↔ a TLS 1.2-only peer: negotiates `TLS_DHE_PSK_WITH_AES_128_CBC_SHA` (AES70 baseline).
+
+The TLS 1.3 PSK callbacks fire only for _external_ PSKs (the prior-agreement OCA-PSK case). Session-ticket resumption flows through a different OpenSSL code path and is unaffected. SwiftOCA pins the TLS 1.3 ciphersuite list to the SHA-256 subset (`TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256`) because the synthesized PSK session is bound to the SHA-256 hash; allowing `TLS_AES_256_GCM_SHA384` would cause the PSK to be silently rejected mid-handshake.
+
+## DTLS (datagram TLS over UDP)
+
+The `Ocp1TLSDatagramConnection` / `Ocp1TLSDatagramDeviceEndpoint` pair carries OCP.1 over a DTLS-protected UDP flow. Construction mirrors the TLS-stream API:
+
+```swift
+import SwiftOCA
+
+let connection = try Ocp1TLSDatagramConnection(
+  deviceAddress: addressData,
+  credential: .preSharedKey(identity: OcaPreSharedKeyIdentityHint, key: pskBytes),
+  hostname: "device.local",
+  trustRoots: nil
+)
+try await connection.connect()
+```
+
+```swift
+import SwiftOCADevice
+
+// PSK-only on Linux; cert + PSK both supported on Apple.
+let endpoint = try await Ocp1TLSDatagramDeviceEndpoint(port: 65011)
+try await endpoint.run()
+```
+
+Bonjour service type is `_ocasec._udp.` (`OcaNetworkAdvertisingServiceType.udpSecure`); connection prefix is `ocasec/udp`.
+
+> **Cert + DTLS on Linux.** `Ocp1OpenSSLDTLSDeviceEndpoint` (and the matching client `Ocp1OpenSSLDTLSConnection`) reject non-PSK credentials at construction with `.notImplemented`. Cert-mode DTLS handshakes produce multi-record server flights that the current memory-BIO drain emits as one UDP write, which trips IP-level fragmentation or `EMSGSIZE` on most paths. A packet-preserving outbound path (per-record send, already wired for the PSK case) is on the roadmap to lift this; until then PSK is the only supported DTLS credential on Linux. Apple DTLS supports both PSK and cert.
+
+### Server hardening knobs (Linux)
+
+`Ocp1OpenSSLDTLSDeviceEndpoint` accepts four datagram-specific parameters with safe defaults; tune them for the deployment shape:
+
+| Parameter             | Default     | Purpose                                                                                 |
+| :---                  | :---        | :---                                                                                    |
+| `maxPeers`            | 256         | Hard cap on simultaneous peer entries in the endpoint's controller table.               |
+| `idleTimeout`         | 5 min       | Drop fully-handshaked peers that have stopped sending datagrams for this long.          |
+| `handshakeDeadline`   | 10 s        | Drop peers whose handshake never completed within this window — typically spoof noise.  |
+| `sourceAddressFilter` | `nil`       | Optional `(Data) -> Bool` gate; runs before any per-peer allocation. `nil` = accept all. |
+
+A periodic GC sweep (5 s cadence) enforces the handshake and idle deadlines and is started from `run()`.
+
+> **Operator requirement.** Defaults assume a trusted subnet. **Hostile-subnet deployments MUST** front the endpoint with one of: a restrictive `sourceAddressFilter` (subnet allowlist), an external firewall/ACL, or both. Also tighten `idleTimeout` (e.g. 30 s) and lower `maxPeers` to the expected steady-state controller count. The 2-per-source allocation throttle (10 s window) backstops these but **does not** stop distributed or spoofed multi-source floods on its own — without an upstream filter, a sustained spoofed flood can fill the peer table for ~`handshakeDeadline + sweep cadence`.
+
+### Revocation checking (opt-in)
+
+`Ocp1TLSRevocationOptions` enables CRL / OCSP checking. Empty `flags`
+disables it (default); set `.enabled` to opt in. Off by default keeps
+private-PKI deployments without a CRL/OCSP responder working unchanged.
+
+| Backend      | With `.enabled`                                                                            |
+| :---         | :---                                                                                       |
+| Apple (NW)   | `SecPolicyCreateRevocation(kSecRevocationUseAnyAvailableMethod)` installed alongside the SSL policy. **Soft-fail**: an unreachable responder permits the chain. CRL data in `crls` is ignored — Security.framework fetches it on its own. |
+| OpenSSL      | `crls` (PEM CRL bundle) are loaded into the X509 store and `X509_V_FLAG_CRL_CHECK` is armed. **Leaf-only by default, soft-fail with no CRLs supplied** — without loaded CRLs the flag would hard-fail every handshake, so we skip arming it. Add `.checkChain` to arm `X509_V_FLAG_CRL_CHECK_ALL`; the bundle MUST then carry every intermediate's CRL or OpenSSL hard-fails. |
+
+Operators wiring this up should:
+
+- Plumb a fresh CRL into `Ocp1TLSCRLBundle.crlData(...)` (or `.crlFile(...)` for a path); the OpenSSL store snapshots at endpoint init, so rotating CRLs requires an endpoint restart.
+- On Apple, ensure the responder is reachable from the deployment subnet — soft-fail will silently permit chains otherwise.
+- Prefer `.strict` (= `.enabled + .checkChain`) for new code. Use bare `.enabled` only when the bundle deliberately covers the leaf only.
+
+### Audit logging
+
+Three operator-visible signals fire at `info` / `warning` level so misconfigurations surface in logs instead of failing silently:
+
+- **`TLS certificate verification is disabled (insecure)`** — emitted *once per connect* on the client side when `Ocp1ConnectionOptions.flags` contains `.disableCertificateVerification`. This flag is intentionally dev-only.
+- **`<endpoint> requires client certificates (mTLS)`** — emitted at server startup (or, on Apple, at endpoint init) whenever `clientCertificateTrustRoots` is configured. Lets you confirm a server is enforcing mTLS without grepping a packet capture.
+- **`TLS handshake failed or timed out: ...`** — emitted at `warning` for any inbound stream handshake that fails the 10 s deadline or returns an OpenSSL error. The error string is the OpenSSL queue contents; if the queue is empty the string is `(no detail in OpenSSL error queue)` rather than blank.
+
+### DTLS handshake transport
+
+- **Cookie exchange (RFC 6347 §4.2.1)** is enabled on the server: the first ClientHello from a new peer prompts a small HelloVerifyRequest with an HMAC-SHA256 cookie bound to the peer's source address. The peer must echo the cookie before any state-bearing handshake records flow back, blocking the basic DoS-amplification vector.
+- **Retransmit watchdog**: a 200 ms ticker on both client and server drives `DTLSv1_handle_timeout` while the handshake is in flight. Without it, a single lost handshake datagram would stall the handshake indefinitely because the memory-BIO engine has no built-in scheduler.
+- **MTU**: a conservative 1200-byte DTLS payload MTU is set up front (RFC 6347 §4.1.1 fallback). Outbound flights are split at the 13-byte DTLS record header (`sendDTLSRecords`) so each record ships in its own datagram, avoiding IP-level fragmentation. The cert-mode DTLS rejection above closes the remaining oversize-handshake case for Linux.
+
+### Residual exposure
+
+The cookie callback fires *inside* `SSL_do_handshake` on the per-peer engine, so the per-peer state (~30–60 KB) is still allocated when the first ClientHello arrives — only the *response* is bounded to a HelloVerifyRequest (~30–50 B). Four layers contain that exposure:
+
+- **Per-source-IP rate limit** — a fixed-window throttle (2 fresh engine allocations per source IP per 10 s, keyed on the IP only so port rotation can't bypass) refuses spoofed-source ClientHello floods before any engine state is allocated. Refunded on construction failure / peer-table overflow.
+- **Peer-table cap** (`maxPeers`, default 256) — backstops the per-source throttle.
+- **Source-address filter** (`Ocp1OpenSSLDTLSEndpointOptions.sourceAddressFilter`) — optional pre-allocation hook that lets operators apply subnet allowlists / AF restrictions before any engine state is allocated.
+- **Handshake-deadline GC** (default 10 s) — sweeps slots whose engine never reached `isHandshakeComplete`.
+
+**Why we don't reimplement the DTLS pre-cookie path ourselves.** Eliminating the pre-engine allocation entirely would require either (a) using OpenSSL's `DTLSv1_listen` on a dedicated `BIO_dgram` socket, which conflicts with the IORing-driven UDP socket the rest of the endpoint uses, or (b) parsing DTLS record + ClientHello bytes ourselves to apply the cookie HMAC before allocation. (a) is a substantial architectural rework with regression risk that crosses two transport stacks; (b) means importing a chunk of the DTLS state machine into Swift, where any byte-counting bug would be a denial-of-service or worse on a security-critical path. The four containment layers above keep the residual exposure bounded for trusted-subnet deployments. **Hostile-subnet deployments MUST configure `sourceAddressFilter` or an upstream firewall/ACL** — the containment layers alone are not sufficient when an attacker can source from arbitrary IPs.
+
+DTLS-over-UDP has no graceful close. Peers that disconnect ungracefully linger until `idleTimeout` elapses.
+
+The DTLS server binds to `INADDR_ANY` by default — pass an explicit `sockaddr_in` / `sockaddr_in6` to the `address:` initializer to scope to a specific interface.
+
+## Transport abstraction (Linux server)
+
+The OpenSSL-backed server controllers are decoupled from the IORing socket type via two protocols in `SwiftOCASecure`:
+
+- **`Ocp1ByteStream`** — TCP-like reliable byte stream (`read` / `write` / `close`). Used by `Ocp1OpenSSLStreamController` to drive TLS over any byte transport.
+- **`Ocp1DatagramChannel`** — outbound per-peer datagram send (`send` / `close`). Used by `Ocp1OpenSSLDTLSController` to emit ciphertext for a single bound peer.
+
+Two adapters live in `SwiftOCASecureDevice` and are wired up automatically by the existing endpoint convenience inits:
+
+- `IORingByteStream` — wraps an `IORing.Socket` for TLS
+- `_EndpointDatagramChannel` — routes per-peer DTLS sends through the endpoint's shared UDP socket; holds a weak endpoint reference so teardown surfaces as `Ocp1Error.notConnected`
+
+Day-to-day callers don't need to interact with these directly — the standard `Ocp1OpenSSLStreamDeviceEndpoint(port:credential:…)` and `Ocp1OpenSSLDTLSDeviceEndpoint(port:credential:…)` inits remain the recommended entry points and continue to wire IORing under the hood.
+
+The protocols exist so the engine can be exercised end-to-end against an in-memory transport for testing — see `Tests/SwiftOCADeviceTests/PipeByteStream.swift` and `OpenSSLEnginePipeTests.swift`. PSK and certificate-mode handshakes (including mTLS coexistence with PSK) round-trip in ~80 ms per case over the in-memory pipe with no socket / port / accept-loop state shared between cases. The same pattern also leaves the door open for future alternative transports (e.g. FlyingSocks-backed TLS) without further engine changes.
+
+A future refactor (Phase 2) will lift this further by introducing `Ocp1ByteStreamListener` and dropping `Ocp1OpenSSLStreamDeviceEndpoint`'s `Ocp1IORingDeviceEndpoint` inheritance entirely, making the endpoint itself transport-pluggable. That is intentionally out of scope for the current branch.
+
+## `ocacli` examples
+
+The `tls` branch of `ocacli` exposes the credential / trust-roots API as command-line flags:
+
+```sh
+# PSK against a device on the local network, default OCA-PSK identity
+ocacli -S -K $(printf '%.0s00' {1..32}) device.local:65010
+
+# Custom PSK identity
+ocacli -S --psk-identity my-controller -K <hex> device.local:65010
+
+# PEM cert / key, with a private CA bundle for the device cert
+ocacli -S --cert-file client.crt --key-file client.key --cacert ca.pem device.local:65010
+
+# PKCS#12 bundle
+ocacli -S --pkcs12 client.p12 --pkcs12-password secret device.local:65010
+
+# Development: skip server cert verification (matches curl --insecure)
+ocacli -S --insecure device.local:65010
+```
+
+`-S` / `--tls` enables TLS. The flag is currently mutually exclusive with `-U` (UDP). DTLS support in `ocacli` is not yet wired up; the underlying `Ocp1TLSDatagramConnection` is fully functional and can be driven from the library directly (see the DTLS section above).
+
+## Example device
+
+[`Examples/OCADevice/DeviceApp.swift`](../Examples/OCADevice/DeviceApp.swift) reads TLS configuration from environment variables for easy testing:
+
+```sh
+# Run the example with a real cert and an mTLS client trust bundle
+OCA_TLS_CERT_FILE=device.crt \
+OCA_TLS_KEY_FILE=device.key \
+OCA_TLS_CLIENT_CA_FILE=client-ca.pem \
+swift run OCADevice
+
+# Or with a PKCS#12 bundle
+OCA_TLS_PKCS12_FILE=device.p12 \
+OCA_TLS_PKCS12_PASSWORD=secret \
+swift run OCADevice
+```
+
+With no env vars set, the example preloads a zero PSK under the `OCA-PSK` identity so the secure endpoint and Bonjour advertisement work out of the box. The zero PSK is _not_ a real credential — replace it before exposing the endpoint to a network.

--- a/Examples/OCADevice/DeviceApp.swift
+++ b/Examples/OCADevice/DeviceApp.swift
@@ -17,6 +17,10 @@
 import Foundation
 import SwiftOCA
 import SwiftOCADevice
+#if NonEmbeddedBuild
+import SwiftOCASecure
+import SwiftOCASecureDevice
+#endif
 #if canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
@@ -34,6 +38,28 @@ final class DeviceEventDelegate: OcaDeviceEventDelegate {
 public enum DeviceApp {
   nonisolated(unsafe) static var testActuator: SwiftOCADevice.OcaBooleanActuator?
   static let port: UInt16 = 65000
+  #if NonEmbeddedBuild
+  static let securePort: UInt16 = 65010
+
+  /// PEM paths take precedence over PKCS#12; `nil` falls back to PSK-only.
+  static func tlsCredentialFromEnvironment() -> Ocp1TLSCredential? {
+    let env = ProcessInfo.processInfo.environment
+    if let certPath = env["OCA_TLS_CERT_FILE"], let keyPath = env["OCA_TLS_KEY_FILE"] {
+      return .certificateFile(certPath: certPath, keyPath: keyPath)
+    }
+    if let pkcs12Path = env["OCA_TLS_PKCS12_FILE"],
+       let data = try? Data(contentsOf: URL(fileURLWithPath: pkcs12Path))
+    {
+      return .pkcs12(data: data, password: env["OCA_TLS_PKCS12_PASSWORD"])
+    }
+    return nil
+  }
+
+  /// CA bundle for mTLS; when set, every client must present a chain to it.
+  static func clientTrustRootsFromEnvironment() -> Ocp1TLSTrustRoots? {
+    ProcessInfo.processInfo.environment["OCA_TLS_CLIENT_CA_FILE"].map { .caFile($0) }
+  }
+  #endif
 
   public static func main() async throws {
     var listenAddress = sockaddr_in()
@@ -103,6 +129,32 @@ public enum DeviceApp {
     let machPortEndpoint = try await Ocp1MachPortDeviceEndpoint(
       serviceName: "com.padl.OCADevice",
       device: device
+    )
+    #endif
+
+    #if (canImport(Network) || (canImport(COpenSSL) && canImport(IORing))) && NonEmbeddedBuild
+    // Demo PSK preload (NOT a real credential) for smoke-testing the
+    // ocasec/tcp transport when no cert env vars are set. Cert env vars:
+    //   OCA_TLS_CERT_FILE / OCA_TLS_KEY_FILE     — PEM
+    //   OCA_TLS_PKCS12_FILE / OCA_TLS_PKCS12_PASSWORD — PKCS#12
+    let secureCredential = Self.tlsCredentialFromEnvironment()
+    if secureCredential == nil, let securityManager = await device.securityManager {
+      await Task { @OcaDevice in
+        try? securityManager.loadPreSharedKey(
+          identity: OcaPreSharedKeyIdentityHint,
+          key: Data(repeating: 0, count: 32)
+        )
+      }.value
+    }
+    let secureStreamEndpoint = try await Ocp1TLSStreamDeviceEndpoint(
+      port: securePort,
+      credential: secureCredential,
+      clientCertificateTrustRoots: Self.clientTrustRootsFromEnvironment()
+    )
+    let secureDatagramEndpoint = try await Ocp1TLSDatagramDeviceEndpoint(
+      port: securePort,
+      credential: secureCredential,
+      clientCertificateTrustRoots: Self.clientTrustRootsFromEnvironment()
     )
     #endif
 
@@ -214,6 +266,16 @@ public enum DeviceApp {
       taskGroup.addTask {
         print("Starting OCP.1 Mach port endpoint \(machPortEndpoint)...")
         try await machPortEndpoint.run()
+      }
+      #endif
+      #if canImport(Network) || (canImport(COpenSSL) && canImport(IORing))
+      taskGroup.addTask {
+        print("Starting OCP.1 TLS stream endpoint \(secureStreamEndpoint)...")
+        try await secureStreamEndpoint.run()
+      }
+      taskGroup.addTask {
+        print("Starting OCP.1 DTLS datagram endpoint \(secureDatagramEndpoint)...")
+        try await secureDatagramEndpoint.run()
       }
       #endif
       try await taskGroup.next()

--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,11 @@ if EnableASAN {
 
 var PlatformPackageDependencies: [Package.Dependency] = []
 var PlatformTargetDependencies: [Target.Dependency] = []
+// Linux-only OpenSSL + IORing deps for SwiftOCASecure / SwiftOCASecureDevice.
+// Populated inside #if os(Linux) below; empty on Apple platforms, where these
+// packages are not declared as package dependencies (the secure targets are
+// compiled with the Linux OpenSSL/IORing code paths #if'd out).
+var SecureLinuxTargetDependencies: [Target.Dependency] = []
 let PlatformProducts: [Product]
 let PlatformTargets: [Target]
 
@@ -44,6 +49,10 @@ PlatformTargetDependencies += [
     name: "dnssd",
     condition: .when(platforms: [.linux])
   ),
+  .target(
+    name: "COpenSSL",
+    condition: .when(platforms: [.linux], traits: ["NonEmbeddedBuild"])
+  ),
   .product(
     name: "IORing",
     package: "IORingSwift",
@@ -62,6 +71,23 @@ PlatformTargetDependencies += [
   .product(
     name: "FlyingFox",
     package: "FlyingFox",
+    condition: .when(platforms: [.linux], traits: ["NonEmbeddedBuild"])
+  ),
+]
+
+SecureLinuxTargetDependencies = [
+  .target(
+    name: "COpenSSL",
+    condition: .when(platforms: [.linux], traits: ["NonEmbeddedBuild"])
+  ),
+  .product(
+    name: "IORing",
+    package: "IORingSwift",
+    condition: .when(platforms: [.linux], traits: ["NonEmbeddedBuild"])
+  ),
+  .product(
+    name: "IORingUtils",
+    package: "IORingSwift",
     condition: .when(platforms: [.linux], traits: ["NonEmbeddedBuild"])
   ),
 ]
@@ -137,8 +163,16 @@ let CommonProducts: [Product] = [
     targets: ["SwiftOCA"]
   ),
   .library(
+    name: "SwiftOCASecure",
+    targets: ["SwiftOCASecure"]
+  ),
+  .library(
     name: "SwiftOCADevice",
     targets: ["SwiftOCADevice"]
+  ),
+  .library(
+    name: "SwiftOCASecureDevice",
+    targets: ["SwiftOCASecureDevice"]
   ),
 ]
 
@@ -146,6 +180,14 @@ let CommonTargets: [Target] = [
   .systemLibrary(
     name: "dnssd",
     providers: [.apt(["libavahi-compat-libdnssd-dev"])]
+  ),
+  .systemLibrary(
+    name: "COpenSSL",
+    pkgConfig: "openssl",
+    providers: [
+      .apt(["libssl-dev"]),
+      .yum(["openssl-devel"]),
+    ]
   ),
   .target(
     name: "SwiftOCA",
@@ -168,6 +210,17 @@ let CommonTargets: [Target] = [
     ]
   ),
   .target(
+    name: "SwiftOCASecure",
+    dependencies: [
+      "SwiftOCA",
+      "SocketAddress",
+      .product(name: "Logging", package: "swift-log"),
+    ] + SecureLinuxTargetDependencies,
+    swiftSettings: [
+      .enableExperimentalFeature("StrictConcurrency"),
+    ]
+  ),
+  .target(
     name: "SwiftOCADevice",
     dependencies: [
       "SwiftOCA",
@@ -186,10 +239,27 @@ let CommonTargets: [Target] = [
       .enableExperimentalFeature("StrictConcurrency"),
     ]
   ),
+  .target(
+    name: "SwiftOCASecureDevice",
+    dependencies: [
+      "SwiftOCA",
+      "SwiftOCASecure",
+      "SwiftOCADevice",
+      "SocketAddress",
+      .product(name: "Logging", package: "swift-log"),
+      .product(name: "AsyncAlgorithms", package: "swift-async-algorithms"),
+      "AsyncExtensions",
+    ] + SecureLinuxTargetDependencies,
+    swiftSettings: [
+      .enableExperimentalFeature("StrictConcurrency"),
+    ]
+  ),
   .executableTarget(
     name: "OCADevice",
     dependencies: [
       "SwiftOCADevice",
+      .target(name: "SwiftOCASecure", condition: .when(traits: ["NonEmbeddedBuild"])),
+      .target(name: "SwiftOCASecureDevice", condition: .when(traits: ["NonEmbeddedBuild"])),
     ],
     path: "Examples/OCADevice",
     swiftSettings: [
@@ -235,6 +305,8 @@ let CommonTargets: [Target] = [
     name: "SwiftOCADeviceTests",
     dependencies: [
       .target(name: "SwiftOCADevice"),
+      .target(name: "SwiftOCASecure", condition: .when(traits: ["NonEmbeddedBuild"])),
+      .target(name: "SwiftOCASecureDevice", condition: .when(traits: ["NonEmbeddedBuild"])),
     ],
     swiftSettings: [
       .unsafeFlags(ASANSwiftFlags),

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ All APIs are async-safe and support both macOS and Linux: on macOS, [FlyingFox](
 * **Block and matrix containers**: `OcaBlock` and `OcaMatrix` for organizing objects into hierarchical or grid-based topologies.
 * **JSON serialization/deserialization**: persist and restore device state via `serialize`/`deserialize` and the parameter dataset API.
 * **Multiple transport endpoints**: run TCP, UDP, WebSocket, Unix domain socket, and Mach port (Darwin) endpoints concurrently.
+* **TLS-secured TCP** (`ocasec`): PSK (AES70 baseline) and X.509 certificate credentials on both Apple and Linux, with optional mTLS and TLS 1.3 external PSK. See [Documentation/TLS.md](Documentation/TLS.md).
 
 ### SwiftOCAUI
 

--- a/Sources/COpenSSL/module.modulemap
+++ b/Sources/COpenSSL/module.modulemap
@@ -1,0 +1,6 @@
+module COpenSSL [system] {
+  header "shim.h"
+  link "ssl"
+  link "crypto"
+  export *
+}

--- a/Sources/COpenSSL/shim.h
+++ b/Sources/COpenSSL/shim.h
@@ -1,0 +1,113 @@
+#ifndef COPENSSL_SHIM_H
+#define COPENSSL_SHIM_H
+
+#include <openssl/ssl.h>
+#include <openssl/bio.h>
+#include <openssl/err.h>
+#include <openssl/pkcs12.h>
+#include <openssl/x509.h>
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+#include <openssl/hmac.h>
+#include <openssl/crypto.h>
+#include <openssl/rand.h>
+#include <stddef.h>
+
+// Re-publish OpenSSL macro-control APIs as ordinary functions so the Swift
+// importer sees clean signatures.
+
+static inline size_t COpenSSL_BIO_pending(BIO *b) {
+  return (size_t)BIO_pending(b);
+}
+
+static inline int COpenSSL_SSL_CTX_set_min_proto_version(SSL_CTX *ctx, int version) {
+  return (int)SSL_CTX_set_min_proto_version(ctx, version);
+}
+
+static inline int COpenSSL_SSL_CTX_set_max_proto_version(SSL_CTX *ctx, int version) {
+  return (int)SSL_CTX_set_max_proto_version(ctx, version);
+}
+
+static inline long COpenSSL_SSL_CTX_add_extra_chain_cert(SSL_CTX *ctx, X509 *cert) {
+  return SSL_CTX_add_extra_chain_cert(ctx, cert);
+}
+
+// STACK_OF(X509) is itself a macro; we take void * and cast.
+static inline int COpenSSL_sk_X509_num(void *sk) {
+  return sk_X509_num((const STACK_OF(X509) *)sk);
+}
+
+static inline X509 *COpenSSL_sk_X509_value(void *sk, int idx) {
+  return sk_X509_value((const STACK_OF(X509) *)sk, idx);
+}
+
+static inline void COpenSSL_sk_X509_pop_free(void *sk) {
+  sk_X509_pop_free((STACK_OF(X509) *)sk, X509_free);
+}
+
+static inline int COpenSSL_SSL_get_ex_new_index(long argl, void *argp,
+                                                CRYPTO_EX_new *new_func,
+                                                CRYPTO_EX_dup *dup_func,
+                                                CRYPTO_EX_free *free_func) {
+  return SSL_get_ex_new_index(argl, argp, new_func, dup_func, free_func);
+}
+
+static inline long COpenSSL_SSL_set_tlsext_host_name(SSL *ssl, const char *name) {
+  return SSL_set_tlsext_host_name(ssl, name);
+}
+
+static inline long COpenSSL_SSL_set_mtu(SSL *ssl, long mtu) {
+  return SSL_set_mtu(ssl, mtu);
+}
+
+static inline long COpenSSL_DTLSv1_handle_timeout(SSL *ssl) {
+  return DTLSv1_handle_timeout(ssl);
+}
+
+static inline long COpenSSL_DTLSv1_get_timeout(SSL *ssl, struct timeval *tv) {
+  return DTLSv1_get_timeout(ssl, tv);
+}
+
+static const uint64_t COpenSSL_SSL_OP_COOKIE_EXCHANGE = SSL_OP_COOKIE_EXCHANGE;
+static const uint64_t COpenSSL_SSL_OP_NO_RENEGOTIATION = SSL_OP_NO_RENEGOTIATION;
+static const uint64_t COpenSSL_SSL_OP_CIPHER_SERVER_PREFERENCE = SSL_OP_CIPHER_SERVER_PREFERENCE;
+static const uint64_t COpenSSL_SSL_OP_NO_TICKET = SSL_OP_NO_TICKET;
+
+static inline int COpenSSL_SSL_CTX_set_max_early_data(SSL_CTX *ctx, uint32_t max) {
+  return SSL_CTX_set_max_early_data(ctx, max);
+}
+
+static inline X509 *COpenSSL_SSL_get_peer_certificate(const SSL *ssl) {
+  return SSL_get_peer_certificate(ssl);
+}
+
+static inline int COpenSSL_X509_digest_sha256(X509 *cert, unsigned char *out, unsigned int *outlen) {
+  return X509_digest(cert, EVP_sha256(), out, outlen);
+}
+
+static inline long COpenSSL_SSL_CTX_set_mode(SSL_CTX *ctx, long mode) {
+  return SSL_CTX_set_mode(ctx, mode);
+}
+
+static inline int COpenSSL_BIO_reset(BIO *b) {
+  return BIO_reset(b);
+}
+
+static const long COpenSSL_SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER = SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER;
+static const long COpenSSL_SSL_MODE_ENABLE_PARTIAL_WRITE = SSL_MODE_ENABLE_PARTIAL_WRITE;
+
+// CRL revocation checking. CRL_CHECK validates the leaf; CRL_CHECK_ALL
+// extends to every intermediate as well — opt-in via the public
+// `Ocp1TLSRevocationOptions.chainWide` flag.
+static inline int COpenSSL_X509_STORE_add_crl(X509_STORE *store, X509_CRL *crl) {
+  return X509_STORE_add_crl(store, crl);
+}
+
+static inline int COpenSSL_X509_STORE_set_flags(X509_STORE *store, unsigned long flags) {
+  return X509_STORE_set_flags(store, flags);
+}
+
+static const unsigned long COpenSSL_X509_V_FLAG_CRL_CHECK = X509_V_FLAG_CRL_CHECK;
+static const unsigned long COpenSSL_X509_V_FLAG_CRL_CHECK_ALL = X509_V_FLAG_CRL_CHECK_ALL;
+
+#endif /* COPENSSL_SHIM_H */

--- a/Sources/SwiftOCA/OCA/Helpers/Locking.swift
+++ b/Sources/SwiftOCA/OCA/Helpers/Locking.swift
@@ -1,7 +1,7 @@
 import Synchronization
 
 extension Mutex {
-  var criticalValue: Value {
+  package var criticalValue: Value {
     withLock { $0 }
   }
 }

--- a/Sources/SwiftOCA/OCA/OcaPeerIdentity.swift
+++ b/Sources/SwiftOCA/OCA/OcaPeerIdentity.swift
@@ -1,0 +1,58 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+/// Authenticated identity of an OCP.1 peer. Snapshotted at handshake
+/// completion as plain values — holds no credential material, no retained
+/// X509/SecCertificate refs, safe to use as a Hashable ACL key.
+public enum OcaPeerIdentity: Sendable, Hashable {
+  /// Identity the peer sent in the ClientHello PSK identity field; cleartext
+  /// on the wire, so callers MUST NOT use secret material here.
+  case preSharedKey(identity: String)
+
+  /// X.509 leaf, already chain-validated. `fingerprint` is the lower-case
+  /// hex SHA-256 of the DER and is the recommended ACL key — DN equality
+  /// can be defeated by reissue against an unchanged public key.
+  case certificate(subject: String, fingerprint: String)
+
+  /// Non-TLS, or TLS with `disableCertificateVerification`. MUST NOT be
+  /// eligible for privileged operations.
+  case anonymous
+
+  public var isAuthenticated: Bool {
+    if case .anonymous = self { return false }
+    return true
+  }
+}
+
+extension OcaPeerIdentity: CustomStringConvertible {
+  public var description: String {
+    switch self {
+    case .preSharedKey(let id):
+      return "psk:\(id)"
+    case .certificate(let subject, let fp):
+      let short = fp.count > 16 ? String(fp.prefix(16)) + "…" : fp
+      return "x509:\(subject) fp=\(short)"
+    case .anonymous:
+      return "anonymous"
+    }
+  }
+}

--- a/Sources/SwiftOCA/OCC/ControlDataTypes/NetworkApplicationDataTypes.swift
+++ b/Sources/SwiftOCA/OCC/ControlDataTypes/NetworkApplicationDataTypes.swift
@@ -46,6 +46,7 @@ public enum OcaNetworkAdvertisingServiceType: String, Sendable, CaseIterable {
   case tcp = "_oca._tcp."
   case tcpSecure = "_ocasec._tcp."
   case udp = "_oca._udp."
+  case udpSecure = "_ocasec._udp."
   case tcpWebSocket = "_ocaws._tcp."
 
   public var shortDescription: String {
@@ -58,6 +59,8 @@ public enum OcaNetworkAdvertisingServiceType: String, Sendable, CaseIterable {
       "TLS"
     case .udp:
       "UDP"
+    case .udpSecure:
+      "DTLS"
     case .tcpWebSocket:
       "WS"
     }

--- a/Sources/SwiftOCA/OCP.1/Backend/Ocp1IORingConnection.swift
+++ b/Sources/SwiftOCA/OCP.1/Backend/Ocp1IORingConnection.swift
@@ -40,19 +40,15 @@ import struct SystemPackage.Errno
 import Synchronization
 #endif
 
-fileprivate extension Errno {
+package extension Errno {
   var mappedError: Error {
     switch self {
-    case .connectionRefused:
-      fallthrough
-    case .connectionReset:
-      fallthrough
-    case .brokenPipe:
-      return Ocp1Error.notConnected
+    case .connectionRefused, .connectionReset, .brokenPipe:
+      Ocp1Error.notConnected
     case .canceled:
-      return Ocp1Error.retryOperation
+      Ocp1Error.retryOperation
     default:
-      return self
+      self
     }
   }
 }

--- a/Sources/SwiftOCA/OCP.1/Backend/Ocp1NWConnection.swift
+++ b/Sources/SwiftOCA/OCP.1/Backend/Ocp1NWConnection.swift
@@ -66,28 +66,49 @@ private extension SocketAddress {
   }
 }
 
-public class Ocp1NWConnection: Ocp1Connection, Ocp1MutableConnection {
-  fileprivate let _deviceAddress: Mutex<AnySocketAddress>
-  fileprivate var _queue: DispatchQueue!
-  fileprivate var _nwConnection: NWConnection!
+open class Ocp1NWConnection: Ocp1Connection, Ocp1MutableConnection {
+  package let _deviceAddress: Mutex<AnySocketAddress>
+  package var _queue: DispatchQueue!
+  package var _nwConnection: NWConnection!
 
-  fileprivate var parameters: NWParameters {
+  open var parameters: NWParameters {
     fatalError("must be implemented by subclass")
   }
 
-  private init(
+  /// Shared TCP options factory so plaintext and TLS subclasses stay in sync.
+  package func makeTCPOptions() -> NWProtocolTCP.Options {
+    let options = NWProtocolTCP.Options()
+    options.noDelay = true
+    options.enableFastOpen = true
+    options.connectionTimeout = Int(self.options.connectionTimeout.seconds)
+    return options
+  }
+
+  package init(
     deviceAddress: AnySocketAddress,
     options: Ocp1ConnectionOptions = Ocp1ConnectionOptions()
   ) throws {
     _deviceAddress = Mutex(deviceAddress)
     super.init(options: options)
     _nwConnection = try NWConnection(to: nwEndpoint, using: parameters)
-    _nwConnection.stateUpdateHandler = { [weak self] state in
-      if let self, state == .cancelled {
-        Task { [weak self] in try await self?.disconnect() }
-      }
+    Self._installPostReadyStateHandler(_nwConnection) { [weak self] in
+      try await self?.disconnect()
     }
     _queue = DispatchQueue(label: connectionPrefix, attributes: .concurrent)
+  }
+
+  /// Long-lived state handler installed once `connectDevice` has resolved
+  /// the initial `.ready`/`.failed` race; only `.cancelled` matters here.
+  /// Post-ready `.failed` surfaces via the next read/write.
+  fileprivate static func _installPostReadyStateHandler(
+    _ connection: NWConnection,
+    onCancelled: @Sendable @escaping () async throws -> Void
+  ) {
+    connection.stateUpdateHandler = { state in
+      if state == .cancelled {
+        Task { try await onCancelled() }
+      }
+    }
   }
 
   public convenience init(
@@ -127,10 +148,8 @@ public class Ocp1NWConnection: Ocp1Connection, Ocp1MutableConnection {
     _nwConnection.stateUpdateHandler = nil
     _nwConnection.cancel()
     _nwConnection = try NWConnection(to: nwEndpoint, using: parameters)
-    _nwConnection.stateUpdateHandler = { [weak self] state in
-      if let self, state == .cancelled {
-        Task { [weak self] in try await self?.disconnect() }
-      }
+    Self._installPostReadyStateHandler(_nwConnection) { [weak self] in
+      try await self?.disconnect()
     }
   }
 
@@ -138,7 +157,41 @@ public class Ocp1NWConnection: Ocp1Connection, Ocp1MutableConnection {
     if _nwConnection.state != .setup {
       try _cleanupConnection()
     }
-    _nwConnection.start(queue: _queue)
+    // Wait for `.ready`/`.failed` before completing connect — without this
+    // any TLS handshake error is invisible until the first read/write.
+    let connection = _nwConnection!
+    try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+      // Guard against double-resume from transient state toggling.
+      let resumed = Mutex(false)
+      connection.stateUpdateHandler = { state in
+        let outcome: Result<Void, Error>?
+        switch state {
+        case .ready:
+          outcome = .success(())
+        case let .failed(error):
+          outcome = .failure(error)
+        case let .waiting(error):
+          // TLS auth failures surface as `.waiting` (NW retries forever);
+          // treat as terminal during connect rather than hanging.
+          outcome = .failure(error)
+        case .cancelled:
+          outcome = .failure(Ocp1Error.notConnected)
+        default:
+          outcome = nil
+        }
+        guard let outcome else { return }
+        let claimed = resumed.withLock { flag -> Bool in
+          if flag { return false }
+          flag = true
+          return true
+        }
+        if claimed { cont.resume(with: outcome) }
+      }
+      connection.start(queue: _queue)
+    }
+    Self._installPostReadyStateHandler(connection) { [weak self] in
+      try await self?.disconnect()
+    }
     try await super.connectDevice()
   }
 
@@ -203,13 +256,13 @@ public class Ocp1NWConnection: Ocp1Connection, Ocp1MutableConnection {
     }
   }
 
-  fileprivate nonisolated var nwEndpoint: NWEndpoint {
+  open nonisolated var nwEndpoint: NWEndpoint {
     get throws {
       try _deviceAddress.criticalValue.asNWEndpoint()
     }
   }
 
-  fileprivate nonisolated var presentationAddress: String {
+  package nonisolated var presentationAddress: String {
     _deviceAddress.criticalValue._presentationAddress
   }
 }
@@ -225,7 +278,7 @@ public final class Ocp1NWUDPConnection: Ocp1NWConnection {
 
   override public var isDatagram: Bool { true }
 
-  override var parameters: NWParameters {
+  override public var parameters: NWParameters {
     let options = NWProtocolUDP.Options()
     return NWParameters(dtls: nil, udp: options)
   }
@@ -238,12 +291,8 @@ public final class Ocp1NWTCPConnection: Ocp1NWConnection {
 
   override public var isDatagram: Bool { false }
 
-  override var parameters: NWParameters {
-    let options = NWProtocolTCP.Options()
-    options.noDelay = true
-    options.enableFastOpen = true
-    options.connectionTimeout = Int(self.options.connectionTimeout.seconds)
-    return NWParameters(tls: nil, tcp: options)
+  override public var parameters: NWParameters {
+    NWParameters(tls: nil, tcp: makeTCPOptions())
   }
 }
 

--- a/Sources/SwiftOCA/OCP.1/Ocp1Connection+Connect.swift
+++ b/Sources/SwiftOCA/OCP.1/Ocp1Connection+Connect.swift
@@ -249,9 +249,13 @@ extension Ocp1Connection {
 
   /// connect to the OCA device, throwing `Ocp1Error.connectionTimeout` if it times out
   private func _connectDeviceWithTimeout() async throws {
+    // Plain UDP has no handshake; DTLS over UDP does and can hang, so it
+    // gets the same connect timeout as TCP.
+    let timeout: Duration =
+      (isDatagram && !hasTransportLayerSecurity) ? .zero : _connectionTimeout
     do {
       try await withThrowingTimeout(
-        of: isDatagram ? .zero : _connectionTimeout,
+        of: timeout,
         clock: .continuous
       ) {
         try await self.connectDevice()
@@ -280,6 +284,15 @@ extension Ocp1Connection {
       throw Ocp1Error.alreadyConnected
     } else if isConnecting {
       throw Ocp1Error.connectionAlreadyInProgress
+    }
+    // Audit trail for cert-verification bypass so a flag accidentally
+    // copied into production deployment surfaces loudly in logs.
+    if hasTransportLayerSecurity,
+       options.flags.contains(.disableCertificateVerification)
+    {
+      logger.critical(
+        "\(connectionPrefix): TLS certificate verification is disabled (INSECURE — do not use in production)"
+      )
     }
     _updateConnectionState(.connecting)
     do {
@@ -407,13 +420,13 @@ extension Ocp1Connection {
     }
   }
 
-  func deviceAddressDidChange() {
+  package func deviceAddressDidChange() {
     Task { [weak self] in
       try await self?.onMonitorError(id: -1, Ocp1Error.deviceAddressChanged)
     }
   }
 
-  func deviceAddressDidChange() async {
+  package func deviceAddressDidChange() async {
     try? await onMonitorError(id: -1, Ocp1Error.deviceAddressChanged)
   }
 

--- a/Sources/SwiftOCA/OCP.1/Ocp1Connection.swift
+++ b/Sources/SwiftOCA/OCP.1/Ocp1Connection.swift
@@ -74,7 +74,6 @@ package let SOCK_DGRAM = Int32(Glibc.SOCK_DGRAM.rawValue)
 
 public let OcaTcpConnectionPrefix = "oca/tcp"
 public let OcaUdpConnectionPrefix = "oca/udp"
-public let OcaSecureTcpConnectionPrefix = "ocasec/tcp"
 public let OcaWebSocketTcpConnectionPrefix = "ocaws/tcp"
 public let OcaLocalConnectionPrefix = "oca/local"
 public let OcaDatagramProxyConnectionPrefix = "oca/dg-proxy"
@@ -88,6 +87,8 @@ public struct Ocp1ConnectionFlags: OptionSet, Sendable {
   public static let retainObjectCacheAfterDisconnect = Ocp1ConnectionFlags(rawValue: 1 << 2)
   public static let enableTracing = Ocp1ConnectionFlags(rawValue: 1 << 3)
   public static let refreshSubscriptionsOnReconnection = Ocp1ConnectionFlags(rawValue: 1 << 4)
+  /// Disable TLS certificate verification.
+  public static let disableCertificateVerification = Ocp1ConnectionFlags(rawValue: 1 << 5)
 
   public typealias RawValue = UInt
 
@@ -465,6 +466,11 @@ open class Ocp1Connection: CustomStringConvertible {
   /// A concrete implementation is free to override this however.
   open var isDatagram: Bool {
     heartbeatTime > .seconds(0)
+  }
+
+  /// Plaintext transports return `false`; TLS-wrapping transports override.
+  open var hasTransportLayerSecurity: Bool {
+    false
   }
 
   /// The local socket address of the connection, if available.

--- a/Sources/SwiftOCADevice/OCA/Controller.swift
+++ b/Sources/SwiftOCADevice/OCA/Controller.swift
@@ -24,11 +24,18 @@ public struct OcaControllerFlags: OptionSet, Sendable {
   public init(rawValue: RawValue) { self.rawValue = rawValue }
 
   public static let supportsLocking = Self(rawValue: 1 << 0)
+  /// Set by TLS-wrapping controllers.
+  public static let hasTransportLayerSecurity = Self(rawValue: 1 << 1)
   public static let isLocal = Self(rawValue: 1 << 2)
 }
 
 public protocol OcaController: Actor {
   nonisolated var flags: OcaControllerFlags { get }
+
+  /// Authenticated peer identity; `.anonymous` for plaintext transports.
+  /// Privileged checks MUST consult this — `.hasTransportLayerSecurity`
+  /// only proves *some* trusted peer is on the wire, not which.
+  nonisolated var peerIdentity: OcaPeerIdentity { get }
 
   func addSubscription(
     _ subscription: OcaSubscriptionManagerSubscription
@@ -51,6 +58,8 @@ public protocol OcaController: Actor {
 }
 
 public extension OcaController {
+  nonisolated var peerIdentity: OcaPeerIdentity { .anonymous }
+
   func sendMessage(
     _ messages: Ocp1Message,
     type messageType: OcaMessageType

--- a/Sources/SwiftOCADevice/OCA/Device.swift
+++ b/Sources/SwiftOCADevice/OCA/Device.swift
@@ -41,6 +41,7 @@ public actor OcaDevice {
   public private(set) var rootBlock: OcaBlock<OcaRoot>!
   public private(set) var subscriptionManager: OcaSubscriptionManager!
   public private(set) var deviceManager: OcaDeviceManager!
+  public private(set) var securityManager: OcaSecurityManager!
 
   var objects = [OcaONo: OcaRoot]()
   var nextObjectNumber: OcaONo = OcaMaximumReservedONo + 1
@@ -61,7 +62,10 @@ public actor OcaDevice {
     return nextObjectNumber
   }
 
-  public func initializeDefaultObjects(deviceManager: OcaDeviceManager? = nil) async throws {
+  public func initializeDefaultObjects(
+    deviceManager: OcaDeviceManager? = nil,
+    securityManager: OcaSecurityManager? = nil
+  ) async throws {
     rootBlock = try await OcaBlock(
       objectNumber: OcaRootBlockONo,
       role: "",
@@ -69,6 +73,11 @@ public actor OcaDevice {
       addToRootBlock: false
     )
     subscriptionManager = try await OcaSubscriptionManager(deviceDelegate: self)
+    if let securityManager {
+      self.securityManager = securityManager
+    } else {
+      self.securityManager = try await OcaSecurityManager(deviceDelegate: self)
+    }
     Task { @OcaDevice in await rootBlock.type = 1 }
     if let deviceManager {
       self.deviceManager = deviceManager

--- a/Sources/SwiftOCADevice/OCA/DeviceEndpoint.swift
+++ b/Sources/SwiftOCADevice/OCA/DeviceEndpoint.swift
@@ -26,16 +26,16 @@ public protocol OcaDeviceEndpoint: AnyObject, Sendable {
   var controllers: [OcaController] { get async }
 }
 
-enum OcaMessageDirection {
+package enum OcaMessageDirection {
   case tx
   case rx
 }
 
-protocol OcaDeviceEndpointPrivate: OcaDeviceEndpoint {
+package protocol OcaDeviceEndpointPrivate: OcaDeviceEndpoint {
   associatedtype ControllerType: Ocp1ControllerInternal
 
-  var device: OcaDevice { get }
-  var timeout: Duration { get }
+  nonisolated var device: OcaDevice { get }
+  nonisolated var timeout: Duration { get }
 
   nonisolated var logger: Logger { get }
   nonisolated var enableMessageTracing: Bool { get }
@@ -45,7 +45,7 @@ protocol OcaDeviceEndpointPrivate: OcaDeviceEndpoint {
 }
 
 extension OcaDeviceEndpointPrivate {
-  func unlockAndRemove(controller: ControllerType) async {
+  package func unlockAndRemove(controller: ControllerType) async {
     await controller.cancelKeepAlive()
 
     Task { await device.eventDelegate?.onControllerExpiry(controller) }
@@ -63,12 +63,12 @@ extension OcaDeviceEndpointPrivate {
     try? await controller.close()
   }
 
-  func handle(messagePduData: Data, from controller: ControllerType) async throws {
+  package func handle(messagePduData: Data, from controller: ControllerType) async throws {
     let messageList = try await controller.decodeMessages(from: messagePduData)
     try await controller.handle(for: self, messageList: messageList)
   }
 
-  func handle(messagePduData: [UInt8], from controller: ControllerType) async throws {
+  package func handle(messagePduData: [UInt8], from controller: ControllerType) async throws {
     try await handle(messagePduData: Data(messagePduData), from: controller)
   }
 }

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Managers/SecurityManager.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Managers/SecurityManager.swift
@@ -1,0 +1,181 @@
+//
+// Copyright (c) 2024-2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+import SwiftOCA
+import Synchronization
+
+open class OcaSecurityManager: OcaManager {
+  override open class var classID: OcaClassID { OcaClassID("1.3.2") }
+  override open class var classVersion: OcaClassVersionNumber { 3 }
+
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("3.1"),
+    getMethodID: OcaMethodID("3.1")
+  )
+  public var secureControlData: OcaBoolean = false
+
+  /// Mutex-backed so the OpenSSL PSK callback can read synchronously from
+  /// outside the actor. OCA add/delete paths take the same lock.
+  ///
+  /// Runtime mutations (via `AddPreSharedKey` / `DeletePreSharedKey`) take
+  /// effect immediately for backends that read PSKs per handshake (OpenSSL
+  /// on Linux). On Apple, Network.framework bakes the PSK set into static
+  /// listener config at bind time, so runtime changes require an endpoint
+  /// restart — see `Ocp1NWSecureTCPDeviceEndpoint` /
+  /// `Ocp1NWSecureUDPDeviceEndpoint`.
+  package nonisolated let _preSharedKeys = Mutex<[OcaString: Data]>([:])
+
+  /// Register a PSK without going through OCA command authorization;
+  /// intended for static configuration at device startup.
+  public func loadPreSharedKey(identity: OcaString, key: Data) throws {
+    try _add(identity: identity, key: key, mustExist: false)
+  }
+
+  /// Mirrored from `SwiftOCASecure.OcaMinimumPreSharedKeyLength`;
+  /// SwiftOCADevice doesn't depend on SwiftOCASecure.
+  private static let minimumPreSharedKeyLength: Int = 16
+
+  /// Wipe a PSK `Data` in place. Caller MUST hold exclusive ownership of
+  /// the Data — pull the slot out of the dict via `removeValue` first, and
+  /// keep the PSK provider's read callback under the same lock so no
+  /// concurrent reference can exist. Without exclusive ownership, Swift's
+  /// COW will silently redirect `resetBytes` to a fresh copy.
+  private static func _zero(_ key: inout Data) {
+    let count = key.count
+    guard count > 0 else { return }
+    key.resetBytes(in: 0..<count)
+  }
+
+  private func _add(identity: OcaString, key: Data, mustExist: Bool) throws {
+    guard !identity.isEmpty else {
+      throw Ocp1Error.status(.parameterError)
+    }
+    guard key.count >= Self.minimumPreSharedKeyLength else {
+      throw Ocp1Error.status(.parameterError)
+    }
+    // Defensive copy: caller's `Data` may share storage we can't see,
+    // and COW would otherwise redirect our future wipe to a fresh copy.
+    // `Data(count:)` is uniquely owned at insertion.
+    var owned = Data(count: key.count)
+    owned.withUnsafeMutableBytes { dst in
+      key.withUnsafeBytes { src in
+        if let dp = dst.baseAddress, let sp = src.baseAddress {
+          dp.copyMemory(from: sp, byteCount: key.count)
+        }
+      }
+    }
+    try _preSharedKeys.withLock { dict in
+      guard (dict[identity] != nil) == mustExist else {
+        throw Ocp1Error.status(.parameterError)
+      }
+      // Replace: take exclusive ownership of the prior key before wiping
+      // so `_zero` hits the stored buffer, not a COW copy.
+      if var prior = dict.removeValue(forKey: identity) {
+        Self._zero(&prior)
+      }
+      dict[identity] = owned
+    }
+  }
+
+  private func _delete(identity: OcaString) throws {
+    try _preSharedKeys.withLock { dict in
+      guard var removed = dict.removeValue(forKey: identity) else {
+        throw Ocp1Error.status(.parameterError)
+      }
+      Self._zero(&removed)
+    }
+  }
+
+  /// PSKs and security state must never traverse a plaintext connection.
+  override open func ensureReadable(
+    by controller: any OcaController,
+    command: Ocp1Command
+  ) async throws {
+    guard controller.flags.contains(.hasTransportLayerSecurity) else {
+      throw Ocp1Error.status(.notImplemented)
+    }
+    try await super.ensureReadable(by: controller, command: command)
+  }
+
+  /// Write access denied unconditionally; PSK add/change/delete scaffolding
+  /// is in place but disabled until admin role gating is implemented.
+  /// Subclasses introducing ACLs MUST consult `controller.peerIdentity` and
+  /// reject `.anonymous` — `.hasTransportLayerSecurity` only proves *some*
+  /// trusted peer is on the wire, not which principal.
+  override open func ensureWritable(
+    by controller: any OcaController,
+    command: Ocp1Command
+  ) async throws {
+    throw Ocp1Error.status(.permissionDenied)
+  }
+
+  override open func handleCommand(
+    _ command: Ocp1Command,
+    from controller: any OcaController
+  ) async throws -> Ocp1Response {
+    switch command.methodID {
+    case OcaMethodID("3.1"):
+      try decodeNullCommand(command)
+      try await ensureWritable(by: controller, command: command)
+      secureControlData = true
+      return Ocp1Response()
+    case OcaMethodID("3.2"):
+      try decodeNullCommand(command)
+      try await ensureWritable(by: controller, command: command)
+      secureControlData = false
+      return Ocp1Response()
+    case OcaMethodID("3.3"):
+      let params: SwiftOCA.OcaSecurityManager
+        .AddPreSharedKeyParameters = try decodeCommand(command)
+      try await ensureWritable(by: controller, command: command)
+      try _add(identity: params.identity, key: Data(params.key), mustExist: true)
+      return Ocp1Response()
+    case OcaMethodID("3.4"):
+      let params: SwiftOCA.OcaSecurityManager
+        .AddPreSharedKeyParameters = try decodeCommand(command)
+      try await ensureWritable(by: controller, command: command)
+      try _add(identity: params.identity, key: Data(params.key), mustExist: false)
+      return Ocp1Response()
+    case OcaMethodID("3.5"):
+      let identity: OcaString = try decodeCommand(command)
+      try await ensureWritable(by: controller, command: command)
+      try _delete(identity: identity)
+      return Ocp1Response()
+    default:
+      return try await super.handleCommand(command, from: controller)
+    }
+  }
+
+  public convenience init(
+    deviceDelegate: OcaDevice? = nil,
+    preSharedKeys: [OcaString: OcaBlob] = [:]
+  ) async throws {
+    try await self.init(
+      objectNumber: OcaSecurityManagerONo,
+      role: "Security Manager",
+      deviceDelegate: deviceDelegate,
+      addToRootBlock: true
+    )
+    for (identity, key) in preSharedKeys {
+      try loadPreSharedKey(identity: identity, key: Data(key))
+    }
+  }
+}

--- a/Sources/SwiftOCADevice/OCP.1/Backend/CF/Ocp1CFController.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/CF/Ocp1CFController.swift
@@ -51,7 +51,7 @@ protocol Ocp1CFControllerPrivate: Ocp1ControllerInternal,
 }
 
 extension Ocp1CFControllerPrivate {
-  func sendOcp1EncodedData(
+  package func sendOcp1EncodedData(
     _ data: Data,
     to destinationAddress: OcaNetworkAddress
   ) async throws {
@@ -68,13 +68,13 @@ extension Ocp1CFControllerPrivate {
     try await sendOcp1EncodedMessage(CFSocket.Message(address: peerAddress, buffer: data))
   }
 
-  nonisolated var identifier: String {
+  package nonisolated var identifier: String {
     (try? peerAddress.presentationAddress) ?? "unknown"
   }
 }
 
-actor Ocp1CFStreamController: Ocp1CFControllerPrivate, CustomStringConvertible {
-  nonisolated var flags: OcaControllerFlags {
+package actor Ocp1CFStreamController: Ocp1CFControllerPrivate, CustomStringConvertible {
+  package nonisolated var flags: OcaControllerFlags {
     var flags: OcaControllerFlags = .supportsLocking
     if peerAddress.family == sa_family_t(AF_LOCAL) {
       flags.insert(.isLocal)
@@ -82,17 +82,17 @@ actor Ocp1CFStreamController: Ocp1CFControllerPrivate, CustomStringConvertible {
     return flags
   }
 
-  nonisolated let connectionPrefix: String
+  package nonisolated let connectionPrefix: String
 
-  var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()
+  package var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()
   let peerAddress: AnySocketAddress
   var receiveMessageTask: Task<(), Never>?
-  var keepAliveTask: Task<(), Error>?
-  var lastMessageReceivedTime = ContinuousClock.recentPast
-  var lastMessageSentTime = ContinuousClock.recentPast
-  weak var endpoint: Ocp1CFStreamDeviceEndpoint?
+  package var keepAliveTask: Task<(), Error>?
+  package var lastMessageReceivedTime = ContinuousClock.recentPast
+  package var lastMessageSentTime = ContinuousClock.recentPast
+  package weak var endpoint: Ocp1CFStreamDeviceEndpoint?
 
-  var messages: AnyAsyncSequence<Ocp1MessageList> {
+  package var messages: AnyAsyncSequence<Ocp1MessageList> {
     _messages.eraseToAnyAsyncSequence()
   }
 
@@ -101,7 +101,7 @@ actor Ocp1CFStreamController: Ocp1CFControllerPrivate, CustomStringConvertible {
   private let _socket: Mutex<_CFSocketWrapper?>
   let notificationSocket: _CFSocketWrapper
 
-  nonisolated var description: String {
+  package nonisolated var description: String {
     let socket = socket
     return "\(type(of: self))(socket: \(socket != nil ? String(describing: socket!) : "<disconnected>"))"
   }
@@ -152,7 +152,7 @@ actor Ocp1CFStreamController: Ocp1CFControllerPrivate, CustomStringConvertible {
     }
   }
 
-  func close() async throws {
+  package func close() async throws {
     keepAliveTask?.cancel()
     keepAliveTask = nil
 
@@ -174,13 +174,13 @@ actor Ocp1CFStreamController: Ocp1CFControllerPrivate, CustomStringConvertible {
     _messagesContinuation.finish()
   }
 
-  var heartbeatTime = Duration.seconds(0) {
+  package var heartbeatTime = Duration.seconds(0) {
     didSet {
       heartbeatTimeDidChange(from: oldValue)
     }
   }
 
-  func sendOcp1EncodedData(_ data: Data) async throws {
+  package func sendOcp1EncodedData(_ data: Data) async throws {
     guard let socket else { throw Errno.badFileDescriptor }
     _ = try await socket.write(data: data)
   }
@@ -218,21 +218,21 @@ private extension Ocp1NetworkAddress {
   }
 }
 
-actor Ocp1CFDatagramController: Ocp1CFControllerPrivate, Ocp1ControllerDatagramSemantics {
-  nonisolated var flags: OcaControllerFlags { .supportsLocking }
+package actor Ocp1CFDatagramController: Ocp1CFControllerPrivate, Ocp1ControllerDatagramSemantics {
+  package nonisolated var flags: OcaControllerFlags { .supportsLocking }
 
-  nonisolated var connectionPrefix: String { OcaUdpConnectionPrefix }
+  package nonisolated var connectionPrefix: String { OcaUdpConnectionPrefix }
 
-  var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()
+  package var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()
   let peerAddress: AnySocketAddress
-  var keepAliveTask: Task<(), Error>?
-  var lastMessageReceivedTime = ContinuousClock.recentPast
-  var lastMessageSentTime = ContinuousClock.recentPast
+  package var keepAliveTask: Task<(), Error>?
+  package var lastMessageReceivedTime = ContinuousClock.recentPast
+  package var lastMessageSentTime = ContinuousClock.recentPast
 
-  private(set) var isOpen: Bool = false
-  weak var endpoint: Ocp1CFDatagramDeviceEndpoint?
+  package private(set) var isOpen: Bool = false
+  package weak var endpoint: Ocp1CFDatagramDeviceEndpoint?
 
-  var messages: AnyAsyncSequence<Ocp1MessageList> {
+  package var messages: AnyAsyncSequence<Ocp1MessageList> {
     AsyncEmptySequence<Ocp1MessageList>().eraseToAnyAsyncSequence()
   }
 
@@ -244,13 +244,13 @@ actor Ocp1CFDatagramController: Ocp1CFControllerPrivate, Ocp1ControllerDatagramS
     self.peerAddress = AnySocketAddress(peerAddress)
   }
 
-  var heartbeatTime = Duration.seconds(1) {
+  package var heartbeatTime = Duration.seconds(1) {
     didSet {
       heartbeatTimeDidChange(from: oldValue)
     }
   }
 
-  func sendOcp1EncodedData(_ data: Data) async throws {
+  package func sendOcp1EncodedData(_ data: Data) async throws {
     try await sendOcp1EncodedMessage(CFSocket.Message(address: peerAddress, buffer: data))
   }
 
@@ -258,21 +258,21 @@ actor Ocp1CFDatagramController: Ocp1CFControllerPrivate, Ocp1ControllerDatagramS
     try await endpoint?.sendOcp1EncodedMessage(messagePdu)
   }
 
-  func close() async throws {}
+  package func close() async throws {}
 
-  func didOpen() {
+  package func didOpen() {
     isOpen = true
   }
 }
 
 extension Ocp1CFControllerPrivate {
-  nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
+  package nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
     lhs.peerAddress == rhs.peerAddress
   }
 }
 
 extension Ocp1CFControllerPrivate {
-  nonisolated func hash(into hasher: inout Hasher) {
+  package nonisolated func hash(into hasher: inout Hasher) {
     peerAddress.hash(into: &hasher)
   }
 }

--- a/Sources/SwiftOCADevice/OCP.1/Backend/CF/Ocp1CFDeviceEndpoint.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/CF/Ocp1CFDeviceEndpoint.swift
@@ -46,10 +46,10 @@ public class Ocp1CFDeviceEndpoint: OcaBonjourRegistrableDeviceEndpoint,
   CustomStringConvertible
 {
   let address: any SocketAddress
-  let timeout: Duration
-  let device: OcaDevice
-  let logger: Logger
-  nonisolated(unsafe) var enableMessageTracing = false
+  package let timeout: Duration
+  package let device: OcaDevice
+  package let logger: Logger
+  package nonisolated(unsafe) var enableMessageTracing = false
 
   var socket: _CFSocketWrapper?
   #if canImport(dnssd)
@@ -137,7 +137,7 @@ public class Ocp1CFDeviceEndpoint: OcaBonjourRegistrableDeviceEndpoint,
 public final class Ocp1CFStreamDeviceEndpoint: Ocp1CFDeviceEndpoint,
   OcaDeviceEndpointPrivate
 {
-  typealias ControllerType = Ocp1CFStreamController
+  package typealias ControllerType = Ocp1CFStreamController
 
   var notificationSocket: _CFSocketWrapper?
 
@@ -192,11 +192,11 @@ public final class Ocp1CFStreamDeviceEndpoint: Ocp1CFDeviceEndpoint,
   }
   #endif
 
-  func add(controller: ControllerType) async {
+  package func add(controller: ControllerType) async {
     _controllers.append(controller)
   }
 
-  func remove(controller: ControllerType) async {
+  package func remove(controller: ControllerType) async {
     _controllers.removeAll(where: { $0 == controller })
   }
 }
@@ -205,7 +205,7 @@ public final class Ocp1CFStreamDeviceEndpoint: Ocp1CFDeviceEndpoint,
 public class Ocp1CFDatagramDeviceEndpoint: Ocp1CFDeviceEndpoint,
   OcaDeviceEndpointPrivate
 {
-  typealias ControllerType = Ocp1CFDatagramController
+  package typealias ControllerType = Ocp1CFDatagramController
 
   var _controllers = [AnySocketAddress: ControllerType]()
 
@@ -276,9 +276,9 @@ public class Ocp1CFDatagramDeviceEndpoint: Ocp1CFDeviceEndpoint,
   }
   #endif
 
-  func add(controller: ControllerType) async {}
+  package func add(controller: ControllerType) async {}
 
-  func remove(controller: ControllerType) async {
+  package func remove(controller: ControllerType) async {
     _controllers[controller.peerAddress] = nil
   }
 }

--- a/Sources/SwiftOCADevice/OCP.1/Backend/DatagramProxy/DatagramProxyController.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/DatagramProxy/DatagramProxyController.swift
@@ -22,23 +22,23 @@ import Foundation
 #endif
 import SwiftOCA
 
-actor DatagramProxyController<T: DatagramProxyPeerIdentifier>: Ocp1ControllerInternal,
+package actor DatagramProxyController<T: DatagramProxyPeerIdentifier>: Ocp1ControllerInternal,
   Ocp1ControllerDatagramSemantics,
   CustomStringConvertible
 {
-  nonisolated var flags: OcaControllerFlags { .supportsLocking }
-  nonisolated var connectionPrefix: String { OcaDatagramProxyConnectionPrefix }
+  package nonisolated var flags: OcaControllerFlags { .supportsLocking }
+  package nonisolated var connectionPrefix: String { OcaDatagramProxyConnectionPrefix }
 
   let peerID: T
-  var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()
-  var keepAliveTask: Task<(), Error>?
-  var lastMessageReceivedTime = ContinuousClock.recentPast
-  var lastMessageSentTime = ContinuousClock.recentPast
+  package var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()
+  package var keepAliveTask: Task<(), Error>?
+  package var lastMessageReceivedTime = ContinuousClock.recentPast
+  package var lastMessageSentTime = ContinuousClock.recentPast
 
-  private(set) var isOpen: Bool = false
-  weak var endpoint: DatagramProxyDeviceEndpoint<T>?
+  package private(set) var isOpen: Bool = false
+  package weak var endpoint: DatagramProxyDeviceEndpoint<T>?
 
-  var messages: AnyAsyncSequence<Ocp1MessageList> {
+  package var messages: AnyAsyncSequence<Ocp1MessageList> {
     AsyncEmptySequence<Ocp1MessageList>().eraseToAnyAsyncSequence()
   }
 
@@ -48,7 +48,7 @@ actor DatagramProxyController<T: DatagramProxyPeerIdentifier>: Ocp1ControllerInt
     heartbeatTime = endpoint.timeout
   }
 
-  var heartbeatTime: Duration {
+  package var heartbeatTime: Duration {
     didSet {
       heartbeatTimeDidChange(from: oldValue)
     }
@@ -61,21 +61,21 @@ actor DatagramProxyController<T: DatagramProxyPeerIdentifier>: Ocp1ControllerInt
     }
   }
 
-  func sendOcp1EncodedData(_ data: Data) async throws {
+  package func sendOcp1EncodedData(_ data: Data) async throws {
     endpoint?.outputStream.yield((peerID, [UInt8](data)))
   }
 
-  nonisolated var identifier: String {
+  package nonisolated var identifier: String {
     String(describing: peerID)
   }
 
-  nonisolated var description: String {
+  package nonisolated var description: String {
     "\(type(of: self))(peerID: \(String(describing: peerID))"
   }
 
-  func close() async throws {}
+  package func close() async throws {}
 
-  func didOpen() {
+  package func didOpen() {
     isOpen = true
   }
 }

--- a/Sources/SwiftOCADevice/OCP.1/Backend/DatagramProxy/DatagramProxyDeviceEndpoint.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/DatagramProxy/DatagramProxyDeviceEndpoint.swift
@@ -39,12 +39,12 @@ public class DatagramProxyDeviceEndpoint<
     _controllers.values.map { $0 }
   }
 
-  typealias ControllerType = DatagramProxyController<T>
+  package typealias ControllerType = DatagramProxyController<T>
 
-  let timeout: Duration
-  let device: OcaDevice
-  let logger = Logger(label: "com.padl.SwiftOCADevice.DatagramProxyDeviceEndpoint")
-  nonisolated(unsafe) var enableMessageTracing = false
+  package let timeout: Duration
+  package let device: OcaDevice
+  package let logger = Logger(label: "com.padl.SwiftOCADevice.DatagramProxyDeviceEndpoint")
+  package nonisolated(unsafe) var enableMessageTracing = false
   let outputStream: AsyncStream<PeerMessagePDU>.Continuation
 
   private var _controllers = [T: ControllerType]()
@@ -95,9 +95,9 @@ public class DatagramProxyDeviceEndpoint<
   }
 
   // only needed for stream-oriented controllers
-  func add(controller: ControllerType) async {}
+  package func add(controller: ControllerType) async {}
 
-  func remove(controller: ControllerType) async {
+  package func remove(controller: ControllerType) async {
     _controllers[controller.peerID] = nil
   }
 }

--- a/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingFoxController.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingFoxController.swift
@@ -27,21 +27,21 @@ import Foundation
 import SwiftOCA
 
 /// A remote WebSocket endpoint
-actor Ocp1FlyingFoxController: Ocp1ControllerInternal, CustomStringConvertible {
-  nonisolated var flags: OcaControllerFlags { .supportsLocking }
-  nonisolated var connectionPrefix: String { OcaWebSocketTcpConnectionPrefix }
+package actor Ocp1FlyingFoxController: Ocp1ControllerInternal, CustomStringConvertible {
+  package nonisolated var flags: OcaControllerFlags { .supportsLocking }
+  package nonisolated var connectionPrefix: String { OcaWebSocketTcpConnectionPrefix }
 
-  var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()
+  package var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()
 
   private let _messages: AsyncThrowingStream<Ocp1MessageList, Error>
   private let outputStream: AsyncStream<WSMessage>.Continuation
-  var endpoint: Ocp1FlyingFoxDeviceEndpoint?
+  package var endpoint: Ocp1FlyingFoxDeviceEndpoint?
 
-  var keepAliveTask: Task<(), Error>?
-  var lastMessageReceivedTime = ContinuousClock.recentPast
-  var lastMessageSentTime = ContinuousClock.recentPast
+  package var keepAliveTask: Task<(), Error>?
+  package var lastMessageReceivedTime = ContinuousClock.recentPast
+  package var lastMessageSentTime = ContinuousClock.recentPast
 
-  var messages: AsyncExtensions.AnyAsyncSequence<Ocp1MessageList> {
+  package var messages: AsyncExtensions.AnyAsyncSequence<Ocp1MessageList> {
     _messages.eraseToAnyAsyncSequence()
   }
 
@@ -73,17 +73,17 @@ actor Ocp1FlyingFoxController: Ocp1ControllerInternal, CustomStringConvertible {
     }
   }
 
-  var heartbeatTime = Duration.seconds(0) {
+  package var heartbeatTime = Duration.seconds(0) {
     didSet {
       heartbeatTimeDidChange(from: oldValue)
     }
   }
 
-  func sendOcp1EncodedData(_ data: Data) async throws {
+  package func sendOcp1EncodedData(_ data: Data) async throws {
     outputStream.yield(.data(data))
   }
 
-  func close() async {
+  package func close() async {
     outputStream.finish()
 
     keepAliveTask?.cancel()
@@ -95,11 +95,11 @@ actor Ocp1FlyingFoxController: Ocp1ControllerInternal, CustomStringConvertible {
     outputStream.finish()
   }
 
-  nonisolated var identifier: String {
+  package nonisolated var identifier: String {
     String(describing: id)
   }
 
-  nonisolated var description: String {
+  package nonisolated var description: String {
     "\(type(of: self))(id: \(id))"
   }
 }

--- a/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingFoxDeviceEndpoint.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingFoxDeviceEndpoint.swift
@@ -39,16 +39,16 @@ public final class Ocp1FlyingFoxDeviceEndpoint: OcaDeviceEndpointPrivate,
   OcaBonjourRegistrableDeviceEndpoint,
   CustomStringConvertible
 {
-  typealias ControllerType = Ocp1FlyingFoxController
+  package typealias ControllerType = Ocp1FlyingFoxController
 
   public var controllers: [OcaController] {
     _controllers
   }
 
-  let timeout: Duration
-  let device: OcaDevice
-  let logger: Logger
-  nonisolated(unsafe) var enableMessageTracing = false
+  package let timeout: Duration
+  package let device: OcaDevice
+  package let logger: Logger
+  package nonisolated(unsafe) var enableMessageTracing = false
 
   private(set) var httpServer: HTTPServer!
   private let address: sockaddr_storage
@@ -59,7 +59,7 @@ public final class Ocp1FlyingFoxDeviceEndpoint: OcaDeviceEndpointPrivate,
 
   final class Handler: WSMessageHandler, @unchecked
   Sendable {
-    weak var endpoint: Ocp1FlyingFoxDeviceEndpoint?
+    package weak var endpoint: Ocp1FlyingFoxDeviceEndpoint?
 
     init(_ endpoint: Ocp1FlyingFoxDeviceEndpoint) {
       self.endpoint = endpoint
@@ -160,11 +160,11 @@ public final class Ocp1FlyingFoxDeviceEndpoint: OcaDeviceEndpointPrivate,
     (try? address.port) ?? 0
   }
 
-  func add(controller: Ocp1FlyingFoxController) async {
+  package func add(controller: Ocp1FlyingFoxController) async {
     _controllers.append(controller)
   }
 
-  func remove(controller: Ocp1FlyingFoxController) async {
+  package func remove(controller: Ocp1FlyingFoxController) async {
     _controllers.removeAll(where: { $0.id == controller.id })
   }
 }

--- a/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingSocksDatagramController.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingSocksDatagramController.swift
@@ -31,22 +31,22 @@ import Glibc
 #endif
 
 /// A remote controller
-actor Ocp1FlyingSocksDatagramController: Ocp1ControllerInternal {
-  nonisolated var flags: OcaControllerFlags { .supportsLocking }
-  nonisolated var connectionPrefix: String { OcaUdpConnectionPrefix }
+package actor Ocp1FlyingSocksDatagramController: Ocp1ControllerInternal {
+  package nonisolated var flags: OcaControllerFlags { .supportsLocking }
+  package nonisolated var connectionPrefix: String { OcaUdpConnectionPrefix }
 
-  var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()
+  package var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()
   let peerAddress: any SocketAddress
   let interfaceIndex: UInt32?
   let localAddress: (any SocketAddress)?
-  var keepAliveTask: Task<(), Error>?
-  var lastMessageReceivedTime = ContinuousClock.recentPast
-  var lastMessageSentTime = ContinuousClock.recentPast
+  package var keepAliveTask: Task<(), Error>?
+  package var lastMessageReceivedTime = ContinuousClock.recentPast
+  package var lastMessageSentTime = ContinuousClock.recentPast
 
-  private(set) var isOpen: Bool = false
-  weak var endpoint: Ocp1FlyingSocksDatagramDeviceEndpoint?
+  package private(set) var isOpen: Bool = false
+  package weak var endpoint: Ocp1FlyingSocksDatagramDeviceEndpoint?
 
-  var messages: AnyAsyncSequence<Ocp1MessageList> {
+  package var messages: AnyAsyncSequence<Ocp1MessageList> {
     AsyncEmptySequence<Ocp1MessageList>().eraseToAnyAsyncSequence()
   }
 
@@ -62,13 +62,13 @@ actor Ocp1FlyingSocksDatagramController: Ocp1ControllerInternal {
     self.localAddress = localAddress
   }
 
-  var heartbeatTime = Duration.seconds(1) {
+  package var heartbeatTime = Duration.seconds(1) {
     didSet {
       heartbeatTimeDidChange(from: oldValue)
     }
   }
 
-  func sendOcp1EncodedData(_ data: Data) async throws {
+  package func sendOcp1EncodedData(_ data: Data) async throws {
     let peerAddress = FlyingSocks.AnySocketAddress(peerAddress)
     let localAddress = localAddress != nil ? FlyingSocks.AnySocketAddress(localAddress!) : nil
 
@@ -84,13 +84,13 @@ actor Ocp1FlyingSocksDatagramController: Ocp1ControllerInternal {
     try await endpoint?.sendOcp1EncodedMessage(messagePdu)
   }
 
-  func close() async throws {}
+  package func close() async throws {}
 
-  func didOpen() {
+  package func didOpen() {
     isOpen = true
   }
 
-  nonisolated var identifier: String {
+  package nonisolated var identifier: String {
     peerAddress.makeStorage()._presentationAddress
   }
 
@@ -103,7 +103,7 @@ actor Ocp1FlyingSocksDatagramController: Ocp1ControllerInternal {
 }
 
 extension Ocp1FlyingSocksDatagramController: Equatable {
-  nonisolated static func == (
+  package nonisolated static func == (
     lhs: Ocp1FlyingSocksDatagramController,
     rhs: Ocp1FlyingSocksDatagramController
   ) -> Bool {
@@ -112,7 +112,7 @@ extension Ocp1FlyingSocksDatagramController: Equatable {
 }
 
 extension Ocp1FlyingSocksDatagramController: Hashable {
-  nonisolated func hash(into hasher: inout Hasher) {
+  package nonisolated func hash(into hasher: inout Hasher) {
     var peerAddress = peerAddress.makeStorage()
     Data(bytes: &peerAddress, count: MemoryLayout<sockaddr_storage>.size).hash(into: &hasher)
   }

--- a/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingSocksDatagramDeviceEndpoint.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingSocksDatagramDeviceEndpoint.swift
@@ -49,7 +49,7 @@ public final class Ocp1FlyingSocksDatagramDeviceEndpoint: OcaDeviceEndpointPriva
   OcaBonjourRegistrableDeviceEndpoint,
   CustomStringConvertible
 {
-  typealias ControllerType = Ocp1FlyingSocksDatagramController
+  package typealias ControllerType = Ocp1FlyingSocksDatagramController
 
   var _controllers = Set<ControllerType>()
 
@@ -60,10 +60,10 @@ public final class Ocp1FlyingSocksDatagramDeviceEndpoint: OcaDeviceEndpointPriva
   let pool: AsyncSocketPool
 
   private let address: SocketAddress
-  let timeout: Duration
-  let device: OcaDevice
-  let logger: Logger
-  nonisolated(unsafe) var enableMessageTracing = false
+  package let timeout: Duration
+  package let device: OcaDevice
+  package let logger: Logger
+  package nonisolated(unsafe) var enableMessageTracing = false
 
   private(set) var socket: Socket?
   private var asyncSocket: AsyncSocket?
@@ -247,9 +247,9 @@ public final class Ocp1FlyingSocksDatagramDeviceEndpoint: OcaDeviceEndpointPriva
     address.port
   }
 
-  func add(controller: ControllerType) async {}
+  package func add(controller: ControllerType) async {}
 
-  func remove(controller: ControllerType) async {
+  package func remove(controller: ControllerType) async {
     _controllers.remove(controller)
   }
 

--- a/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingSocksStreamController.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingSocksStreamController.swift
@@ -31,22 +31,22 @@ import Glibc
 #endif
 
 /// A remote controller
-actor Ocp1FlyingSocksStreamController: Ocp1ControllerInternal, CustomStringConvertible {
-  nonisolated let flags: OcaControllerFlags
-  nonisolated let connectionPrefix: String
+package actor Ocp1FlyingSocksStreamController: Ocp1ControllerInternal, CustomStringConvertible {
+  package nonisolated let flags: OcaControllerFlags
+  package nonisolated let connectionPrefix: String
 
-  var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()
-  var keepAliveTask: Task<(), Error>?
-  var lastMessageReceivedTime = ContinuousClock.recentPast
-  var lastMessageSentTime = ContinuousClock.recentPast
-  weak var endpoint: Ocp1FlyingSocksStreamDeviceEndpoint?
+  package var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()
+  package var keepAliveTask: Task<(), Error>?
+  package var lastMessageReceivedTime = ContinuousClock.recentPast
+  package var lastMessageSentTime = ContinuousClock.recentPast
+  package weak var endpoint: Ocp1FlyingSocksStreamDeviceEndpoint?
 
   private let address: String
   private let socket: AsyncSocket
   private let _messages: AsyncThrowingStream<Ocp1MessageList, Error>
   private var socketClosed = false
 
-  var messages: AnyAsyncSequence<Ocp1MessageList> {
+  package var messages: AnyAsyncSequence<Ocp1MessageList> {
     _messages.eraseToAnyAsyncSequence()
   }
 
@@ -69,13 +69,13 @@ actor Ocp1FlyingSocksStreamController: Ocp1ControllerInternal, CustomStringConve
     _messages = AsyncThrowingStream.decodingMessages(from: socket.bytes, timeout: endpoint.timeout)
   }
 
-  var heartbeatTime = Duration.seconds(0) {
+  package var heartbeatTime = Duration.seconds(0) {
     didSet {
       heartbeatTimeDidChange(from: oldValue)
     }
   }
 
-  func sendOcp1EncodedData(_ data: Data) async throws {
+  package func sendOcp1EncodedData(_ data: Data) async throws {
     try await socket.write(data)
   }
 
@@ -85,7 +85,7 @@ actor Ocp1FlyingSocksStreamController: Ocp1ControllerInternal, CustomStringConve
     socketClosed = true
   }
 
-  func close() async throws {
+  package func close() async throws {
     try closeSocket()
 
     keepAliveTask?.cancel()
@@ -96,11 +96,11 @@ actor Ocp1FlyingSocksStreamController: Ocp1ControllerInternal, CustomStringConve
     keepAliveTask?.cancel()
   }
 
-  nonisolated var identifier: String {
+  package nonisolated var identifier: String {
     address
   }
 
-  nonisolated var description: String {
+  package nonisolated var description: String {
     "\(type(of: self))(address: \(address))"
   }
 
@@ -110,7 +110,7 @@ actor Ocp1FlyingSocksStreamController: Ocp1ControllerInternal, CustomStringConve
 }
 
 extension Ocp1FlyingSocksStreamController: Equatable {
-  nonisolated static func == (
+  package nonisolated static func == (
     lhs: Ocp1FlyingSocksStreamController,
     rhs: Ocp1FlyingSocksStreamController
   ) -> Bool {
@@ -119,7 +119,7 @@ extension Ocp1FlyingSocksStreamController: Equatable {
 }
 
 extension Ocp1FlyingSocksStreamController: Hashable {
-  nonisolated func hash(into hasher: inout Hasher) {
+  package nonisolated func hash(into hasher: inout Hasher) {
     fileDescriptor.hash(into: &hasher)
   }
 }

--- a/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingSocksStreamDeviceEndpoint.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingSocksStreamDeviceEndpoint.swift
@@ -49,7 +49,7 @@ public final class Ocp1FlyingSocksStreamDeviceEndpoint: OcaDeviceEndpointPrivate
   OcaBonjourRegistrableDeviceEndpoint,
   CustomStringConvertible
 {
-  typealias ControllerType = Ocp1FlyingSocksStreamController
+  package typealias ControllerType = Ocp1FlyingSocksStreamController
 
   public var controllers: [OcaController] {
     _controllers
@@ -58,10 +58,10 @@ public final class Ocp1FlyingSocksStreamDeviceEndpoint: OcaDeviceEndpointPrivate
   let pool: AsyncSocketPool
 
   private let address: any SocketAddress
-  let timeout: Duration
-  let device: OcaDevice
-  let logger: Logger
-  nonisolated(unsafe) var enableMessageTracing = false
+  package let timeout: Duration
+  package let device: OcaDevice
+  package let logger: Logger
+  package nonisolated(unsafe) var enableMessageTracing = false
 
   private var _controllers = [Ocp1FlyingSocksStreamController]()
   #if canImport(dnssd)
@@ -249,11 +249,11 @@ public final class Ocp1FlyingSocksStreamDeviceEndpoint: OcaDeviceEndpointPrivate
     address.port
   }
 
-  func add(controller: ControllerType) async {
+  package func add(controller: ControllerType) async {
     _controllers.append(controller)
   }
 
-  func remove(controller: ControllerType) async {
+  package func remove(controller: ControllerType) async {
     _controllers.removeAll(where: { $0 == controller })
   }
 

--- a/Sources/SwiftOCADevice/OCP.1/Backend/IORing/Ocp1IORingController.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/IORing/Ocp1IORingController.swift
@@ -48,7 +48,7 @@ protocol Ocp1IORingControllerPrivate: Ocp1ControllerInternal,
 }
 
 extension Ocp1IORingControllerPrivate {
-  func sendOcp1EncodedData(
+  package func sendOcp1EncodedData(
     _ data: Data,
     to destinationAddress: OcaNetworkAddress
   ) async throws {
@@ -66,8 +66,8 @@ extension Ocp1IORingControllerPrivate {
   }
 }
 
-actor Ocp1IORingStreamController: Ocp1IORingControllerPrivate, CustomStringConvertible {
-  nonisolated var flags: OcaControllerFlags {
+package actor Ocp1IORingStreamController: Ocp1IORingControllerPrivate, CustomStringConvertible {
+  package nonisolated var flags: OcaControllerFlags {
     var flags: OcaControllerFlags = .supportsLocking
     if peerAddress.family == sa_family_t(AF_LOCAL) {
       flags.insert(.isLocal)
@@ -75,17 +75,17 @@ actor Ocp1IORingStreamController: Ocp1IORingControllerPrivate, CustomStringConve
     return flags
   }
 
-  nonisolated let connectionPrefix: String
+  package nonisolated let connectionPrefix: String
 
-  var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()
+  package var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()
   let peerAddress: AnySocketAddress
   var receiveMessageTask: Task<(), Never>?
-  var keepAliveTask: Task<(), Error>?
-  var lastMessageReceivedTime = ContinuousClock.recentPast
-  var lastMessageSentTime = ContinuousClock.recentPast
-  weak var endpoint: Ocp1IORingStreamDeviceEndpoint?
+  package var keepAliveTask: Task<(), Error>?
+  package var lastMessageReceivedTime = ContinuousClock.recentPast
+  package var lastMessageSentTime = ContinuousClock.recentPast
+  package weak var endpoint: Ocp1IORingStreamDeviceEndpoint?
 
-  var messages: AnyAsyncSequence<Ocp1MessageList> {
+  package var messages: AnyAsyncSequence<Ocp1MessageList> {
     _messages.eraseToAnyAsyncSequence()
   }
 
@@ -94,7 +94,7 @@ actor Ocp1IORingStreamController: Ocp1IORingControllerPrivate, CustomStringConve
   private let _socket: Mutex<Socket?>
   let notificationSocket: Socket
 
-  nonisolated var description: String {
+  package nonisolated var description: String {
     let socket = socket
     return "\(type(of: self))(socket: \(socket != nil ? String(describing: socket!) : "<disconnected>"))"
   }
@@ -148,7 +148,7 @@ actor Ocp1IORingStreamController: Ocp1IORingControllerPrivate, CustomStringConve
     }
   }
 
-  func close() async {
+  package func close() async {
     keepAliveTask?.cancel()
     keepAliveTask = nil
 
@@ -171,13 +171,13 @@ actor Ocp1IORingStreamController: Ocp1IORingControllerPrivate, CustomStringConve
     _messagesContinuation.finish()
   }
 
-  var heartbeatTime = Duration.seconds(0) {
+  package var heartbeatTime = Duration.seconds(0) {
     didSet {
       heartbeatTimeDidChange(from: oldValue)
     }
   }
 
-  func sendOcp1EncodedData(_ data: Data) async throws {
+  package func sendOcp1EncodedData(_ data: Data) async throws {
     guard let socket else { throw Errno.badFileDescriptor }
     _ = try await socket.write(
       [UInt8](data),
@@ -190,7 +190,7 @@ actor Ocp1IORingStreamController: Ocp1IORingControllerPrivate, CustomStringConve
     try await notificationSocket.sendMessage(messagePdu)
   }
 
-  nonisolated var identifier: String {
+  package nonisolated var identifier: String {
     (try? peerAddress.presentationAddress) ?? "unknown"
   }
 }
@@ -223,20 +223,20 @@ private extension Ocp1NetworkAddress {
   }
 }
 
-actor Ocp1IORingDatagramController: Ocp1IORingControllerPrivate, Ocp1ControllerDatagramSemantics {
-  nonisolated var flags: OcaControllerFlags { .supportsLocking }
-  nonisolated var connectionPrefix: String { OcaUdpConnectionPrefix }
+package actor Ocp1IORingDatagramController: Ocp1IORingControllerPrivate, Ocp1ControllerDatagramSemantics {
+  package nonisolated var flags: OcaControllerFlags { .supportsLocking }
+  package nonisolated var connectionPrefix: String { OcaUdpConnectionPrefix }
 
-  var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()
+  package var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()
   let peerAddress: AnySocketAddress
-  var keepAliveTask: Task<(), Error>?
-  var lastMessageReceivedTime = ContinuousClock.recentPast
-  var lastMessageSentTime = ContinuousClock.recentPast
+  package var keepAliveTask: Task<(), Error>?
+  package var lastMessageReceivedTime = ContinuousClock.recentPast
+  package var lastMessageSentTime = ContinuousClock.recentPast
 
-  private(set) var isOpen: Bool = false
-  weak var endpoint: Ocp1IORingDatagramDeviceEndpoint?
+  package private(set) var isOpen: Bool = false
+  package weak var endpoint: Ocp1IORingDatagramDeviceEndpoint?
 
-  var messages: AnyAsyncSequence<Ocp1MessageList> {
+  package var messages: AnyAsyncSequence<Ocp1MessageList> {
     AsyncEmptySequence<Ocp1MessageList>().eraseToAnyAsyncSequence()
   }
 
@@ -248,13 +248,13 @@ actor Ocp1IORingDatagramController: Ocp1IORingControllerPrivate, Ocp1ControllerD
     self.peerAddress = peerAddress
   }
 
-  var heartbeatTime = Duration.seconds(1) {
+  package var heartbeatTime = Duration.seconds(1) {
     didSet {
       heartbeatTimeDidChange(from: oldValue)
     }
   }
 
-  func sendOcp1EncodedData(_ data: Data) async throws {
+  package func sendOcp1EncodedData(_ data: Data) async throws {
     try await sendOcp1EncodedMessage(Message(address: peerAddress, buffer: [UInt8](data)))
   }
 
@@ -262,25 +262,25 @@ actor Ocp1IORingDatagramController: Ocp1IORingControllerPrivate, Ocp1ControllerD
     try await endpoint?.sendOcp1EncodedMessage(messagePdu)
   }
 
-  nonisolated var identifier: String {
+  package nonisolated var identifier: String {
     (try? peerAddress.presentationAddress) ?? "unknown"
   }
 
-  func close() async throws {}
+  package func close() async throws {}
 
-  func didOpen() {
+  package func didOpen() {
     isOpen = true
   }
 }
 
 extension Ocp1IORingControllerPrivate {
-  nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
+  package nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
     lhs.peerAddress == rhs.peerAddress
   }
 }
 
 extension Ocp1IORingControllerPrivate {
-  nonisolated func hash(into hasher: inout Hasher) {
+  package nonisolated func hash(into hasher: inout Hasher) {
     peerAddress.hash(into: &hasher)
   }
 }

--- a/Sources/SwiftOCADevice/OCP.1/Backend/IORing/Ocp1IORingDeviceEndpoint.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/IORing/Ocp1IORingDeviceEndpoint.swift
@@ -28,7 +28,7 @@ import Glibc
 
 #if swift(>=6.0)
 public import IORing
-internal import IORingUtils
+package import IORingUtils
 #else
 public import IORing
 @_implementationOnly import IORingUtils
@@ -41,22 +41,22 @@ import SwiftOCA
 import struct SystemPackage.Errno
 
 @OcaDevice
-public class Ocp1IORingDeviceEndpoint: OcaBonjourRegistrableDeviceEndpoint,
+open class Ocp1IORingDeviceEndpoint: OcaBonjourRegistrableDeviceEndpoint,
   CustomStringConvertible
 {
-  let address: any SocketAddress
-  let timeout: Duration
-  let device: OcaDevice
-  let logger: Logger
-  let ring: IORing
-  nonisolated(unsafe) var enableMessageTracing = false
+  package nonisolated let address: any SocketAddress
+  package nonisolated let timeout: Duration
+  package nonisolated let device: OcaDevice
+  package nonisolated let logger: Logger
+  package nonisolated let ring: IORing
+  package nonisolated(unsafe) var enableMessageTracing = false
 
-  var socket: Socket?
+  package var socket: Socket?
   #if canImport(dnssd)
   private var _endpointRegistrarTask: Task<(), Error>?
   #endif
 
-  public var controllers: [OcaController] {
+  open var controllers: [OcaController] {
     []
   }
 
@@ -75,7 +75,7 @@ public class Ocp1IORingDeviceEndpoint: OcaBonjourRegistrableDeviceEndpoint,
     try await device.add(endpoint: self)
   }
 
-  public nonisolated var description: String {
+  open nonisolated var description: String {
     "\(type(of: self))(address: \((try? address.presentationAddress) ?? "<unknown>"), timeout: \(timeout))"
   }
 
@@ -103,7 +103,7 @@ public class Ocp1IORingDeviceEndpoint: OcaBonjourRegistrableDeviceEndpoint,
   }
 
   #if canImport(dnssd)
-  public nonisolated var serviceType: OcaNetworkAdvertisingServiceType {
+  open nonisolated var serviceType: OcaNetworkAdvertisingServiceType {
     .none
   }
   #endif
@@ -112,7 +112,7 @@ public class Ocp1IORingDeviceEndpoint: OcaBonjourRegistrableDeviceEndpoint,
     (try? address.port) ?? 0
   }
 
-  public func run() async throws {
+  open func run() async throws {
     if port != 0 {
       #if canImport(dnssd)
       _endpointRegistrarTask = makeBonjourRegistrarTask(for: device)
@@ -146,7 +146,7 @@ public class Ocp1IORingDeviceEndpoint: OcaBonjourRegistrableDeviceEndpoint,
 public final class Ocp1IORingStreamDeviceEndpoint: Ocp1IORingDeviceEndpoint,
   OcaDeviceEndpointPrivate
 {
-  typealias ControllerType = Ocp1IORingStreamController
+  package typealias ControllerType = Ocp1IORingStreamController
 
   var notificationSocket: Socket?
 
@@ -239,11 +239,11 @@ public final class Ocp1IORingStreamDeviceEndpoint: Ocp1IORingDeviceEndpoint,
   }
   #endif
 
-  func add(controller: ControllerType) async {
+  package func add(controller: ControllerType) async {
     _controllers.append(controller)
   }
 
-  func remove(controller: ControllerType) async {
+  package func remove(controller: ControllerType) async {
     _controllers.removeAll(where: { $0 == controller })
   }
 }
@@ -252,7 +252,7 @@ public final class Ocp1IORingStreamDeviceEndpoint: Ocp1IORingDeviceEndpoint,
 public class Ocp1IORingDatagramDeviceEndpoint: Ocp1IORingDeviceEndpoint,
   OcaDeviceEndpointPrivate
 {
-  typealias ControllerType = Ocp1IORingDatagramController
+  package typealias ControllerType = Ocp1IORingDatagramController
 
   private let _bufferCount: Int?
   var _controllers = [AnySocketAddress: ControllerType]()
@@ -407,9 +407,9 @@ public class Ocp1IORingDatagramDeviceEndpoint: Ocp1IORingDeviceEndpoint,
     .udp
   }
 
-  func add(controller: ControllerType) async {}
+  package func add(controller: ControllerType) async {}
 
-  func remove(controller: ControllerType) async {
+  package func remove(controller: ControllerType) async {
     _controllers[controller.peerAddress] = nil
   }
 }

--- a/Sources/SwiftOCADevice/OCP.1/Backend/Local/LocalController.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/Local/LocalController.swift
@@ -22,37 +22,37 @@ import Foundation
 #endif
 import SwiftOCA
 
-actor OcaLocalController: Ocp1ControllerInternal {
-  nonisolated var flags: OcaControllerFlags { [.supportsLocking, .isLocal] }
-  nonisolated var connectionPrefix: String { OcaLocalConnectionPrefix }
+package actor OcaLocalController: Ocp1ControllerInternal {
+  package nonisolated var flags: OcaControllerFlags { [.supportsLocking, .isLocal] }
+  package nonisolated var connectionPrefix: String { OcaLocalConnectionPrefix }
 
-  var lastMessageReceivedTime = ContinuousClock.recentPast
-  var lastMessageSentTime = ContinuousClock.recentPast
-  var heartbeatTime = Duration.seconds(0)
-  var keepAliveTask: Task<(), Error>?
+  package var lastMessageReceivedTime = ContinuousClock.recentPast
+  package var lastMessageSentTime = ContinuousClock.recentPast
+  package var heartbeatTime = Duration.seconds(0)
+  package var keepAliveTask: Task<(), Error>?
 
-  weak var endpoint: OcaLocalDeviceEndpoint?
-  var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()
+  package weak var endpoint: OcaLocalDeviceEndpoint?
+  package var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()
 
   init(endpoint: OcaLocalDeviceEndpoint) async {
     self.endpoint = endpoint
   }
 
-  var messages: AnyAsyncSequence<Ocp1MessageList> {
+  package var messages: AnyAsyncSequence<Ocp1MessageList> {
     endpoint!.requestChannel.map { data in
       try Ocp1MessageList(messagePduData: data)
     }.eraseToAnyAsyncSequence()
   }
 
-  func sendOcp1EncodedData(_ data: Data) async throws {
+  package func sendOcp1EncodedData(_ data: Data) async throws {
     await endpoint?.responseChannel.send(data)
   }
 
-  nonisolated var identifier: String {
+  package nonisolated var identifier: String {
     "local"
   }
 
-  func close() throws {}
+  package func close() throws {}
 
   deinit {
     keepAliveTask?.cancel()

--- a/Sources/SwiftOCADevice/OCP.1/Backend/Local/LocalDeviceEndpoint.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/Local/LocalDeviceEndpoint.swift
@@ -26,12 +26,12 @@ import SwiftOCA
 
 @OcaDevice
 public final class OcaLocalDeviceEndpoint: OcaDeviceEndpointPrivate {
-  typealias ControllerType = OcaLocalController
+  package typealias ControllerType = OcaLocalController
 
-  let timeout: Duration = .zero
-  let device: OcaDevice
-  let logger: Logger
-  nonisolated(unsafe) var enableMessageTracing = false
+  package let timeout: Duration = .zero
+  package let device: OcaDevice
+  package let logger: Logger
+  package nonisolated(unsafe) var enableMessageTracing = false
 
   public var controllers: [OcaController] {
     [controller]
@@ -44,9 +44,9 @@ public final class OcaLocalDeviceEndpoint: OcaDeviceEndpointPrivate {
 
   private var controller: OcaLocalController!
 
-  func add(controller: ControllerType) async {}
+  package func add(controller: ControllerType) async {}
 
-  func remove(controller: ControllerType) async {}
+  package func remove(controller: ControllerType) async {}
 
   public init(
     device: OcaDevice = OcaDevice.shared,

--- a/Sources/SwiftOCADevice/OCP.1/Backend/MachPort/Ocp1MachPortController.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/MachPort/Ocp1MachPortController.swift
@@ -22,22 +22,22 @@ import Foundation
 @_spi(SwiftOCAPrivate)
 import SwiftOCA
 
-actor Ocp1MachPortController: Ocp1ControllerInternal {
-  nonisolated var flags: OcaControllerFlags { [.supportsLocking, .isLocal] }
-  nonisolated var connectionPrefix: String { OcaMachPortConnectionPrefix }
+package actor Ocp1MachPortController: Ocp1ControllerInternal {
+  package nonisolated var flags: OcaControllerFlags { [.supportsLocking, .isLocal] }
+  package nonisolated var connectionPrefix: String { OcaMachPortConnectionPrefix }
 
-  var lastMessageReceivedTime = ContinuousClock.recentPast
-  var lastMessageSentTime = ContinuousClock.recentPast
-  var heartbeatTime = Duration.seconds(0) {
+  package var lastMessageReceivedTime = ContinuousClock.recentPast
+  package var lastMessageSentTime = ContinuousClock.recentPast
+  package var heartbeatTime = Duration.seconds(0) {
     didSet {
       heartbeatTimeDidChange(from: oldValue)
     }
   }
 
-  var keepAliveTask: Task<(), Error>?
+  package var keepAliveTask: Task<(), Error>?
 
-  weak var endpoint: Ocp1MachPortDeviceEndpoint?
-  var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()
+  package weak var endpoint: Ocp1MachPortDeviceEndpoint?
+  package var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()
 
   /// our dedicated receive port for this controller session
   private let receiveHandle: Ocp1MachPortHandle
@@ -45,7 +45,7 @@ actor Ocp1MachPortController: Ocp1ControllerInternal {
   private let clientSendPort: mach_port_t
   private let _messages: AsyncThrowingStream<Ocp1MessageList, Error>
 
-  nonisolated let identifier: String
+  package nonisolated let identifier: String
 
   init(
     endpoint: Ocp1MachPortDeviceEndpoint,
@@ -85,15 +85,15 @@ actor Ocp1MachPortController: Ocp1ControllerInternal {
     }
   }
 
-  var messages: AnyAsyncSequence<Ocp1MessageList> {
+  package var messages: AnyAsyncSequence<Ocp1MessageList> {
     _messages.eraseToAnyAsyncSequence()
   }
 
-  func sendOcp1EncodedData(_ data: Data) async throws {
+  package func sendOcp1EncodedData(_ data: Data) async throws {
     try receiveHandle.sendData(data, to: clientSendPort)
   }
 
-  func close() throws {
+  package func close() throws {
     try? receiveHandle.sendDisconnect(to: clientSendPort)
     Ocp1MachPortHandle.deallocateSendRight(clientSendPort)
     receiveHandle.destroy()
@@ -101,7 +101,7 @@ actor Ocp1MachPortController: Ocp1ControllerInternal {
 }
 
 extension Ocp1MachPortController: Equatable {
-  nonisolated static func == (
+  package nonisolated static func == (
     lhs: Ocp1MachPortController,
     rhs: Ocp1MachPortController
   ) -> Bool {
@@ -110,7 +110,7 @@ extension Ocp1MachPortController: Equatable {
 }
 
 extension Ocp1MachPortController: Hashable {
-  nonisolated func hash(into hasher: inout Hasher) {
+  package nonisolated func hash(into hasher: inout Hasher) {
     hasher.combine(receiveHandle.port)
   }
 }

--- a/Sources/SwiftOCADevice/OCP.1/Backend/MachPort/Ocp1MachPortDeviceEndpoint.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/MachPort/Ocp1MachPortDeviceEndpoint.swift
@@ -30,12 +30,12 @@ import SwiftOCA
 /// for bidirectional OCP.1 PDU exchange.
 @OcaDevice
 public final class Ocp1MachPortDeviceEndpoint: OcaDeviceEndpointPrivate, CustomStringConvertible {
-  typealias ControllerType = Ocp1MachPortController
+  package typealias ControllerType = Ocp1MachPortController
 
-  let timeout: Duration
-  let device: OcaDevice
-  let logger: Logger
-  nonisolated(unsafe) var enableMessageTracing = false
+  package let timeout: Duration
+  package let device: OcaDevice
+  package let logger: Logger
+  package nonisolated(unsafe) var enableMessageTracing = false
 
   public var controllers: [OcaController] {
     _controllers
@@ -165,11 +165,11 @@ public final class Ocp1MachPortDeviceEndpoint: OcaDeviceEndpointPrivate, CustomS
     }
   }
 
-  func add(controller: ControllerType) async {
+  package func add(controller: ControllerType) async {
     _controllers.append(controller)
   }
 
-  func remove(controller: ControllerType) async {
+  package func remove(controller: ControllerType) async {
     _controllers.removeAll(where: { $0 == controller })
   }
 }

--- a/Sources/SwiftOCADevice/OCP.1/Backend/Network/Ocp1NWDatagramController.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/Network/Ocp1NWDatagramController.swift
@@ -1,0 +1,173 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(Network)
+
+import AsyncExtensions
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+import Network
+@_spi(SwiftOCAPrivate)
+import SwiftOCA
+import Synchronization
+
+/// Per-peer remote controller for Network.framework's UDP (plain or DTLS)
+/// path. NWListener demuxes datagrams to per-peer NWConnections for us;
+/// each `receiveMessage` yields one whole datagram for decode.
+package actor Ocp1NWDatagramController: Ocp1ControllerInternal,
+  Ocp1ControllerDatagramSemantics,
+  CustomStringConvertible
+{
+  package nonisolated let flags: OcaControllerFlags
+  package nonisolated let connectionPrefix: String
+  package nonisolated let identifier: String
+  /// Filled by the secure UDP endpoint after the DTLS handshake; left
+  /// `.anonymous` on plaintext UDP.
+  private let _peerIdentity = Mutex<OcaPeerIdentity>(.anonymous)
+  package nonisolated var peerIdentity: OcaPeerIdentity {
+    _peerIdentity.withLock { $0 }
+  }
+  package nonisolated func setPeerIdentity(_ identity: OcaPeerIdentity) {
+    _peerIdentity.withLock { $0 = identity }
+  }
+
+  package var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()
+  package var keepAliveTask: Task<(), Error>?
+  package var lastMessageReceivedTime = ContinuousClock.recentPast
+  package var lastMessageSentTime = ContinuousClock.recentPast
+  package weak var endpoint: Ocp1NWDatagramDeviceEndpoint?
+
+  private let connection: NWConnection
+  private let _messages: AsyncThrowingStream<Ocp1MessageList, Error>
+  private var connectionClosed = false
+  package private(set) var isOpen: Bool = false
+
+  package var messages: AnyAsyncSequence<Ocp1MessageList> {
+    _messages.eraseToAnyAsyncSequence()
+  }
+
+  package var heartbeatTime = Duration.seconds(1) {
+    didSet {
+      heartbeatTimeDidChange(from: oldValue)
+    }
+  }
+
+  init(endpoint: Ocp1NWDatagramDeviceEndpoint, connection: NWConnection) {
+    self.endpoint = endpoint
+    self.connection = connection
+    flags = endpoint.controllerFlags
+    connectionPrefix = endpoint.controllerConnectionPrefix
+    identifier = Self.makeIdentifier(from: connection)
+    _messages = Self.makeMessagesStream(on: connection)
+  }
+
+  package func sendOcp1EncodedData(_ data: Data) async throws {
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+      connection.send(
+        content: data,
+        completion: .contentProcessed { error in
+          if let error {
+            continuation.resume(throwing: error)
+          } else {
+            continuation.resume()
+          }
+        }
+      )
+    }
+  }
+
+  package func close() async throws {
+    guard !connectionClosed else { return }
+    connection.cancel()
+    connectionClosed = true
+    keepAliveTask?.cancel()
+    keepAliveTask = nil
+  }
+
+  package func didOpen() {
+    isOpen = true
+  }
+
+  deinit {
+    keepAliveTask?.cancel()
+  }
+
+  package nonisolated var description: String {
+    "\(type(of: self))(\(identifier))"
+  }
+}
+
+extension Ocp1NWDatagramController: Equatable {
+  package nonisolated static func == (
+    lhs: Ocp1NWDatagramController,
+    rhs: Ocp1NWDatagramController
+  ) -> Bool {
+    ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
+  }
+}
+
+extension Ocp1NWDatagramController: Hashable {
+  package nonisolated func hash(into hasher: inout Hasher) {
+    ObjectIdentifier(self).hash(into: &hasher)
+  }
+}
+
+private extension Ocp1NWDatagramController {
+  static func makeIdentifier(from connection: NWConnection) -> String {
+    switch connection.endpoint {
+    case let .hostPort(host, port):
+      "\(host):\(port.rawValue)"
+    default:
+      String(describing: connection.endpoint)
+    }
+  }
+
+  /// One whole datagram per element; one datagram may carry multiple
+  /// concatenated OCP.1 PDUs.
+  static func makeMessagesStream(
+    on connection: NWConnection
+  ) -> AsyncThrowingStream<Ocp1MessageList, Error> {
+    AsyncThrowingStream { () async throws -> Ocp1MessageList? in
+      let datagram = try await connection.receiveOneDatagram()
+      return try Ocp1MessageList(messagePduData: datagram)
+    }
+  }
+}
+
+private extension NWConnection {
+  /// Maps graceful peer shutdown (`isComplete && data == nil`) to
+  /// `.notConnected` so the stream terminates cleanly.
+  func receiveOneDatagram() async throws -> Data {
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Data, Error>) in
+      receiveMessage { data, _, isComplete, error in
+        if let error {
+          continuation.resume(throwing: error)
+        } else if isComplete, data == nil {
+          continuation.resume(throwing: Ocp1Error.notConnected)
+        } else if let data, !data.isEmpty {
+          continuation.resume(returning: data)
+        } else {
+          continuation.resume(throwing: Ocp1Error.notConnected)
+        }
+      }
+    }
+  }
+}
+
+#endif

--- a/Sources/SwiftOCADevice/OCP.1/Backend/Network/Ocp1NWDatagramDeviceEndpoint.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/Network/Ocp1NWDatagramDeviceEndpoint.swift
@@ -1,0 +1,257 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(Network)
+
+import AsyncExtensions
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+import Logging
+import Network
+@_spi(SwiftOCAPrivate)
+import SwiftOCA
+import Synchronization
+
+/// Base class for OCP.1 datagram device endpoints on Network.framework.
+/// NWListener demuxes inbound UDP datagrams to per-peer NWConnections;
+/// concrete subclasses supply the NWParameters (plain UDP, or DTLS via
+/// `NWProtocolTLS.Options`) and controller metadata.
+@OcaDevice
+open class Ocp1NWDatagramDeviceEndpoint: OcaDeviceEndpointPrivate,
+  OcaBonjourRegistrableDeviceEndpoint,
+  CustomStringConvertible
+{
+  package typealias ControllerType = Ocp1NWDatagramController
+
+  open var controllers: [OcaController] { _controllers }
+
+  package let timeout: Duration
+  package let device: OcaDevice
+  package nonisolated let logger: Logger
+  package nonisolated(unsafe) var enableMessageTracing = false
+
+  private let _port: NWEndpoint.Port
+  private let _boundPort = Mutex<UInt16>(0)
+  private var listener: NWListener?
+  private let queue: DispatchQueue
+  private var _controllers: [Ocp1NWDatagramController] = []
+  private var _boundWaiters: [CheckedContinuation<UInt16, Error>] = []
+  #if canImport(dnssd)
+  private var _endpointRegistrarTask: Task<(), Error>?
+  #endif
+
+  // MARK: - Subclass hooks
+
+  /// NWParameters for the listener; DTLS subclasses supply non-nil TLS
+  /// options. Async so subclasses can await device state when building.
+  open func makeParameters() async -> NWParameters {
+    fatalError("makeParameters() must be implemented by a concrete subclass")
+  }
+
+  open nonisolated var controllerConnectionPrefix: String {
+    fatalError("controllerConnectionPrefix must be implemented by a concrete subclass")
+  }
+
+  open nonisolated var controllerFlags: OcaControllerFlags {
+    .supportsLocking
+  }
+
+  open nonisolated var serviceType: OcaNetworkAdvertisingServiceType {
+    fatalError("serviceType must be implemented by a concrete subclass")
+  }
+
+  // MARK: - Lifecycle
+
+  public init(
+    port: UInt16,
+    timeout: Duration = OcaDevice.DefaultTimeout,
+    device: OcaDevice = OcaDevice.shared,
+    logger: Logger = Logger(label: "com.padl.SwiftOCADevice.Ocp1NWDatagramDeviceEndpoint")
+  ) async throws {
+    guard let nwPort = NWEndpoint.Port(rawValue: port) else {
+      throw Ocp1Error.status(.parameterError)
+    }
+    _port = nwPort
+    self.timeout = timeout
+    self.device = device
+    self.logger = logger
+    queue = DispatchQueue(label: "com.padl.SwiftOCADevice.NWListener.udp.\(port)")
+    try await device.add(endpoint: self)
+  }
+
+  public nonisolated var description: String {
+    "\(type(of: self))(port: \(_port.rawValue), timeout: \(timeout))"
+  }
+
+  public nonisolated var port: UInt16 {
+    let bound = _boundPort.withLock { $0 }
+    return bound != 0 ? bound : _port.rawValue
+  }
+
+  /// Suspends until the listener has bound and returns the OS-assigned port
+  /// (useful when the endpoint was constructed with `port: 0`).
+  public func awaitBoundPort() async throws -> UInt16 {
+    let snapshot = _boundPort.withLock { $0 }
+    if snapshot != 0 { return snapshot }
+    return try await withCheckedThrowingContinuation { continuation in
+      _boundWaiters.append(continuation)
+    }
+  }
+
+  private func _resolveBoundPort(_ result: Result<UInt16, Error>) {
+    if case let .success(port) = result {
+      _boundPort.withLock { $0 = port }
+      #if canImport(dnssd)
+      if _endpointRegistrarTask == nil {
+        _endpointRegistrarTask = makeBonjourRegistrarTask(for: device)
+      }
+      #endif
+    }
+    let waiters = _boundWaiters
+    _boundWaiters.removeAll()
+    for continuation in waiters {
+      continuation.resume(with: result)
+    }
+  }
+
+  open func run() async throws {
+    let listener = try await NWListener(using: makeParameters(), on: _port)
+    self.listener = listener
+    let connections = AsyncStream<NWConnection>.makeStream()
+    let listenerState = AsyncStream<NWListener.State>.makeStream()
+
+    listener.stateUpdateHandler = { state in
+      listenerState.continuation.yield(state)
+    }
+    listener.newConnectionHandler = { connection in
+      connections.continuation.yield(connection)
+    }
+    listener.start(queue: queue)
+    logger.info("starting \(type(of: self)) on port \(_port.rawValue)")
+
+    // Bonjour registration is wired up in `_resolveBoundPort` once the
+    // OS-assigned port is known — DNS-SD silently rejects port 0.
+
+    do {
+      try await withThrowingTaskGroup(of: Void.self) { group in
+        group.addTask { [weak self, logger] in
+          for await state in listenerState.stream {
+            switch state {
+            case .ready:
+              if let port = listener.port {
+                await self?._resolveBoundPort(.success(port.rawValue))
+              }
+            case let .failed(error):
+              logger.critical("listener failed: \(error)")
+              await self?._resolveBoundPort(.failure(error))
+              throw error
+            case .cancelled:
+              return
+            default:
+              break
+            }
+          }
+        }
+        group.addTask { [weak self] in
+          guard let self else { return }
+          await self.acceptLoop(connections: connections.stream)
+        }
+        try await group.next()
+        group.cancelAll()
+      }
+    } catch {
+      logger.critical("server error: \(error)")
+      listener.cancel()
+      throw error
+    }
+
+    listener.cancel()
+    self.listener = nil
+    try? await device.remove(endpoint: self)
+  }
+
+  private func acceptLoop(connections: AsyncStream<NWConnection>) async {
+    await withDiscardingTaskGroup { group in
+      for await connection in connections {
+        group.addTask { [weak self] in
+          guard let self else { return }
+          await self.run(connection: connection)
+        }
+      }
+    }
+  }
+
+  private func run(connection: NWConnection) async {
+    let connectionLogger = logger
+    let controller = Ocp1NWDatagramController(endpoint: self, connection: connection)
+    let endpointRef = self
+    connection.stateUpdateHandler = { state in
+      switch state {
+      case .ready:
+        if let identity = endpointRef.peerIdentity(for: connection) {
+          controller.setPeerIdentity(identity)
+        }
+      case let .failed(error):
+        connectionLogger.warning("connection \(connection.endpoint) failed: \(error)")
+      default:
+        break
+      }
+    }
+    connection.start(queue: queue)
+    await controller.handle(for: self)
+  }
+
+  /// See `Ocp1NWStreamDeviceEndpoint.peerIdentity(for:)`.
+  open nonisolated func peerIdentity(for connection: NWConnection) -> OcaPeerIdentity? {
+    nil
+  }
+
+  package func add(controller: Ocp1NWDatagramController) async {
+    _controllers.append(controller)
+  }
+
+  package func remove(controller: Ocp1NWDatagramController) async {
+    _controllers.removeAll(where: { $0 === controller })
+  }
+
+  deinit {
+    #if canImport(dnssd)
+    _endpointRegistrarTask?.cancel()
+    #endif
+    listener?.cancel()
+  }
+}
+
+/// Plaintext OCP.1 UDP device endpoint via Network.framework.
+@OcaDevice
+public final class Ocp1NWUDPDeviceEndpoint: Ocp1NWDatagramDeviceEndpoint {
+  override public func makeParameters() async -> NWParameters {
+    NWParameters(dtls: nil, udp: NWProtocolUDP.Options())
+  }
+
+  override public nonisolated var controllerConnectionPrefix: String {
+    OcaUdpConnectionPrefix
+  }
+
+  override public nonisolated var serviceType: OcaNetworkAdvertisingServiceType {
+    .udp
+  }
+}
+
+#endif

--- a/Sources/SwiftOCADevice/OCP.1/Backend/Network/Ocp1NWStreamController.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/Network/Ocp1NWStreamController.swift
@@ -1,0 +1,166 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(Network)
+
+import AsyncAlgorithms
+import AsyncExtensions
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+import Network
+@_spi(SwiftOCAPrivate)
+import SwiftOCA
+import Synchronization
+
+/// Remote controller via Network.framework; shared by plaintext TCP and TLS.
+package actor Ocp1NWStreamController: Ocp1ControllerInternal, CustomStringConvertible {
+  package nonisolated let flags: OcaControllerFlags
+  package nonisolated let connectionPrefix: String
+  package nonisolated let identifier: String
+  /// Filled by the secure endpoint on `.ready`; left `.anonymous` on plaintext.
+  private let _peerIdentity = Mutex<OcaPeerIdentity>(.anonymous)
+  package nonisolated var peerIdentity: OcaPeerIdentity {
+    _peerIdentity.withLock { $0 }
+  }
+  package nonisolated func setPeerIdentity(_ identity: OcaPeerIdentity) {
+    _peerIdentity.withLock { $0 = identity }
+  }
+
+  package var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()
+  package var keepAliveTask: Task<(), Error>?
+  package var lastMessageReceivedTime = ContinuousClock.recentPast
+  package var lastMessageSentTime = ContinuousClock.recentPast
+  package weak var endpoint: Ocp1NWStreamDeviceEndpoint?
+
+  private let connection: NWConnection
+  private let _messages: AsyncThrowingStream<Ocp1MessageList, Error>
+  private var connectionClosed = false
+
+  package var messages: AnyAsyncSequence<Ocp1MessageList> {
+    _messages.eraseToAnyAsyncSequence()
+  }
+
+  package var heartbeatTime = Duration.seconds(0) {
+    didSet {
+      heartbeatTimeDidChange(from: oldValue)
+    }
+  }
+
+  init(endpoint: Ocp1NWStreamDeviceEndpoint, connection: NWConnection) {
+    self.endpoint = endpoint
+    self.connection = connection
+    flags = endpoint.controllerFlags
+    connectionPrefix = endpoint.controllerConnectionPrefix
+    identifier = Self.makeIdentifier(from: connection)
+    _messages = Self.makeMessagesStream(on: connection, timeout: endpoint.timeout)
+  }
+
+  package func sendOcp1EncodedData(_ data: Data) async throws {
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+      connection.send(
+        content: data,
+        completion: .contentProcessed { error in
+          if let error {
+            continuation.resume(throwing: error)
+          } else {
+            continuation.resume()
+          }
+        }
+      )
+    }
+  }
+
+  package func close() async throws {
+    guard !connectionClosed else { return }
+    connection.cancel()
+    connectionClosed = true
+    keepAliveTask?.cancel()
+    keepAliveTask = nil
+  }
+
+  deinit {
+    keepAliveTask?.cancel()
+  }
+
+  package nonisolated var description: String {
+    "\(type(of: self))(\(identifier))"
+  }
+}
+
+extension Ocp1NWStreamController: Equatable {
+  package nonisolated static func == (
+    lhs: Ocp1NWStreamController,
+    rhs: Ocp1NWStreamController
+  ) -> Bool {
+    ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
+  }
+}
+
+extension Ocp1NWStreamController: Hashable {
+  package nonisolated func hash(into hasher: inout Hasher) {
+    ObjectIdentifier(self).hash(into: &hasher)
+  }
+}
+
+private extension Ocp1NWStreamController {
+  static func makeIdentifier(from connection: NWConnection) -> String {
+    switch connection.endpoint {
+    case let .hostPort(host, port):
+      "\(host):\(port.rawValue)"
+    case let .unix(path):
+      path
+    default:
+      String(describing: connection.endpoint)
+    }
+  }
+
+  static func makeMessagesStream(
+    on connection: NWConnection,
+    timeout: Duration
+  ) -> AsyncThrowingStream<Ocp1MessageList, Error> {
+    AsyncThrowingStream { () async throws -> Ocp1MessageList? in
+      try await withThrowingTimeout(of: timeout, clock: .continuous) {
+        try await OcaDevice.asyncReceiveMessages { count in
+          try await connection.receiveExactly(count)
+        }
+      }
+    }
+  }
+}
+
+extension NWConnection {
+  /// Maps graceful peer-close to `.notConnected`.
+  fileprivate func receiveExactly(_ count: Int) async throws -> Data {
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Data, Error>) in
+      receive(minimumIncompleteLength: count, maximumLength: count) { data, _, isComplete, error in
+        if let error {
+          continuation.resume(throwing: error)
+        } else if let data, data.count == count {
+          continuation.resume(returning: data)
+        } else if isComplete {
+          continuation.resume(throwing: Ocp1Error.notConnected)
+        } else {
+          continuation.resume(throwing: Ocp1Error.notConnected)
+        }
+      }
+    }
+  }
+}
+
+#endif

--- a/Sources/SwiftOCADevice/OCP.1/Backend/Network/Ocp1NWStreamDeviceEndpoint.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/Network/Ocp1NWStreamDeviceEndpoint.swift
@@ -1,0 +1,269 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(Network)
+
+import AsyncExtensions
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+import Logging
+import Network
+@_spi(SwiftOCAPrivate)
+import SwiftOCA
+import Synchronization
+
+/// Base class for OCP.1 stream device endpoints on Network.framework.
+/// Concrete subclasses supply `NWParameters` (with TLS options when
+/// applicable) and controller-side metadata.
+@OcaDevice
+open class Ocp1NWStreamDeviceEndpoint: OcaDeviceEndpointPrivate,
+  OcaBonjourRegistrableDeviceEndpoint,
+  CustomStringConvertible
+{
+  package typealias ControllerType = Ocp1NWStreamController
+
+  open var controllers: [OcaController] {
+    _controllers
+  }
+
+  package let timeout: Duration
+  package let device: OcaDevice
+  package nonisolated let logger: Logger
+  package nonisolated(unsafe) var enableMessageTracing = false
+
+  private let _port: NWEndpoint.Port
+  private let _boundPort = Mutex<UInt16>(0)
+  private var listener: NWListener?
+  private let queue: DispatchQueue
+  private var _controllers = [Ocp1NWStreamController]()
+  private var _boundWaiters: [CheckedContinuation<UInt16, Error>] = []
+  #if canImport(dnssd)
+  private var _endpointRegistrarTask: Task<(), Error>?
+  #endif
+
+  // MARK: - Subclass hooks
+
+  /// NWParameters for the listener; TLS subclasses supply non-nil TLS
+  /// options. Async so subclasses can await device state when building.
+  open func makeParameters() async -> NWParameters {
+    fatalError("makeParameters() must be implemented by a concrete subclass")
+  }
+
+  open nonisolated var controllerConnectionPrefix: String {
+    fatalError("controllerConnectionPrefix must be implemented by a concrete subclass")
+  }
+
+  open nonisolated var controllerFlags: OcaControllerFlags {
+    .supportsLocking
+  }
+
+  open nonisolated var serviceType: OcaNetworkAdvertisingServiceType {
+    fatalError("serviceType must be implemented by a concrete subclass")
+  }
+
+  /// Shared TCP options factory so plaintext and TLS stay in sync.
+  package func makeTCPOptions() -> NWProtocolTCP.Options {
+    let options = NWProtocolTCP.Options()
+    options.noDelay = true
+    return options
+  }
+
+  // MARK: - Lifecycle
+
+  public init(
+    port: UInt16,
+    timeout: Duration = OcaDevice.DefaultTimeout,
+    device: OcaDevice = OcaDevice.shared,
+    logger: Logger = Logger(label: "com.padl.SwiftOCADevice.Ocp1NWStreamDeviceEndpoint")
+  ) async throws {
+    guard let nwPort = NWEndpoint.Port(rawValue: port) else {
+      throw Ocp1Error.status(.parameterError)
+    }
+    _port = nwPort
+    self.timeout = timeout
+    self.device = device
+    self.logger = logger
+    queue = DispatchQueue(label: "com.padl.SwiftOCADevice.NWListener.\(port)")
+
+    try await device.add(endpoint: self)
+  }
+
+  public nonisolated var description: String {
+    "\(type(of: self))(port: \(_port.rawValue), timeout: \(timeout))"
+  }
+
+  public nonisolated var port: UInt16 {
+    let bound = _boundPort.withLock { $0 }
+    return bound != 0 ? bound : _port.rawValue
+  }
+
+  /// Suspends until the listener has bound and returns the OS-assigned port
+  /// (useful when the endpoint was constructed with `port: 0`).
+  public func awaitBoundPort() async throws -> UInt16 {
+    let snapshot = _boundPort.withLock { $0 }
+    if snapshot != 0 { return snapshot }
+    return try await withCheckedThrowingContinuation { continuation in
+      _boundWaiters.append(continuation)
+    }
+  }
+
+  private func _resolveBoundPort(_ result: Result<UInt16, Error>) {
+    if case let .success(port) = result {
+      _boundPort.withLock { $0 = port }
+      #if canImport(dnssd)
+      // `makeBonjourRegistrarTask` reads `port` synchronously, so we wait
+      // until the listener has resolved one before invoking it.
+      if _endpointRegistrarTask == nil {
+        _endpointRegistrarTask = makeBonjourRegistrarTask(for: device)
+      }
+      #endif
+    }
+    let waiters = _boundWaiters
+    _boundWaiters.removeAll()
+    for continuation in waiters {
+      continuation.resume(with: result)
+    }
+  }
+
+  open func run() async throws {
+    let listener = try await NWListener(using: makeParameters(), on: _port)
+    self.listener = listener
+    let connections = AsyncStream<NWConnection>.makeStream()
+    let listenerState = AsyncStream<NWListener.State>.makeStream()
+
+    listener.stateUpdateHandler = { state in
+      listenerState.continuation.yield(state)
+    }
+    listener.newConnectionHandler = { connection in
+      connections.continuation.yield(connection)
+    }
+    listener.start(queue: queue)
+    logger.info("starting \(type(of: self)) on port \(_port.rawValue)")
+
+    // Bonjour registration is wired up in `_resolveBoundPort` once the
+    // OS-assigned port is known — DNS-SD silently rejects port 0.
+
+    do {
+      try await withThrowingTaskGroup(of: Void.self) { group in
+        group.addTask { [weak self, logger] in
+          for await state in listenerState.stream {
+            switch state {
+            case .ready:
+              if let port = listener.port {
+                await self?._resolveBoundPort(.success(port.rawValue))
+              }
+            case let .failed(error):
+              logger.critical("listener failed: \(error)")
+              await self?._resolveBoundPort(.failure(error))
+              throw error
+            case .cancelled:
+              return
+            default:
+              break
+            }
+          }
+        }
+        group.addTask { [weak self] in
+          guard let self else { return }
+          await self.acceptLoop(connections: connections.stream)
+        }
+        try await group.next()
+        group.cancelAll()
+      }
+    } catch {
+      logger.critical("server error: \(error)")
+      listener.cancel()
+      throw error
+    }
+
+    listener.cancel()
+    self.listener = nil
+    try? await device.remove(endpoint: self)
+  }
+
+  private func acceptLoop(connections: AsyncStream<NWConnection>) async {
+    await withDiscardingTaskGroup { group in
+      for await connection in connections {
+        group.addTask { [weak self] in
+          guard let self else { return }
+          await self.run(connection: connection)
+        }
+      }
+    }
+  }
+
+  private func run(connection: NWConnection) async {
+    let connectionLogger = logger
+    let controller = Ocp1NWStreamController(endpoint: self, connection: connection)
+    let endpointRef = self
+    connection.stateUpdateHandler = { state in
+      switch state {
+      case .ready:
+        if let identity = endpointRef.peerIdentity(for: connection) {
+          controller.setPeerIdentity(identity)
+        }
+      case let .failed(error):
+        connectionLogger.warning("connection \(connection.endpoint) failed: \(error)")
+      default:
+        break
+      }
+    }
+    connection.start(queue: queue)
+    await controller.handle(for: self)
+  }
+
+  /// Override point for secure subclasses to snapshot the peer identity
+  /// on `.ready`. Plaintext base returns `nil`. Runs on the connection's queue.
+  open nonisolated func peerIdentity(for connection: NWConnection) -> OcaPeerIdentity? {
+    nil
+  }
+
+  package func add(controller: Ocp1NWStreamController) async {
+    _controllers.append(controller)
+  }
+
+  package func remove(controller: Ocp1NWStreamController) async {
+    _controllers.removeAll(where: { $0 === controller })
+  }
+
+  deinit {
+    #if canImport(dnssd)
+    _endpointRegistrarTask?.cancel()
+    #endif
+    listener?.cancel()
+  }
+}
+
+/// Plaintext OCP.1 TCP device endpoint via Network.framework.
+@OcaDevice
+public final class Ocp1NWTCPDeviceEndpoint: Ocp1NWStreamDeviceEndpoint {
+  override public func makeParameters() async -> NWParameters {
+    NWParameters(tls: nil, tcp: makeTCPOptions())
+  }
+
+  override public nonisolated var controllerConnectionPrefix: String {
+    OcaTcpConnectionPrefix
+  }
+
+  override public nonisolated var serviceType: OcaNetworkAdvertisingServiceType {
+    .tcp
+  }
+}
+
+#endif

--- a/Sources/SwiftOCADevice/OCP.1/Logger+Ocp1ControllerInternal.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Logger+Ocp1ControllerInternal.swift
@@ -22,37 +22,52 @@ import Foundation
 import Logging
 import SwiftOCA
 
-private extension Ocp1ControllerInternal {
-  nonisolated var loggerMetadata: Logger.Metadata {
+extension Ocp1ControllerInternal {
+  package nonisolated var loggerMetadata: Logger.Metadata {
     ["CONTROLLER": "\(connectionPrefix)/\(identifier)"]
   }
 }
 
+/// Render for trace logs; redact the payload when the target is the
+/// SecurityManager so PSK key material never lands in traces.
+private func _ocp1TraceDescription(_ message: Any) -> String {
+  switch message {
+  case let command as Ocp1Command where command.targetONo == OcaSecurityManagerONo:
+    return
+      "Ocp1Command(handle: \(command.handle), targetONo: \(command.targetONo), methodID: \(command.methodID), parameters: <redacted \(command.parameters.parameterData.count) bytes>)"
+  default:
+    return "\(message)"
+  }
+}
+
 extension OcaDeviceEndpointPrivate {
-  nonisolated func traceMessage(
+  package nonisolated func traceMessage(
     _ message: some Any,
     controller: any Ocp1ControllerInternal,
     direction: OcaMessageDirection
   ) {
     guard enableMessageTracing, logger.logLevel <= .trace else { return }
-    logger.trace("message \(direction): \(message)", metadata: controller.loggerMetadata)
+    logger.trace(
+      "message \(direction): \(_ocp1TraceDescription(message))",
+      metadata: controller.loggerMetadata
+    )
   }
 }
 
 extension Logger {
-  func info(_ message: String, controller: any Ocp1ControllerInternal) {
+  package func info(_ message: String, controller: any Ocp1ControllerInternal) {
     info("\(message)", metadata: controller.loggerMetadata)
   }
 
-  func command(_ command: Ocp1Command, on controller: any Ocp1ControllerInternal) {
-    trace("command \(command)", metadata: controller.loggerMetadata)
+  package func command(_ command: Ocp1Command, on controller: any Ocp1ControllerInternal) {
+    trace("command \(_ocp1TraceDescription(command))", metadata: controller.loggerMetadata)
   }
 
-  func response(_ response: Ocp1Response, on controller: any Ocp1ControllerInternal) {
+  package func response(_ response: Ocp1Response, on controller: any Ocp1ControllerInternal) {
     trace("response \(response)", metadata: controller.loggerMetadata)
   }
 
-  func error(_ error: Error, controller: any Ocp1ControllerInternal) {
+  package func error(_ error: Error, controller: any Ocp1ControllerInternal) {
     warning("error \(error)", metadata: controller.loggerMetadata)
   }
 }

--- a/Sources/SwiftOCADevice/OCP.1/Ocp1ControllerInternal.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Ocp1ControllerInternal.swift
@@ -25,7 +25,7 @@ import Logging
 @_spi(SwiftOCAPrivate)
 import SwiftOCA
 
-struct Ocp1MessageList: Sendable {
+package struct Ocp1MessageList: Sendable {
   let responseRequired: Bool
   let messages: [Ocp1Message]
 
@@ -38,7 +38,7 @@ struct Ocp1MessageList: Sendable {
     self.init(responseRequired: messageType == .ocaCmdRrq, messages: messages)
   }
 
-  init(messagePduData data: Data) throws {
+  package init(messagePduData data: Data) throws {
     var messagePdus = [Data]()
 
     let messageType = try Ocp1Connection.decodeOcp1MessagePdu(from: data, messages: &messagePdus)
@@ -52,7 +52,7 @@ struct Ocp1MessageList: Sendable {
 /// OcaControllerPrivate should eventually be merged into OcaController once we are ready to
 /// support out-of-tree endpoints
 
-protocol Ocp1ControllerInternal: OcaControllerDefaultSubscribing, Actor {
+package protocol Ocp1ControllerInternal: OcaControllerDefaultSubscribing, Actor {
   associatedtype Endpoint: OcaDeviceEndpointPrivate
 
   nonisolated var connectionPrefix: String { get }
@@ -86,7 +86,7 @@ protocol Ocp1ControllerInternal: OcaControllerDefaultSubscribing, Actor {
 /// When using UDP, the Controller sends a Keep-alive message to the Device before sending other
 /// messages. A Device using UDP ignores all messages received from a Controller prior to receipt of
 /// a Keep-alive message from that Controller.
-protocol Ocp1ControllerDatagramSemantics: Actor {
+package protocol Ocp1ControllerDatagramSemantics: Actor {
   var isOpen: Bool { get }
 
   func didOpen()
@@ -144,7 +144,7 @@ extension Ocp1ControllerInternal {
   }
 
   /// handle a list of messages
-  func handle(
+  package func handle(
     for endpoint: some OcaDeviceEndpointPrivate,
     messageList: Ocp1MessageList
   ) async throws {
@@ -171,7 +171,7 @@ extension Ocp1ControllerInternal {
   }
 
   /// handle messages until an error
-  func handle<Endpoint: OcaDeviceEndpointPrivate>(for endpoint: Endpoint) async {
+  package func handle<Endpoint: OcaDeviceEndpointPrivate>(for endpoint: Endpoint) async {
     let controller = self as! Endpoint.ControllerType
 
     endpoint.logger.info("controller added", controller: controller)
@@ -207,14 +207,14 @@ extension Ocp1ControllerInternal {
     )
   }
 
-  func cancelKeepAlive() {
+  package func cancelKeepAlive() {
     keepAliveTask?.cancel()
     keepAliveTask = nil
   }
 
   /// Oca-3 notes that both controller and device send `KeepAlive` messages if they haven't
   /// yet received (or sent) another message during `HeartbeatTime`.
-  func heartbeatTimeDidChange(from oldValue: Duration) {
+  package func heartbeatTimeDidChange(from oldValue: Duration) {
     if heartbeatTime == .zero {
       cancelKeepAlive()
     } else if heartbeatTime != oldValue || keepAliveTask == nil {
@@ -252,7 +252,7 @@ extension Ocp1ControllerInternal {
     }
   }
 
-  func decodeMessages(from messagePduData: Data) throws -> Ocp1MessageList {
+  package func decodeMessages(from messagePduData: Data) throws -> Ocp1MessageList {
     guard messagePduData.count >= Ocp1Connection.MinimumPduSize,
           messagePduData[messagePduData.startIndex] == Ocp1SyncValue
     else {
@@ -266,7 +266,7 @@ extension Ocp1ControllerInternal {
     return try Ocp1MessageList(messagePduData: messagePduData)
   }
 
-  func sendMessages(
+  package func sendMessages(
     _ messages: [Ocp1Message],
     type messageType: OcaMessageType
   ) async throws {
@@ -280,7 +280,7 @@ extension Ocp1ControllerInternal {
 }
 
 extension OcaDevice {
-  typealias ReadCallback = @Sendable (Int) async throws -> Data
+  package typealias ReadCallback = @Sendable (Int) async throws -> Data
 
   static func _receiveMessages(_ read: (Int) async throws -> Data) async throws -> Ocp1MessageList {
     var messagePduData = try await read(Ocp1Connection.MinimumPduSize)
@@ -307,12 +307,12 @@ extension OcaDevice {
     return try Ocp1MessageList(messagePduData: messagePduData)
   }
 
-  static func receiveMessages(_ read: ReadCallback) async throws -> Ocp1MessageList {
+  package static func receiveMessages(_ read: ReadCallback) async throws -> Ocp1MessageList {
     try await _receiveMessages(read)
   }
 }
 
-protocol Ocp1ControllerInternalLightweightNotifyingInternal: OcaControllerLightweightNotifying {
+package protocol Ocp1ControllerInternalLightweightNotifyingInternal: OcaControllerLightweightNotifying {
   func sendOcp1EncodedData(
     _ data: Data,
     to destinationAddress: OcaNetworkAddress
@@ -320,7 +320,7 @@ protocol Ocp1ControllerInternalLightweightNotifyingInternal: OcaControllerLightw
 }
 
 extension Ocp1ControllerInternalLightweightNotifyingInternal {
-  func sendMessage(
+  package func sendMessage(
     _ message: Ocp1Message,
     type messageType: OcaMessageType,
     to destinationAddress: OcaNetworkAddress

--- a/Sources/SwiftOCASecure/OCP.1/Backend/Ocp1NWSecureConnection.swift
+++ b/Sources/SwiftOCASecure/OCP.1/Backend/Ocp1NWSecureConnection.swift
@@ -1,0 +1,663 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(Network)
+
+import CryptoKit
+import Foundation
+import Network
+#if canImport(Security)
+@preconcurrency import Security
+#endif
+import SocketAddress
+@_spi(SwiftOCAPrivate)
+import SwiftOCA
+
+/// OCP.1 TLS-secured TCP connection via Apple's Network.framework. PSK uses
+/// TLS 1.3 external PSK + AEAD; the AES70-mandated TLS_DHE_PSK_WITH_AES_128_
+/// CBC_SHA is appended via raw IANA value (acceptance is best-effort).
+public final class Ocp1NWSecureTCPConnection: Ocp1NWConnection {
+  private let credential: Ocp1TLSCredential
+  /// Pre-loaded at init so a bad CA bundle fails construction rather than
+  /// silently disabling cert verification.
+  private let preloadedAnchors: [SecCertificate]?
+  private let revocation: Ocp1TLSRevocationOptions
+
+  override public var connectionPrefix: String {
+    "\(OcaSecureTcpConnectionPrefix)/\(presentationAddress)"
+  }
+
+  override public var isDatagram: Bool { false }
+
+  override public var hasTransportLayerSecurity: Bool { true }
+
+  override public var parameters: NWParameters {
+    let tls = NWProtocolTLS.Options()
+    let sec = tls.securityProtocolOptions
+    Ocp1TLSCredential.enforceMinimumTLSProtocol(sec)
+    // Pre-validated in init, so apply can't fail here.
+    try? credential.apply(to: sec)
+    // SNI without rewriting the NWEndpoint; the transport destination stays
+    // at `_deviceAddress` for parity with the OpenSSL backend.
+    if let serverHostname {
+      serverHostname.withCString { _ = sec_protocol_options_set_tls_server_name(sec, $0) }
+    }
+    // Gate the permissive verify block to cert credentials: in PSK mode
+    // it would only fire on a cert-downgrade attempt, and we'd rather fail
+    // closed there.
+    if options.flags.contains(.disableCertificateVerification),
+       Self.credentialIsCert(credential)
+    {
+      Self.installPermissiveVerifyBlock(sec)
+    } else if Self.credentialIsCert(credential) {
+      Self.installVerifyBlock(
+        sec,
+        role: .client,
+        anchors: preloadedAnchors,
+        hostname: serverHostname,
+        revocation: revocation
+      )
+    } else {
+      // PSK client: install a fail-closed verify block so a server that
+      // declines PSK and presents a cert cannot silently downgrade us to
+      // cert auth. Mirrors OpenSSL's `_pskClientRejectCertCallback`.
+      Self.installPSKClientRejectCertBlock(sec)
+    }
+    return NWParameters(tls: tls, tcp: makeTCPOptions())
+  }
+
+  /// Verify block that accepts everything. Only used when the caller opts
+  /// into `disableCertificateVerification`.
+  fileprivate nonisolated static func installPermissiveVerifyBlock(_ sec: sec_protocol_options_t) {
+    let queue = DispatchQueue.global(qos: .userInitiated)
+    sec_protocol_options_set_verify_block(sec, { _, _, complete in
+      complete(true)
+    }, queue)
+  }
+
+  /// Runs after chain validation; returning `false` rejects the handshake
+  /// (e.g. for an mTLS allow-list). Called on the verify-block dispatch
+  /// queue — keep work bounded and synchronous.
+  public typealias PeerCertificateValidator = @Sendable (OcaPeerIdentity) -> Bool
+
+  /// `SecPolicyCreateSSL(server:hostname:)` takes a single `Bool` direction.
+  /// Mixing it (e.g. validating client certs with the server policy) lets
+  /// `serverAuth`-only certs satisfy a client-cert check.
+  package enum PeerRole: Sendable {
+    case client
+    case server
+  }
+
+  /// Re-roots trust at `anchors`, pins hostname only in client role,
+  /// runs `peerValidator` against the leaf if supplied.
+  fileprivate nonisolated static func installVerifyBlock(
+    _ sec: sec_protocol_options_t,
+    role: PeerRole,
+    anchors: [SecCertificate]?,
+    hostname: String?,
+    revocation: Ocp1TLSRevocationOptions = .disabled,
+    peerValidator: PeerCertificateValidator? = nil
+  ) {
+    let queue = DispatchQueue.global(qos: .userInitiated)
+    let cfAnchors = anchors.map { $0 as CFArray }
+    let policyHostname = hostname.map { $0 as CFString }
+    let revocationEnabled = revocation.flags.contains(.enabled)
+    sec_protocol_options_set_verify_block(sec, { _, trustRef, complete in
+      let secTrust = sec_trust_copy_ref(trustRef).takeRetainedValue()
+      let sslPolicy: SecPolicy = switch role {
+      case .client: SecPolicyCreateSSL(true, policyHostname)
+      case .server: SecPolicyCreateSSL(false, nil)
+      }
+      // Soft-fail: missing `RequirePositiveResponse` lets unreachable
+      // responders pass the chain.
+      var policies: [SecPolicy] = [sslPolicy]
+      if revocationEnabled {
+        if let rev = SecPolicyCreateRevocation(kSecRevocationUseAnyAvailableMethod) {
+          policies.append(rev)
+        }
+      }
+      SecTrustSetPolicies(secTrust, policies as CFArray)
+      if let cfAnchors {
+        SecTrustSetAnchorCertificates(secTrust, cfAnchors)
+        SecTrustSetAnchorCertificatesOnly(secTrust, true)
+      }
+      var trustError: CFError?
+      let trusted = SecTrustEvaluateWithError(secTrust, &trustError)
+      guard trusted else {
+        complete(false)
+        return
+      }
+      if let peerValidator {
+        let identity = extractPeerCertificateIdentity(from: secTrust)
+        complete(peerValidator(identity))
+        return
+      }
+      complete(true)
+    }, queue)
+  }
+
+  /// Extract a `.certificate(...)` snapshot from the trust's leaf cert.
+  /// Mirrors the `.ready`-time `Ocp1NWExtractPeerIdentity(from:)` path.
+  private nonisolated static func extractPeerCertificateIdentity(
+    from secTrust: SecTrust
+  ) -> OcaPeerIdentity {
+    let chain = SecTrustCopyCertificateChain(secTrust) as? [SecCertificate] ?? []
+    guard let leaf = chain.first else { return .anonymous }
+    let subject = (SecCertificateCopySubjectSummary(leaf) as String?) ?? ""
+    let der = SecCertificateCopyData(leaf) as Data
+    let fp = SHA256.hash(data: der).map { String(format: "%02x", $0) }.joined()
+    if subject.isEmpty, fp.isEmpty { return .anonymous }
+    return .certificate(subject: subject, fingerprint: fp)
+  }
+
+  /// Server-side mTLS verify block: pins the client-auth SSL policy.
+  package nonisolated static func installCustomTrustVerifyBlock(
+    _ sec: sec_protocol_options_t,
+    anchors: [SecCertificate],
+    revocation: Ocp1TLSRevocationOptions = .disabled,
+    peerValidator: PeerCertificateValidator? = nil
+  ) {
+    installVerifyBlock(
+      sec,
+      role: .server,
+      anchors: anchors,
+      hostname: nil,
+      revocation: revocation,
+      peerValidator: peerValidator
+    )
+  }
+
+  /// PSK client fail-closed: any cert at the verify hook means the peer
+  /// tried to downgrade us off PSK. Mirrors OpenSSL's reject callback.
+  fileprivate nonisolated static func installPSKClientRejectCertBlock(
+    _ sec: sec_protocol_options_t
+  ) {
+    let queue = DispatchQueue.global(qos: .userInitiated)
+    sec_protocol_options_set_verify_block(sec, { _, _, complete in
+      complete(false)
+    }, queue)
+  }
+
+  /// Parse a PEM blob into `SecCertificate` values. `nil` only when
+  /// `trustRoots == nil`; supplied-but-unreadable / empty throws — a CA
+  /// path typo must not silently fall back to the system trust store.
+  package nonisolated static func loadAnchorCertificates(
+    from trustRoots: Ocp1TLSTrustRoots?
+  ) throws -> [SecCertificate]? {
+    guard let trustRoots else { return nil }
+    let pemData: Data?
+    switch trustRoots {
+    case let .caFile(path):
+      pemData = try? Data(contentsOf: URL(fileURLWithPath: path))
+    case let .caData(data):
+      pemData = data
+    }
+    guard let raw = pemData, let text = String(data: raw, encoding: .utf8) else {
+      throw Ocp1Error.status(.parameterError)
+    }
+    let begin = "-----BEGIN CERTIFICATE-----"
+    let end = "-----END CERTIFICATE-----"
+    var anchors: [SecCertificate] = []
+    var cursor = text.startIndex
+    while let beginRange = text.range(of: begin, range: cursor..<text.endIndex),
+          let endRange = text.range(of: end, range: beginRange.upperBound..<text.endIndex)
+    {
+      let body = text[beginRange.upperBound..<endRange.lowerBound]
+        .replacingOccurrences(of: "\r", with: "")
+        .replacingOccurrences(of: "\n", with: "")
+        .replacingOccurrences(of: " ", with: "")
+      if let der = Data(base64Encoded: body),
+         let cert = SecCertificateCreateWithData(nil, der as CFData)
+      {
+        anchors.append(cert)
+      }
+      cursor = endRange.upperBound
+    }
+    guard !anchors.isEmpty else {
+      throw Ocp1Error.status(.parameterError)
+    }
+    return anchors
+  }
+
+  /// `true` when the credential is certificate-based (i.e. anything except PSK).
+  package nonisolated static func credentialIsCert(_ credential: Ocp1TLSCredential) -> Bool {
+    switch credential {
+    case .preSharedKey, .preSharedKeyProvider: return false
+    default: return true
+    }
+  }
+
+  /// Used for SNI and as the `SecPolicyCreateSSL` hostname in the verify
+  /// block; the `NWEndpoint` is left at the IP from `deviceAddress`.
+  private let serverHostname: String?
+
+  private let trustRoots: Ocp1TLSTrustRoots?
+
+  private init(
+    deviceAddress: AnySocketAddress,
+    credential: Ocp1TLSCredential,
+    hostname: String?,
+    trustRoots: Ocp1TLSTrustRoots?,
+    revocation: Ocp1TLSRevocationOptions,
+    options: Ocp1ConnectionOptions
+  ) throws {
+    try credential.validate()
+    let verifyPeer = !options.flags.contains(.disableCertificateVerification)
+    if verifyPeer, Self.credentialIsCert(credential), hostname == nil {
+      // Cert + verifyPeer needs a hostname; chain-only would accept any
+      // cert from the configured CA.
+      throw Ocp1Error.status(.parameterError)
+    }
+    try credential.validateAppleLoad()
+    let preloaded = try Self.loadAnchorCertificates(from: trustRoots)
+
+    self.credential = credential
+    serverHostname = hostname
+    self.trustRoots = trustRoots
+    preloadedAnchors = preloaded
+    self.revocation = revocation
+    try super.init(deviceAddress: deviceAddress, options: options)
+  }
+
+  public convenience init(
+    deviceAddress: Data,
+    credential: Ocp1TLSCredential,
+    hostname: String? = nil,
+    trustRoots: Ocp1TLSTrustRoots? = nil,
+    revocation: Ocp1TLSRevocationOptions = .disabled,
+    options: Ocp1ConnectionOptions = Ocp1ConnectionOptions()
+  ) throws {
+    let address = try AnySocketAddress(bytes: Array(deviceAddress))
+    try self.init(
+      deviceAddress: address,
+      credential: credential,
+      hostname: hostname,
+      trustRoots: trustRoots,
+      revocation: revocation,
+      options: options
+    )
+  }
+
+  public convenience init(
+    path: String,
+    credential: Ocp1TLSCredential,
+    options: Ocp1ConnectionOptions = Ocp1ConnectionOptions()
+  ) throws {
+    let address = try AnySocketAddress(
+      family: sa_family_t(AF_LOCAL),
+      presentationAddress: path
+    )
+    try self.init(
+      deviceAddress: address,
+      credential: credential,
+      hostname: nil,
+      trustRoots: nil,
+      revocation: .disabled,
+      options: options
+    )
+  }
+}
+
+/// OCP.1 DTLS-secured UDP connection via Apple's Network.framework. Mirrors
+/// `Ocp1NWSecureTCPConnection`; Network.framework reuses the TLS
+/// `sec_protocol_options_t` configuration for DTLS.
+public final class Ocp1NWSecureUDPConnection: Ocp1NWConnection {
+  private let credential: Ocp1TLSCredential
+  private let serverHostname: String?
+  private let trustRoots: Ocp1TLSTrustRoots?
+  private let preloadedAnchors: [SecCertificate]?
+  private let revocation: Ocp1TLSRevocationOptions
+
+  override public var heartbeatTime: Duration {
+    .seconds(1)
+  }
+
+  override public var connectionPrefix: String {
+    "\(OcaSecureUdpConnectionPrefix)/\(presentationAddress)"
+  }
+
+  override public var isDatagram: Bool { true }
+
+  override public var hasTransportLayerSecurity: Bool { true }
+
+  override public var parameters: NWParameters {
+    // Network.framework spells DTLS as TLS options over UDP — no separate
+    // NWProtocolDTLS class.
+    let tls = NWProtocolTLS.Options()
+    let sec = tls.securityProtocolOptions
+    Ocp1TLSCredential.enforceMinimumTLSProtocol(sec)
+    try? credential.apply(to: sec)
+    if let serverHostname {
+      serverHostname.withCString { _ = sec_protocol_options_set_tls_server_name(sec, $0) }
+    }
+    if options.flags.contains(.disableCertificateVerification),
+       Ocp1NWSecureTCPConnection.credentialIsCert(credential)
+    {
+      Ocp1NWSecureTCPConnection.installPermissiveVerifyBlock(sec)
+    } else if Ocp1NWSecureTCPConnection.credentialIsCert(credential) {
+      Ocp1NWSecureTCPConnection.installVerifyBlock(
+        sec,
+        role: .client,
+        anchors: preloadedAnchors,
+        hostname: serverHostname,
+        revocation: revocation
+      )
+    } else {
+      // PSK DTLS client: see TCP variant. Fail closed on cert downgrade.
+      Ocp1NWSecureTCPConnection.installPSKClientRejectCertBlock(sec)
+    }
+    return NWParameters(dtls: tls, udp: NWProtocolUDP.Options())
+  }
+
+  private init(
+    deviceAddress: AnySocketAddress,
+    credential: Ocp1TLSCredential,
+    hostname: String?,
+    trustRoots: Ocp1TLSTrustRoots?,
+    revocation: Ocp1TLSRevocationOptions,
+    options: Ocp1ConnectionOptions
+  ) throws {
+    try credential.validate()
+    let verifyPeer = !options.flags.contains(.disableCertificateVerification)
+    if verifyPeer, Ocp1NWSecureTCPConnection.credentialIsCert(credential), hostname == nil {
+      throw Ocp1Error.status(.parameterError)
+    }
+    try credential.validateAppleLoad()
+    let preloaded = try Ocp1NWSecureTCPConnection.loadAnchorCertificates(from: trustRoots)
+
+    self.credential = credential
+    serverHostname = hostname
+    self.trustRoots = trustRoots
+    preloadedAnchors = preloaded
+    self.revocation = revocation
+    try super.init(deviceAddress: deviceAddress, options: options)
+  }
+
+  public convenience init(
+    deviceAddress: Data,
+    credential: Ocp1TLSCredential,
+    hostname: String? = nil,
+    trustRoots: Ocp1TLSTrustRoots? = nil,
+    revocation: Ocp1TLSRevocationOptions = .disabled,
+    options: Ocp1ConnectionOptions = Ocp1ConnectionOptions()
+  ) throws {
+    let address = try AnySocketAddress(bytes: Array(deviceAddress))
+    try self.init(
+      deviceAddress: address,
+      credential: credential,
+      hostname: hostname,
+      trustRoots: trustRoots,
+      revocation: revocation,
+      options: options
+    )
+  }
+}
+
+extension Ocp1TLSCredential {
+  /// Install this credential on a `sec_protocol_options_t`. Throws on
+  /// malformed material — use `validateAppleLoad()` at construction time
+  /// to surface import failures before handshake.
+  package func apply(to sec: sec_protocol_options_t) throws {
+    try _loadAndApply(to: sec)
+  }
+
+  /// Exercise the load path without applying. Shares the loader with
+  /// `apply(to:)` so a new credential variant is exercised by both.
+  package func validateAppleLoad() throws {
+    try _loadAndApply(to: nil)
+  }
+
+  /// Parse the credential's cert/PKCS#12/PEM material; install on `sec`
+  /// when non-nil. With `sec == nil` the parse still runs and throws on
+  /// malformed input (what `validateAppleLoad()` needs).
+  private func _loadAndApply(to sec: sec_protocol_options_t?) throws {
+    switch self {
+    case let .preSharedKey(identity, key):
+      if let sec { Self.configurePSK(sec, identity: identity, key: key) }
+    case let .preSharedKeyProvider(identity, provider):
+      if let sec { Self.configurePSK(sec, identity: identity, provider: provider) }
+    #if canImport(Security)
+    case let .identity(secIdentity):
+      if let sec { try Self._configureLocalIdentity(sec, secIdentity: secIdentity) }
+    #endif
+    case let .pkcs12(data, password):
+      #if canImport(Security)
+      let identity = try Self._parsePKCS12(data: data, password: password)
+      if let sec { try Self._configureLocalIdentity(sec, secIdentity: identity) }
+      #else
+      throw Ocp1Error.status(.notImplemented)
+      #endif
+    case let .certificatePEM(certificate, privateKey):
+      #if os(macOS)
+      let (identity, chain) = try Self._parsePEM(
+        certificate: certificate,
+        privateKey: privateKey
+      )
+      if let sec { try Self._applyPEMIdentity(sec, identity: identity, chain: chain) }
+      #else
+      // SecItemImport (PEM aggregate import) is macOS-only; other Apple
+      // platforms must pre-package as PKCS#12.
+      throw Ocp1Error.status(.notImplemented)
+      #endif
+    case let .certificateFile(certPath, keyPath):
+      #if os(macOS)
+      let certData = try Data(contentsOf: URL(fileURLWithPath: certPath))
+      var keyData = try Data(contentsOf: URL(fileURLWithPath: keyPath))
+      // Zero our buffer once Security.framework has the bytes; the OS may
+      // retain its own copy inside the imported identity.
+      defer { keyData.resetBytes(in: 0..<keyData.count) }
+      let (identity, chain) = try Self._parsePEM(certificate: certData, privateKey: keyData)
+      if let sec { try Self._applyPEMIdentity(sec, identity: identity, chain: chain) }
+      #else
+      throw Ocp1Error.status(.notImplemented)
+      #endif
+    }
+  }
+
+  package static func configurePSK(
+    _ sec: sec_protocol_options_t,
+    identity: String,
+    key: Data
+  ) {
+    key.withUnsafeBytes { _configurePSK(sec, identity: identity, keyBytes: $0) }
+  }
+
+  /// Install the PSK for `identity` from `provider` without copying the
+  /// key into our heap. Silently does nothing if the provider has no key.
+  package static func configurePSK(
+    _ sec: sec_protocol_options_t,
+    identity: String,
+    provider: any OcaPreSharedKeyProvider
+  ) {
+    _ = provider.withPreSharedKey(forIdentity: identity) { buf in
+      _configurePSK(sec, identity: identity, keyBytes: UnsafeRawBufferPointer(buf))
+    }
+  }
+
+  private static func _configurePSK(
+    _ sec: sec_protocol_options_t,
+    identity: String,
+    keyBytes: UnsafeRawBufferPointer
+  ) {
+    // Hand Network.framework a `bytesNoCopy` DispatchData over an owned
+    // heap buffer with a zero-on-release deallocator so the PSK bytes
+    // are wiped when NW drops its retained reference, not just freed.
+    let keyBuf = UnsafeMutableRawBufferPointer.allocate(byteCount: keyBytes.count, alignment: 1)
+    if let dst = keyBuf.baseAddress, let src = keyBytes.baseAddress {
+      dst.copyMemory(from: src, byteCount: keyBytes.count)
+    }
+    let keyDispatch = DispatchData(
+      bytesNoCopy: UnsafeRawBufferPointer(keyBuf),
+      deallocator: .custom(nil, {
+        keyBuf.initializeMemory(as: UInt8.self, repeating: 0)
+        keyBuf.deallocate()
+      })
+    )
+    let identityDispatch = Data(identity.utf8).withUnsafeBytes { DispatchData(bytes: $0) }
+    sec_protocol_options_add_pre_shared_key(
+      sec,
+      keyDispatch as __DispatchData,
+      identityDispatch as __DispatchData
+    )
+    // AES70 mandates TLS_DHE_PSK_WITH_AES_128_CBC_SHA (IANA 0x0090); not
+    // in the public `tls_ciphersuite_t` enum so we attempt it raw, with
+    // the TLS 1.3 AEAD suite as fallback.
+    if let mandated = tls_ciphersuite_t(rawValue: 0x0090) {
+      sec_protocol_options_append_tls_ciphersuite(sec, mandated)
+    }
+    sec_protocol_options_append_tls_ciphersuite(sec, .AES_128_GCM_SHA256)
+  }
+
+  /// Pin every TLS/DTLS handshake to 1.2+ and disable resumption /
+  /// false-start / 0-RTT. Control-plane mTLS re-auths every connection,
+  /// and OCP.1 has no idempotent commands so replayable early data is
+  /// unsafe.
+  package static func enforceMinimumTLSProtocol(_ sec: sec_protocol_options_t) {
+    sec_protocol_options_set_min_tls_protocol_version(sec, .TLSv12)
+    sec_protocol_options_set_tls_resumption_enabled(sec, false)
+    sec_protocol_options_set_tls_false_start_enabled(sec, false)
+    sec_protocol_options_set_tls_tickets_enabled(sec, false)
+  }
+
+  #if canImport(Security)
+  private static func _configureLocalIdentity(
+    _ sec: sec_protocol_options_t,
+    secIdentity: SecIdentity
+  ) throws {
+    guard let identity = sec_identity_create(secIdentity) else {
+      throw Ocp1Error.status(.parameterError)
+    }
+    sec_protocol_options_set_local_identity(sec, identity)
+  }
+
+  private static func _parsePKCS12(data: Data, password: String?) throws -> SecIdentity {
+    var options: [String: Any] = [:]
+    // Copy the password into an owned byte buffer and hand a CFString
+    // built from it to `SecPKCS12Import`. The buffer is wiped on exit;
+    // CF's internal copy lives transiently in CF heap (out of our reach,
+    // but bounded by the call).
+    var pwBuf: UnsafeMutableBufferPointer<UInt8>?
+    defer {
+      if let buf = pwBuf {
+        UnsafeMutableRawBufferPointer(buf).initializeMemory(as: UInt8.self, repeating: 0)
+        buf.deallocate()
+      }
+    }
+    if let password {
+      let utf8 = Array(password.utf8)
+      let buf = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: utf8.count)
+      _ = buf.initialize(from: utf8)
+      pwBuf = buf
+      if let cfstr = CFStringCreateWithBytes(
+        kCFAllocatorDefault,
+        buf.baseAddress,
+        buf.count,
+        CFStringBuiltInEncodings.UTF8.rawValue,
+        false
+      ) {
+        options[kSecImportExportPassphrase as String] = cfstr
+      }
+    }
+    var rawItems: CFArray?
+    let status = SecPKCS12Import(data as CFData, options as CFDictionary, &rawItems)
+    guard status == errSecSuccess else {
+      // Surface the OSStatus — without it, "parameterError" hides the
+      // common causes (wrong/empty passphrase, modern PBE the platform
+      // refuses, malformed bag).
+      throw NSError(
+        domain: NSOSStatusErrorDomain,
+        code: Int(status),
+        userInfo: [NSLocalizedDescriptionKey: "SecPKCS12Import failed: OSStatus \(status)"]
+      )
+    }
+    guard let items = rawItems as? [[String: Any]],
+          let item = items.first,
+          let identityRef = item[kSecImportItemIdentity as String]
+    else {
+      throw Ocp1Error.status(.parameterError)
+    }
+    return identityRef as! SecIdentity
+  }
+  #endif
+
+  #if os(macOS)
+  /// Import PEM cert (+ optional chain) and private key into a `SecIdentity`.
+  /// macOS only — `SecItemImport` is unavailable elsewhere.
+  private static func _parsePEM(
+    certificate: Data,
+    privateKey: Data
+  ) throws -> (SecIdentity, [SecCertificate]) {
+    var combined = certificate
+    if combined.last != UInt8(ascii: "\n") {
+      combined.append(UInt8(ascii: "\n"))
+    }
+    combined.append(privateKey)
+    defer { combined.resetBytes(in: 0..<combined.count) }
+
+    var inputFormat = SecExternalFormat.formatPEMSequence
+    var itemType = SecExternalItemType.itemTypeAggregate
+    var outItems: CFArray?
+
+    let status = SecItemImport(
+      combined as CFData,
+      nil,
+      &inputFormat,
+      &itemType,
+      SecItemImportExportFlags(rawValue: 0),
+      nil,
+      nil,
+      &outItems
+    )
+    guard status == errSecSuccess, let items = outItems as? [AnyObject] else {
+      throw Ocp1Error.status(.parameterError)
+    }
+
+    var identity: SecIdentity?
+    var chain: [SecCertificate] = []
+    for item in items {
+      switch CFGetTypeID(item) {
+      case SecIdentityGetTypeID():
+        identity = (item as! SecIdentity)
+      case SecCertificateGetTypeID():
+        chain.append(item as! SecCertificate)
+      default:
+        break
+      }
+    }
+    guard let identity else {
+      throw Ocp1Error.status(.parameterError)
+    }
+    return (identity, chain)
+  }
+
+  /// Plug a parsed identity (+ optional chain) in as the local identity.
+  private static func _applyPEMIdentity(
+    _ sec: sec_protocol_options_t,
+    identity: SecIdentity,
+    chain: [SecCertificate]
+  ) throws {
+    let secIdentity: sec_identity_t? = chain.isEmpty
+      ? sec_identity_create(identity)
+      : sec_identity_create_with_certificates(identity, chain as CFArray)
+    guard let secIdentity else {
+      throw Ocp1Error.status(.parameterError)
+    }
+    sec_protocol_options_set_local_identity(sec, secIdentity)
+  }
+  #endif
+}
+
+#endif

--- a/Sources/SwiftOCASecure/OCP.1/Backend/Ocp1OpenSSLConnection.swift
+++ b/Sources/SwiftOCASecure/OCP.1/Backend/Ocp1OpenSSLConnection.swift
@@ -1,0 +1,234 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(COpenSSL) && canImport(IORing)
+
+import COpenSSL
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+import Glibc
+public import IORing
+internal import IORingUtils
+import SocketAddress
+@_spi(SwiftOCAPrivate)
+import SwiftOCA
+import Synchronization
+import struct SystemPackage.Errno
+
+fileprivate extension Errno {
+  var mappedError: Error {
+    switch self {
+    case .connectionRefused, .connectionReset, .brokenPipe:
+      Ocp1Error.notConnected
+    case .canceled:
+      Ocp1Error.retryOperation
+    default:
+      self
+    }
+  }
+}
+
+/// OCP.1 TLS-secured TCP connection. The socket is owned on the Swift side;
+/// `Ocp1OpenSSLEngine` only sees the memory BIO pair we pump.
+public final class Ocp1OpenSSLConnection: Ocp1Connection, Ocp1MutableConnection {
+  private let _ring: IORing
+  private let _deviceAddress: Mutex<any SocketAddress>
+  private let _socket: Mutex<Socket?> = .init(nil)
+  private let _credential: Ocp1TLSCredential
+  private let _engine: Ocp1OpenSSLEngine
+
+  override public var connectionPrefix: String {
+    "\(OcaSecureTcpConnectionPrefix)/\(_deviceAddress.criticalValue._presentationAddress)"
+  }
+
+  override public var isDatagram: Bool { false }
+  override public var hasTransportLayerSecurity: Bool { true }
+
+  private init(
+    socketAddress: any SocketAddress,
+    credential: Ocp1TLSCredential,
+    hostname: String?,
+    trustRoots: Ocp1TLSTrustRoots?,
+    revocation: Ocp1TLSRevocationOptions,
+    options: Ocp1ConnectionOptions,
+    ring: IORing
+  ) throws {
+    _deviceAddress = Mutex(socketAddress)
+    _ring = ring
+    _credential = credential
+    let verifyPeer = !options.flags.contains(.disableCertificateVerification)
+    _engine = try Ocp1OpenSSLEngine(
+      mode: .client,
+      credential: credential,
+      verifyPeer: verifyPeer,
+      hostname: hostname,
+      trustRoots: trustRoots,
+      revocation: revocation
+    )
+    super.init(options: options)
+  }
+
+  public convenience init(
+    deviceAddress: Data,
+    credential: Ocp1TLSCredential,
+    hostname: String? = nil,
+    trustRoots: Ocp1TLSTrustRoots? = nil,
+    revocation: Ocp1TLSRevocationOptions = .disabled,
+    options: Ocp1ConnectionOptions = Ocp1ConnectionOptions(),
+    ring: IORing = .shared
+  ) throws {
+    try self.init(
+      socketAddress: deviceAddress.socketAddress,
+      credential: credential,
+      hostname: hostname,
+      trustRoots: trustRoots,
+      revocation: revocation,
+      options: options,
+      ring: ring
+    )
+  }
+
+  public convenience init(
+    path: String,
+    credential: Ocp1TLSCredential,
+    options: Ocp1ConnectionOptions = Ocp1ConnectionOptions(),
+    ring: IORing = .shared
+  ) throws {
+    try self.init(
+      socketAddress: sockaddr_un(
+        family: sa_family_t(AF_LOCAL),
+        presentationAddress: path
+      ),
+      credential: credential,
+      hostname: nil,
+      trustRoots: nil,
+      revocation: .disabled,
+      options: options,
+      ring: ring
+    )
+  }
+
+  public nonisolated var deviceAddress: Data {
+    get {
+      AnySocketAddress(_deviceAddress.criticalValue).data
+    }
+    set {
+      do {
+        try _deviceAddress.withLock {
+          $0 = try AnySocketAddress(bytes: Array(newValue))
+          Task { [weak self] in await self?.deviceAddressDidChange() }
+        }
+      } catch {}
+    }
+  }
+
+  override public var localAddress: Data? {
+    guard let socket = _socket.withLock({ $0 }) else { return nil }
+    return try? AnySocketAddress(socket.localAddress).data
+  }
+
+  override public func connectDevice() async throws {
+    // Engine carries SSL state across attempts; reset before each so a
+    // prior failed handshake can't bleed into the next.
+    await _engine.reset()
+    let deviceAddress = _deviceAddress.criticalValue
+    let socket = try Socket(
+      ring: _ring,
+      domain: deviceAddress.family,
+      type: Glibc.SOCK_STREAM,
+      protocol: 0
+    )
+    if deviceAddress.family == AF_INET || deviceAddress.family == AF_INET6 {
+      try socket.setTcpNoDelay()
+    }
+    do {
+      try await socket.connect(to: deviceAddress)
+    } catch let error as Errno {
+      throw error.mappedError
+    }
+    _socket.withLock { $0 = socket }
+
+    let (read, write) = Self.makeTransportClosures(socket)
+    do {
+      try await _engine.handshake(read: read, write: write)
+    } catch {
+      // Drop the socket so a failed handshake doesn't leave half-init
+      // transport state visible to later operations.
+      _socket.withLock { $0 = nil }
+      throw error
+    }
+    try await super.connectDevice()
+  }
+
+  override public func disconnectDevice() async throws {
+    let socket = _socket.withLock { (slot: inout Socket?) -> Socket? in
+      let s = slot
+      slot = nil
+      return s
+    }
+    if let socket {
+      let (read, write) = Self.makeTransportClosures(socket)
+      try? await _engine.shutdown(read: read, write: write)
+    }
+    try await super.disconnectDevice()
+  }
+
+  override public func read(_ length: Int) async throws -> Data {
+    guard let socket = _socket.withLock({ $0 }) else {
+      throw Ocp1Error.notConnected
+    }
+    let (read, write) = Self.makeTransportClosures(socket)
+    do {
+      return try await _engine.read(length, read: read, write: write)
+    } catch let error as Errno {
+      throw error.mappedError
+    }
+  }
+
+  override public func write(_ data: Data) async throws -> Int {
+    guard let socket = _socket.withLock({ $0 }) else {
+      throw Ocp1Error.notConnected
+    }
+    let (read, write) = Self.makeTransportClosures(socket)
+    do {
+      return try await _engine.write(data, read: read, write: write)
+    } catch let error as Errno {
+      throw error.mappedError
+    }
+  }
+
+  /// Wrap a `Socket` (Sendable value type) in the @Sendable read/write
+  /// closures the engine pumps through.
+  private static func makeTransportClosures(
+    _ socket: Socket
+  ) -> (
+    read: @Sendable (Int) async throws -> Data,
+    write: @Sendable (Data) async throws -> Void
+  ) {
+    let read: @Sendable (Int) async throws -> Data = { count in
+      try await Data(socket.read(count: count, awaitingAllRead: false))
+    }
+    let write: @Sendable (Data) async throws -> Void = { data in
+      _ = try await socket.write(Array(data), count: data.count, awaitingAllWritten: true)
+    }
+    return (read, write)
+  }
+}
+
+#endif

--- a/Sources/SwiftOCASecure/OCP.1/Backend/Ocp1OpenSSLDTLSConnection.swift
+++ b/Sources/SwiftOCASecure/OCP.1/Backend/Ocp1OpenSSLDTLSConnection.swift
@@ -1,0 +1,234 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(COpenSSL) && canImport(IORing)
+
+import COpenSSL
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+import Glibc
+public import IORing
+internal import IORingUtils
+import SocketAddress
+@_spi(SwiftOCAPrivate)
+import SwiftOCA
+import Synchronization
+import struct SystemPackage.Errno
+
+fileprivate extension Errno {
+  var mappedError: Error {
+    switch self {
+    case .connectionRefused, .connectionReset, .brokenPipe:
+      Ocp1Error.notConnected
+    case .canceled:
+      Ocp1Error.retryOperation
+    default:
+      self
+    }
+  }
+}
+
+/// OCP.1 DTLS-secured UDP connection. Connected SOCK_DGRAM socket so each
+/// receive returns one peer datagram, which we deposit into the engine's
+/// rbio for SSL_read to drain one DTLS record at a time.
+public final class Ocp1OpenSSLDTLSConnection: Ocp1Connection, Ocp1MutableConnection {
+  private let _ring: IORing
+  private let _deviceAddress: Mutex<any SocketAddress>
+  private let _socket: Mutex<Socket?> = .init(nil)
+  private let _credential: Ocp1TLSCredential
+  private let _engine: Ocp1OpenSSLEngine
+
+  override public var connectionPrefix: String {
+    "\(OcaSecureUdpConnectionPrefix)/\(_deviceAddress.criticalValue._presentationAddress)"
+  }
+
+  override public var isDatagram: Bool { true }
+  override public var hasTransportLayerSecurity: Bool { true }
+
+  override public var heartbeatTime: Duration { .seconds(1) }
+
+  private init(
+    socketAddress: any SocketAddress,
+    credential: Ocp1TLSCredential,
+    hostname: String?,
+    trustRoots: Ocp1TLSTrustRoots?,
+    revocation: Ocp1TLSRevocationOptions,
+    options: Ocp1ConnectionOptions,
+    ring: IORing
+  ) throws {
+    _deviceAddress = Mutex(socketAddress)
+    _ring = ring
+    _credential = credential
+    let verifyPeer = !options.flags.contains(.disableCertificateVerification)
+    _engine = try Ocp1OpenSSLEngine(
+      mode: .client,
+      credential: credential,
+      transport: .datagram,
+      verifyPeer: verifyPeer,
+      hostname: hostname,
+      trustRoots: trustRoots,
+      revocation: revocation
+    )
+    super.init(options: options)
+  }
+
+  public convenience init(
+    deviceAddress: Data,
+    credential: Ocp1TLSCredential,
+    hostname: String? = nil,
+    trustRoots: Ocp1TLSTrustRoots? = nil,
+    revocation: Ocp1TLSRevocationOptions = .disabled,
+    options: Ocp1ConnectionOptions = Ocp1ConnectionOptions(),
+    ring: IORing = .shared
+  ) throws {
+    try self.init(
+      socketAddress: deviceAddress.socketAddress,
+      credential: credential,
+      hostname: hostname,
+      trustRoots: trustRoots,
+      revocation: revocation,
+      options: options,
+      ring: ring
+    )
+  }
+
+  public nonisolated var deviceAddress: Data {
+    get {
+      AnySocketAddress(_deviceAddress.criticalValue).data
+    }
+    set {
+      do {
+        try _deviceAddress.withLock {
+          $0 = try AnySocketAddress(bytes: Array(newValue))
+          Task { [weak self] in await self?.deviceAddressDidChange() }
+        }
+      } catch {}
+    }
+  }
+
+  override public var localAddress: Data? {
+    guard let socket = _socket.withLock({ $0 }) else { return nil }
+    return try? AnySocketAddress(socket.localAddress).data
+  }
+
+  override public func connectDevice() async throws {
+    await _engine.reset()
+    let deviceAddress = _deviceAddress.criticalValue
+    let socket = try Socket(
+      ring: _ring,
+      domain: deviceAddress.family,
+      type: Glibc.SOCK_DGRAM,
+      protocol: 0
+    )
+    do {
+      try await socket.connect(to: deviceAddress)
+    } catch let error as Errno {
+      throw error.mappedError
+    }
+    _socket.withLock { $0 = socket }
+
+    let (read, write) = Self.makeTransportClosures(socket)
+    // DTLS over a memory BIO has no internal scheduler — pair the handshake
+    // with a ticker that drives the engine's retransmit timer.
+    let engine = _engine
+    do {
+      try await withThrowingTaskGroup(of: Void.self) { group in
+        group.addTask {
+          try await engine.handshake(read: read, write: write)
+        }
+        group.addTask {
+          while !Task.isCancelled {
+            try? await Task.sleep(for: .milliseconds(200))
+            if Task.isCancelled { return }
+            if await engine.isHandshakeComplete { return }
+            _ = try? await engine.handleDatagramTimeout(write: write)
+          }
+        }
+        // The handshake task finishes first; cancel the watchdog and
+        // surface the handshake's result.
+        try await group.next()
+        group.cancelAll()
+      }
+    } catch {
+      _socket.withLock { $0 = nil }
+      throw error
+    }
+    try await super.connectDevice()
+  }
+
+  override public func disconnectDevice() async throws {
+    let socket = _socket.withLock { (slot: inout Socket?) -> Socket? in
+      let s = slot
+      slot = nil
+      return s
+    }
+    if let socket {
+      let (read, write) = Self.makeTransportClosures(socket)
+      try? await _engine.shutdown(read: read, write: write)
+    }
+    try await super.disconnectDevice()
+  }
+
+  override public func read(_ length: Int) async throws -> Data {
+    guard let socket = _socket.withLock({ $0 }) else {
+      throw Ocp1Error.notConnected
+    }
+    let (read, write) = Self.makeTransportClosures(socket)
+    do {
+      return try await _engine.readDatagram(read: read, write: write)
+    } catch let error as Errno {
+      throw error.mappedError
+    }
+  }
+
+  override public func write(_ data: Data) async throws -> Int {
+    guard let socket = _socket.withLock({ $0 }) else {
+      throw Ocp1Error.notConnected
+    }
+    let (read, write) = Self.makeTransportClosures(socket)
+    do {
+      return try await _engine.write(data, read: read, write: write)
+    } catch let error as Errno {
+      throw error.mappedError
+    }
+  }
+
+  /// Datagram transport closures. `awaitingAllRead: false` truncates the
+  /// buffer to the actual datagram length — DTLS is strict about record
+  /// framing and would alert on trailing garbage.
+  private static func makeTransportClosures(
+    _ socket: Socket
+  ) -> (
+    read: @Sendable (Int) async throws -> Data,
+    write: @Sendable (Data) async throws -> Void
+  ) {
+    let read: @Sendable (Int) async throws -> Data = { _ in
+      try await Data(socket.read(
+        count: Ocp1MaximumDatagramPduSize,
+        awaitingAllRead: false
+      ))
+    }
+    let write: @Sendable (Data) async throws -> Void = { data in
+      try await socket.send(Array(data))
+    }
+    return (read, write)
+  }
+}
+
+#endif

--- a/Sources/SwiftOCASecure/OCP.1/Backend/Ocp1OpenSSLEngine.swift
+++ b/Sources/SwiftOCASecure/OCP.1/Backend/Ocp1OpenSSLEngine.swift
@@ -1,0 +1,1315 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(COpenSSL)
+
+import COpenSSL
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+@_spi(SwiftOCAPrivate)
+import SwiftOCA
+import Synchronization
+
+/// PSK state reached from the OpenSSL C callbacks via `SSL_set_ex_data`.
+/// Server-side holds a reference to a provider queried on each callback;
+/// client-side holds a single identity/key pair. A class so we can pass
+/// an unretained pointer through the C boundary.
+package final class Ocp1OpenSSLPSKStore: @unchecked Sendable {
+  let serverProvider: (any OcaPreSharedKeyProvider)?
+
+  /// When set, PSK callbacks read key bytes on-demand from the provider
+  /// instead of from `clientKey`, so the secret only lives in the caller's
+  /// storage.
+  let clientProvider: (any OcaPreSharedKeyProvider)?
+
+  let clientIdentity: String?
+
+  /// `var` only so `deinit` can zero the bytes; never reassigned.
+  private(set) var clientKey: Data?
+
+  /// Stable storage for the client identity's UTF-8 bytes — OpenSSL's TLS
+  /// 1.3 `use_session_cb` keeps the pointer past the callback return.
+  fileprivate let clientIdentityBytes: UnsafeMutableBufferPointer<UInt8>?
+
+  /// Bound to the HelloVerifyRequest cookie by the DTLS cookie callbacks.
+  let peerAddressBytes: Data
+
+  /// Server-side: the PSK identity that produced a successful lookup.
+  /// Written by the synchronous C callback, read by the engine actor.
+  private let authenticatedPSKIdentity = Mutex<String?>(nil)
+
+  fileprivate func setAuthenticatedPSKIdentity(_ identity: String) {
+    authenticatedPSKIdentity.withLock { $0 = identity }
+  }
+
+  package func capturedPSKIdentity() -> String? {
+    authenticatedPSKIdentity.withLock { $0 }
+  }
+
+  package func clearAuthenticatedPSKIdentity() {
+    authenticatedPSKIdentity.withLock { $0 = nil }
+  }
+
+  init(
+    serverProvider: (any OcaPreSharedKeyProvider)?,
+    peerAddressBytes: Data = Data()
+  ) {
+    self.serverProvider = serverProvider
+    clientProvider = nil
+    clientIdentity = nil
+    clientKey = nil
+    clientIdentityBytes = nil
+    self.peerAddressBytes = peerAddressBytes
+  }
+
+  init(clientIdentity: String, clientKey: Data) {
+    serverProvider = nil
+    clientProvider = nil
+    self.clientIdentity = clientIdentity
+    // Force a refcount-1 private copy so `deinit`'s `resetBytes` zeros the
+    // actually-stored bytes rather than COW-allocating a fresh copy.
+    var owned = Data(count: clientKey.count)
+    owned.withUnsafeMutableBytes { dst in
+      clientKey.withUnsafeBytes { src in
+        if let dp = dst.baseAddress, let sp = src.baseAddress {
+          dp.copyMemory(from: sp, byteCount: clientKey.count)
+        }
+      }
+    }
+    self.clientKey = owned
+    let utf8 = Array(clientIdentity.utf8)
+    let buf = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: utf8.count)
+    _ = buf.initialize(from: utf8)
+    clientIdentityBytes = buf
+    peerAddressBytes = Data()
+  }
+
+  /// Provider-backed client variant. Key bytes live in the provider's
+  /// storage; no copy is kept on this store.
+  init(clientIdentity: String, clientProvider: any OcaPreSharedKeyProvider) {
+    serverProvider = nil
+    self.clientProvider = clientProvider
+    self.clientIdentity = clientIdentity
+    clientKey = nil
+    let utf8 = Array(clientIdentity.utf8)
+    let buf = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: utf8.count)
+    _ = buf.initialize(from: utf8)
+    clientIdentityBytes = buf
+    peerAddressBytes = Data()
+  }
+
+  deinit {
+    if let count = clientKey?.count {
+      clientKey?.resetBytes(in: 0..<count)
+    }
+    if let clientIdentityBytes {
+      clientIdentityBytes.deinitialize()
+      clientIdentityBytes.deallocate()
+    }
+  }
+}
+
+/// PSK-mode client verify callback. Returns 0 so any cert presented by the
+/// server fails the handshake — PSK handshakes don't carry one, and a cert
+/// appearing here means the server is silently downgrading to cert auth.
+private let _pskClientRejectCertCallback: @convention(c) (
+  _ preverifyOK: CInt,
+  _ ctx: OpaquePointer?
+) -> CInt = { _, _ in
+  0
+}
+
+/// Ex-data slot used to attach an `Ocp1OpenSSLPSKStore` to each `SSL`.
+private let _sslPSKStoreExIndex: Mutex<CInt> = Mutex(-1)
+
+private func _getOrAllocateExIndex() -> CInt {
+  _sslPSKStoreExIndex.withLock { slot in
+    if slot < 0 {
+      slot = COpenSSL_SSL_get_ex_new_index(0, nil, nil, nil, nil)
+    }
+    return slot
+  }
+}
+
+private func _pskStore(from ssl: OpaquePointer?) -> Ocp1OpenSSLPSKStore? {
+  guard let ssl else { return nil }
+  let idx = _getOrAllocateExIndex()
+  guard let raw = SSL_get_ex_data(ssl, idx) else { return nil }
+  return Unmanaged<Ocp1OpenSSLPSKStore>.fromOpaque(raw).takeUnretainedValue()
+}
+
+/// TLS 1.2 server PSK callback. Looks up the identity and copies the key
+/// into the supplied buffer; returns 0 on unknown identity or oversized key.
+private let _pskServerCallback: @convention(c) (
+  _ ssl: OpaquePointer?,
+  _ identity: UnsafePointer<CChar>?,
+  _ psk: UnsafeMutablePointer<UInt8>?,
+  _ maxLen: CUnsignedInt
+) -> CUnsignedInt = { ssl, identityPtr, psk, maxLen in
+  guard let ssl, let identityPtr, let psk, let store = _pskStore(from: ssl) else { return 0 }
+  let maxIdentityBytes = Int(PSK_MAX_IDENTITY_LEN)
+  var identityLen = 0
+  while identityLen < maxIdentityBytes, identityPtr[identityLen] != 0 {
+    identityLen += 1
+  }
+  guard identityLen < maxIdentityBytes else { return 0 }
+  let identityBytes = UnsafeBufferPointer(
+    start: UnsafeRawPointer(identityPtr).assumingMemoryBound(to: UInt8.self),
+    count: identityLen
+  )
+  let identity = String(decoding: identityBytes, as: UTF8.self)
+  guard let provider = store.serverProvider else { return 0 }
+  let written: CUnsignedInt = provider.withPreSharedKey(forIdentity: identity) { src in
+    guard src.count <= Int(maxLen), let base = src.baseAddress else { return CUnsignedInt(0) }
+    psk.update(from: base, count: src.count)
+    return CUnsignedInt(src.count)
+  } ?? 0
+  guard written > 0 else { return 0 }
+  store.setAuthenticatedPSKIdentity(identity)
+  // PSK authenticates the client on its own; if the SSL_CTX was also wired
+  // up for mTLS, don't also demand a client cert that won't be exchanged.
+  SSL_set_verify(ssl, SSL_VERIFY_NONE, nil)
+  return written
+}
+
+/// TLS 1.2 client PSK callback. Key bytes come from `clientKey` (the
+/// `.preSharedKey` variant) or `clientProvider` (`.preSharedKeyProvider`).
+private let _pskClientCallback: @convention(c) (
+  _ ssl: OpaquePointer?,
+  _ hint: UnsafePointer<CChar>?,
+  _ identity: UnsafeMutablePointer<CChar>?,
+  _ maxIdentityLen: CUnsignedInt,
+  _ psk: UnsafeMutablePointer<UInt8>?,
+  _ maxPSKLen: CUnsignedInt
+) -> CUnsignedInt = { ssl, _, identityBuf, maxIdentityLen, psk, maxPSKLen in
+  guard let identityBuf, let psk, let store = _pskStore(from: ssl),
+        let id = store.clientIdentity
+  else { return 0 }
+  let idBytes = Data(id.utf8)
+  guard idBytes.count + 1 <= Int(maxIdentityLen) else { return 0 }
+  idBytes.withUnsafeBytes { src in
+    identityBuf.withMemoryRebound(to: UInt8.self, capacity: idBytes.count + 1) { dest in
+      dest.update(from: src.bindMemory(to: UInt8.self).baseAddress!, count: idBytes.count)
+      dest[idBytes.count] = 0
+    }
+  }
+  if let provider = store.clientProvider {
+    return provider.withPreSharedKey(forIdentity: id) { keyBuf -> CUnsignedInt in
+      guard keyBuf.count <= Int(maxPSKLen), let base = keyBuf.baseAddress else { return 0 }
+      psk.update(from: base, count: keyBuf.count)
+      return CUnsignedInt(keyBuf.count)
+    } ?? 0
+  }
+  guard let key = store.clientKey, key.count <= Int(maxPSKLen) else { return 0 }
+  key.withUnsafeBytes { src in
+    psk.update(from: src.bindMemory(to: UInt8.self).baseAddress!, count: key.count)
+  }
+  return CUnsignedInt(key.count)
+}
+
+/// IANA ID for `TLS_AES_128_GCM_SHA256` — matches the suite Apple's
+/// Network.framework selects when negotiating TLS 1.3 PSK.
+private let _tls13PSKCipherID: [UInt8] = [0x13, 0x01]
+
+/// Build an `SSL_SESSION` carrying `key` as the resumption secret with the
+/// TLS 1.3 cipher installed. Caller transfers ownership to OpenSSL via the
+/// `**sess` out-parameter. Takes a raw buffer so server callers can invoke
+/// this inside the provider's `withPreSharedKey` closure without copying.
+private func _makeTLS13PSKSession(
+  ssl: OpaquePointer,
+  key: UnsafeBufferPointer<UInt8>
+) -> OpaquePointer? {
+  guard let cipher = _tls13PSKCipherID.withUnsafeBufferPointer({ buf in
+    SSL_CIPHER_find(ssl, buf.baseAddress)
+  }) else { return nil }
+  guard let session = SSL_SESSION_new() else { return nil }
+  guard SSL_SESSION_set1_master_key(session, key.baseAddress, key.count) == 1,
+        SSL_SESSION_set_cipher(session, cipher) == 1,
+        SSL_SESSION_set_protocol_version(session, Int32(TLS1_3_VERSION)) == 1
+  else {
+    SSL_SESSION_free(session)
+    return nil
+  }
+  return session
+}
+
+/// TLS 1.3 server-side PSK callback (RFC 8446 §4.2.11 external PSK). Fires
+/// only for externally configured PSKs; session-ticket resumption goes
+/// through OpenSSL's own machinery. Returning `1` with `*sess = nil` means
+/// "no external PSK matched" — handshake falls through to cert auth.
+private let _pskFindSessionCallback: @convention(c) (
+  _ ssl: OpaquePointer?,
+  _ identity: UnsafePointer<UInt8>?,
+  _ identityLen: Int,
+  _ session: UnsafeMutablePointer<OpaquePointer?>?
+) -> CInt = { ssl, identityPtr, identityLen, sessionOut in
+  guard let ssl, let sessionOut else { return 0 }
+  sessionOut.pointee = nil
+  guard let identityPtr, let store = _pskStore(from: ssl) else { return 1 }
+  guard identityLen >= 0, identityLen <= Int(PSK_MAX_IDENTITY_LEN) else { return 1 }
+  let identityBytes = UnsafeBufferPointer(start: identityPtr, count: identityLen)
+  let identity = String(decoding: identityBytes, as: UTF8.self)
+  guard let provider = store.serverProvider else { return 1 }
+  let session: OpaquePointer? = provider.withPreSharedKey(forIdentity: identity) { src in
+    _makeTLS13PSKSession(ssl: ssl, key: src)
+  } ?? nil
+  guard let session else { return 1 }
+  store.setAuthenticatedPSKIdentity(identity)
+  // PSK authenticates the client; clear verify on this SSL so an mTLS
+  // CTX doesn't also demand a client cert that won't be exchanged.
+  SSL_set_verify(ssl, SSL_VERIFY_NONE, nil)
+  sessionOut.pointee = session
+  return 1
+}
+
+/// TLS 1.3 client-side PSK callback. `md != nil` means HelloRetryRequest
+/// asked for a specific digest; we only support SHA-256, so skip PSK if a
+/// different digest was requested.
+private let _pskUseSessionCallback: @convention(c) (
+  _ ssl: OpaquePointer?,
+  _ md: OpaquePointer?,
+  _ id: UnsafeMutablePointer<UnsafePointer<UInt8>?>?,
+  _ idLen: UnsafeMutablePointer<Int>?,
+  _ session: UnsafeMutablePointer<OpaquePointer?>?
+) -> CInt = { ssl, md, idOut, idLenOut, sessionOut in
+  guard let ssl, let idOut, let idLenOut, let sessionOut else { return 0 }
+  idOut.pointee = nil
+  idLenOut.pointee = 0
+  sessionOut.pointee = nil
+
+  if md != nil, md != EVP_sha256() {
+    return 1
+  }
+
+  guard let store = _pskStore(from: ssl),
+        let identityBytes = store.clientIdentityBytes
+  else { return 1 }
+
+  let session: OpaquePointer?
+  if let provider = store.clientProvider, let id = store.clientIdentity {
+    session = provider.withPreSharedKey(forIdentity: id) { keyBuf in
+      _makeTLS13PSKSession(ssl: ssl, key: keyBuf)
+    } ?? nil
+  } else if let key = store.clientKey {
+    session = key.withUnsafeBytes { raw in
+      _makeTLS13PSKSession(ssl: ssl, key: raw.bindMemory(to: UInt8.self))
+    }
+  } else {
+    return 1
+  }
+  guard let session else { return 0 }
+  idOut.pointee = UnsafePointer(identityBytes.baseAddress)
+  idLenOut.pointee = identityBytes.count
+  sessionOut.pointee = session
+  return 1
+}
+
+/// DTLS HelloVerifyRequest cookie machinery (RFC 6347 §4.2.1):
+/// HMAC-SHA256 the peer's source address with a per-process secret. The
+/// secret lives for the process lifetime — rotating would invalidate
+/// in-flight HelloVerifyRequests.
+package enum Ocp1OpenSSLDTLSCookie {
+  /// 32-byte HMAC key, generated once via OpenSSL's CSPRNG.
+  static let secret: Data = {
+    var data = Data(count: 32)
+    let ok = data.withUnsafeMutableBytes { raw -> Int32 in
+      RAND_bytes(raw.bindMemory(to: UInt8.self).baseAddress, Int32(raw.count))
+    }
+    precondition(ok == 1, "RAND_bytes failed seeding the DTLS cookie secret")
+    return data
+  }()
+
+  /// HMAC-SHA256(secret, peerAddress). 32 bytes, well under the 255-byte
+  /// DTLS cookie field limit.
+  static func compute(over peerAddress: Data) -> Data {
+    var output = [UInt8](repeating: 0, count: 32)
+    var outLen: UInt32 = 32
+    secret.withUnsafeBytes { secretBytes in
+      peerAddress.withUnsafeBytes { peerBytes in
+        output.withUnsafeMutableBufferPointer { outBuf in
+          _ = HMAC(
+            EVP_sha256(),
+            secretBytes.baseAddress,
+            Int32(secretBytes.count),
+            peerBytes.bindMemory(to: UInt8.self).baseAddress,
+            peerBytes.count,
+            outBuf.baseAddress,
+            &outLen
+          )
+        }
+      }
+    }
+    return Data(output.prefix(Int(outLen)))
+  }
+}
+
+/// DTLS cookie generate callback. Fires when the server is about to emit
+/// a HelloVerifyRequest.
+private let _cookieGenerateCallback: @convention(c) (
+  _ ssl: OpaquePointer?,
+  _ cookieOut: UnsafeMutablePointer<UInt8>?,
+  _ cookieLenOut: UnsafeMutablePointer<CUnsignedInt>?
+) -> CInt = { ssl, cookieOut, cookieLenOut in
+  guard let ssl, let cookieOut, let cookieLenOut,
+        let store = _pskStore(from: ssl)
+  else { return 0 }
+  let mac = Ocp1OpenSSLDTLSCookie.compute(over: store.peerAddressBytes)
+  guard mac.count <= 255 else { return 0 }
+  mac.withUnsafeBytes { src in
+    cookieOut.update(
+      from: src.bindMemory(to: UInt8.self).baseAddress!,
+      count: mac.count
+    )
+  }
+  cookieLenOut.pointee = CUnsignedInt(mac.count)
+  return 1
+}
+
+/// DTLS cookie verify callback. Recomputes the expected cookie and
+/// constant-time-compares. Cookie verification closes the amplification
+/// path, not the state-allocation path.
+private let _cookieVerifyCallback: @convention(c) (
+  _ ssl: OpaquePointer?,
+  _ cookieIn: UnsafePointer<UInt8>?,
+  _ cookieLen: CUnsignedInt
+) -> CInt = { ssl, cookieIn, cookieLen in
+  guard let ssl, let cookieIn,
+        let store = _pskStore(from: ssl)
+  else { return 0 }
+  let expected = Ocp1OpenSSLDTLSCookie.compute(over: store.peerAddressBytes)
+  guard expected.count == Int(cookieLen) else { return 0 }
+  let match: Int32 = expected.withUnsafeBytes { expBytes in
+    CRYPTO_memcmp(expBytes.baseAddress, cookieIn, expected.count)
+  }
+  return match == 0 ? 1 : 0
+}
+
+/// TLS 1.2 PSK suites, strongest first. PFS-only: non-PFS PSK-AES-GCM was
+/// dropped (PSK leak under those would decrypt all past traffic).
+package let Ocp1OpenSSLPSKCipherList = [
+  "ECDHE-PSK-CHACHA20-POLY1305", // RFC 7905, ECDHE PFS + AEAD
+  "DHE-PSK-CHACHA20-POLY1305",   // RFC 7905, DHE PFS + AEAD
+  "DHE-PSK-AES256-GCM-SHA384",   // RFC 5487, DHE PFS + AEAD-256
+  "DHE-PSK-AES128-GCM-SHA256",   // RFC 5487, DHE PFS + AEAD-128
+  "DHE-PSK-AES128-CBC-SHA",      // RFC 4279, AES70-2024 mandated PFS baseline
+].joined(separator: ":")
+
+/// TLS 1.2 cert-mode suites — explicit PFS + AEAD list so a permissive
+/// OpenSSL build policy can't silently weaken the channel.
+package let Ocp1OpenSSLCertCipherList = [
+  "ECDHE-ECDSA-AES256-GCM-SHA384",
+  "ECDHE-RSA-AES256-GCM-SHA384",
+  "ECDHE-ECDSA-CHACHA20-POLY1305",
+  "ECDHE-RSA-CHACHA20-POLY1305",
+  "ECDHE-ECDSA-AES128-GCM-SHA256",
+  "ECDHE-RSA-AES128-GCM-SHA256",
+  "DHE-RSA-AES256-GCM-SHA384",
+  "DHE-RSA-CHACHA20-POLY1305",
+  "DHE-RSA-AES128-GCM-SHA256",
+].joined(separator: ":")
+
+/// Transport-agnostic OpenSSL TLS engine. Owns the `SSL_CTX`/`SSL` and a
+/// pair of memory BIOs; callers drive bytes through `read`/`write` closures
+/// bound to whatever byte stream they hold. All `SSL_*` calls run on the
+/// engine actor against non-blocking memory BIOs.
+package actor Ocp1OpenSSLEngine {
+  package enum Mode: Sendable {
+    case client
+    case server
+  }
+
+  /// `.stream` selects TLS over TCP/Unix; `.datagram` selects DTLS over UDP.
+  package enum Transport: Sendable {
+    case stream
+    case datagram
+  }
+
+  private let transport: Transport
+  private let mode: Mode
+  private var ctx: OpaquePointer?
+  private var ssl: OpaquePointer?
+  /// Network → TLS (we BIO_write inbound ciphertext here).
+  private var rbio: OpaquePointer?
+  /// TLS → Network (we BIO_read outbound ciphertext from here).
+  private var wbio: OpaquePointer?
+  private let pskStore: Ocp1OpenSSLPSKStore
+  private var handshakeComplete = false
+  private var closed = false
+
+  /// Must comfortably exceed the per-record DTLS MTU.
+  private static let readBufferSize = 16 * 1024
+
+  /// DTLS record header layout (RFC 6347 §4.1):
+  ///   byte 0:     content type
+  ///   bytes 1-2:  protocol version
+  ///   bytes 3-10: epoch (2) + sequence number (6)
+  ///   bytes 11-12: length (big-endian)
+  /// Payload follows at byte 13.
+  private static let dtlsRecordHeaderSize = 13
+  private static let dtlsRecordLengthOffset = 11
+
+  /// RFC 6347 §4.1.1 recommended fallback that survives most paths without
+  /// IP-level fragmentation. OpenSSL refuses to send oversized records.
+  private static let DefaultDTLSMtu: Int32 = 1200
+
+  package init(
+    mode: Mode,
+    credential: Ocp1TLSCredential?,
+    transport: Transport = .stream,
+    serverPSKProvider: (any OcaPreSharedKeyProvider)? = nil,
+    verifyPeer: Bool = false,
+    hostname: String? = nil,
+    trustRoots: Ocp1TLSTrustRoots? = nil,
+    clientTrustRoots: Ocp1TLSTrustRoots? = nil,
+    revocation: Ocp1TLSRevocationOptions = .disabled,
+    peerAddressBytes: Data = Data()
+  ) throws {
+    try credential?.validate()
+
+    // Cert-mode DTLS handshakes produce multi-record flights that don't
+    // survive the current `drainOutbound` coalescing — refuse until a
+    // packet-preserving outbound path lands. PSK stays within one record.
+    if transport == .datagram, let credential, !Self.credentialIsPSK(credential) {
+      throw Ocp1Error.status(.notImplemented)
+    }
+    // Empty `peerAddressBytes` would collapse the cookie HMAC to a
+    // server-wide constant, defeating source-address verification.
+    if transport == .datagram, mode == .server, peerAddressBytes.isEmpty {
+      throw Ocp1Error.status(.parameterError)
+    }
+    // Cert-mode clients with verifyPeer need a hostname to verify against;
+    // chain-only validation accepts any cert from the configured CA.
+    if mode == .client, verifyPeer, !Self.credentialIsPSK(credential), hostname == nil {
+      throw Ocp1Error.status(.parameterError)
+    }
+    // `.preSharedKey*` is a client-side shape; server PSKs come from the
+    // injected provider.
+    if mode == .server, Self.credentialIsPSK(credential) {
+      throw Ocp1Error.status(.parameterError)
+    }
+
+    self.transport = transport
+    self.mode = mode
+    pskStore = switch (mode, credential) {
+    case let (.client, .preSharedKey(identity, key)?):
+      Ocp1OpenSSLPSKStore(clientIdentity: identity, clientKey: key)
+    case let (.client, .preSharedKeyProvider(identity, provider)?):
+      Ocp1OpenSSLPSKStore(clientIdentity: identity, clientProvider: provider)
+    case (.client, _):
+      Ocp1OpenSSLPSKStore(serverProvider: nil)
+    case (.server, _):
+      Ocp1OpenSSLPSKStore(
+        serverProvider: serverPSKProvider,
+        peerAddressBytes: peerAddressBytes
+      )
+    }
+
+    let method: OpaquePointer? = switch (transport, mode) {
+    case (.stream, .server): TLS_server_method()
+    case (.stream, .client): TLS_client_method()
+    case (.datagram, .server): DTLS_server_method()
+    case (.datagram, .client): DTLS_client_method()
+    }
+    guard let method, let ctx = SSL_CTX_new(method) else {
+      throw Ocp1Error.unknownServiceType
+    }
+    self.ctx = ctx
+
+    // MOVING_WRITE_BUFFER: `Data.withUnsafeBytes` can hand out a different
+    // pointer between async hops, which would trip OpenSSL's retry-with-
+    // the-same-pointer contract (SSL_R_BAD_WRITE_RETRY).
+    // ENABLE_PARTIAL_WRITE lets `SSL_write` return after a partial write
+    // so we can yield between records.
+    _ = COpenSSL_SSL_CTX_set_mode(
+      ctx,
+      COpenSSL_SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER | COpenSSL_SSL_MODE_ENABLE_PARTIAL_WRITE
+    )
+
+    // TLS/DTLS 1.2+. The AES70-mandated PSK suite is TLS 1.2-only and
+    // DTLS 1.0 is RFC 8996 deprecated.
+    let minVersion: Int32 = transport == .datagram ? Int32(DTLS1_2_VERSION) : Int32(TLS1_2_VERSION)
+    guard COpenSSL_SSL_CTX_set_min_proto_version(ctx, minVersion) == 1 else {
+      SSL_CTX_free(ctx)
+      self.ctx = nil
+      throw Ocp1OpenSSLError(code: 0, detail: Self.collectErrorMessages())
+    }
+
+    // Restrict TLS 1.3 to SHA-256 suites. `_makeTLS13PSKSession` pins the
+    // PSK to TLS_AES_128_GCM_SHA256, and RFC 8446 §4.2.11 requires the
+    // session's hash to match the negotiated cipher's — letting the server
+    // pick TLS_AES_256_GCM_SHA384 would silently fall through to cert mode.
+    guard SSL_CTX_set_ciphersuites(ctx, "TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256") == 1 else {
+      SSL_CTX_free(ctx)
+      self.ctx = nil
+      throw Ocp1OpenSSLError(code: 0, detail: Self.collectErrorMessages())
+    }
+
+    if let credential {
+      try Self.configureCredential(ctx: ctx, credential: credential)
+    } else {
+      // No per-engine credential: assume PSK-only and force the PSK suites.
+      // Default cipher list = cert-only, which would silently deny PSK.
+      guard SSL_CTX_set_cipher_list(ctx, Ocp1OpenSSLPSKCipherList) == 1 else {
+        SSL_CTX_free(ctx)
+        self.ctx = nil
+        throw Ocp1OpenSSLError(code: 0, detail: Self.collectErrorMessages())
+      }
+    }
+
+    // Arm PSK callbacks regardless of mTLS config: PSK and cert auth are
+    // independent OCP.1 paths and OpenSSL picks the right one. Both TLS 1.2
+    // (raw byte) and TLS 1.3 (RFC 8773 external PSK) callbacks are wired so
+    // the negotiated protocol version determines which fires.
+    if mode == .server {
+      SSL_CTX_set_psk_server_callback(ctx, _pskServerCallback)
+      SSL_CTX_set_psk_find_session_callback(ctx, _pskFindSessionCallback)
+    } else {
+      SSL_CTX_set_psk_client_callback(ctx, _pskClientCallback)
+      SSL_CTX_set_psk_use_session_callback(ctx, _pskUseSessionCallback)
+    }
+
+    // DTLS HelloVerifyRequest cookie exchange (RFC 6347 §4.2.1): blocks the
+    // amplification DoS by forcing the peer to echo back a source-bound
+    // cookie before the server emits the full ServerHello flight.
+    if mode == .server, transport == .datagram {
+      _ = SSL_CTX_set_options(ctx, COpenSSL_SSL_OP_COOKIE_EXCHANGE)
+      SSL_CTX_set_cookie_generate_cb(ctx, _cookieGenerateCallback)
+      SSL_CTX_set_cookie_verify_cb(ctx, _cookieVerifyCallback)
+    }
+
+    // Refuse renegotiation both ways — a hostile TLS 1.2 server can drive
+    // PSK clients into CPU-burning renegotiation loops. TLS 1.3 has no
+    // renegotiation, so this is a no-op there.
+    _ = SSL_CTX_set_options(ctx, COpenSSL_SSL_OP_NO_RENEGOTIATION)
+    // Disable session tickets so every connection re-authenticates from
+    // scratch — control-plane mTLS should not replay credentials, and
+    // resumption complicates revocation enforcement.
+    _ = SSL_CTX_set_options(ctx, COpenSSL_SSL_OP_NO_TICKET)
+    // Reject TLS 1.3 0-RTT / early data; the OCP.1 protocol has no
+    // idempotent commands and 0-RTT is replayable.
+    _ = COpenSSL_SSL_CTX_set_max_early_data(ctx, 0)
+    if mode == .server {
+      _ = SSL_CTX_set_options(ctx, COpenSSL_SSL_OP_CIPHER_SERVER_PREFERENCE)
+    }
+
+    // Server-cert verification: client mode, verifyPeer, cert credential.
+    if mode == .client, verifyPeer, !Self.credentialIsPSK(credential) {
+      do {
+        try Self.configureTrustRoots(ctx: ctx, trustRoots: trustRoots)
+        try Self.configureRevocation(ctx: ctx, revocation: revocation)
+      } catch {
+        SSL_CTX_free(ctx)
+        self.ctx = nil
+        throw error
+      }
+      SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, nil)
+    } else if mode == .client, Self.credentialIsPSK(credential) {
+      // PSK client: install a verify callback that hard-rejects any peer
+      // cert, so a server claiming "no PSK matched" can't silently
+      // downgrade us to cert auth.
+      SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, _pskClientRejectCertCallback)
+    } else if mode == .server, let clientTrustRoots {
+      // mTLS: require a client cert that chains to `clientTrustRoots`.
+      do {
+        try Self.configureTrustRoots(ctx: ctx, trustRoots: clientTrustRoots)
+        try Self.configureRevocation(ctx: ctx, revocation: revocation)
+      } catch {
+        SSL_CTX_free(ctx)
+        self.ctx = nil
+        throw error
+      }
+      SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, nil)
+    } else {
+      SSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, nil)
+    }
+
+    guard let ssl = SSL_new(ctx) else {
+      SSL_CTX_free(ctx)
+      self.ctx = nil
+      throw Ocp1Error.unknownServiceType
+    }
+    self.ssl = ssl
+
+    if transport == .datagram {
+      // OpenSSL won't probe path MTU without a real BIO_dgram socket.
+      _ = COpenSSL_SSL_set_mtu(ssl, Int(Self.DefaultDTLSMtu))
+    }
+
+    let exIdx = _getOrAllocateExIndex()
+    SSL_set_ex_data(ssl, exIdx, Unmanaged.passUnretained(pskStore).toOpaque())
+
+    // Set SNI whenever the caller supplies a hostname (servers route on
+    // it even without verification); only bind hostname verification when
+    // we're actually checking the cert.
+    if let hostname, mode == .client {
+      hostname.withCString { _ = COpenSSL_SSL_set_tlsext_host_name(ssl, $0) }
+      if verifyPeer, !Self.credentialIsPSK(credential) {
+        hostname.withCString { _ = SSL_set1_host(ssl, $0) }
+      }
+    }
+
+    guard let rbio = BIO_new(BIO_s_mem()), let wbio = BIO_new(BIO_s_mem()) else {
+      SSL_free(ssl)
+      SSL_CTX_free(ctx)
+      self.ssl = nil
+      self.ctx = nil
+      throw Ocp1Error.unknownServiceType
+    }
+    self.rbio = rbio
+    self.wbio = wbio
+    SSL_set_bio(ssl, rbio, wbio)
+
+    switch mode {
+    case .client:
+      SSL_set_connect_state(ssl)
+    case .server:
+      SSL_set_accept_state(ssl)
+    }
+  }
+
+  private static func credentialIsPSK(_ credential: Ocp1TLSCredential?) -> Bool {
+    switch credential {
+    case .preSharedKey, .preSharedKeyProvider: return true
+    default: return false
+    }
+  }
+
+  /// Pre-flight a trust-root configuration so device endpoints surface a
+  /// CA-bundle typo at init time, not as per-peer handshake failures.
+  package nonisolated static func validateTrustRoots(
+    _ trustRoots: Ocp1TLSTrustRoots?
+  ) throws {
+    guard let trustRoots else { return } // platform-default is always loadable
+    let ctx = SSL_CTX_new(TLS_method())
+    guard let ctx else {
+      throw Ocp1OpenSSLError(code: 0, detail: collectErrorMessages())
+    }
+    defer { SSL_CTX_free(ctx) }
+    try configureTrustRoots(ctx: ctx, trustRoots: trustRoots)
+  }
+
+  /// Load CRLs into the SSL_CTX's X509_STORE and arm CRL checking. No-op
+  /// when revocation is disabled or no CRLs are supplied — OpenSSL's
+  /// CRL_CHECK without loaded CRLs would hard-fail every handshake, which
+  /// is not "soft-fail."
+  private static func configureRevocation(
+    ctx: OpaquePointer,
+    revocation: Ocp1TLSRevocationOptions
+  ) throws {
+    guard revocation.flags.contains(.enabled), let crls = revocation.crls else { return }
+    guard let store = SSL_CTX_get_cert_store(ctx) else {
+      throw Ocp1OpenSSLError(code: 0, detail: collectErrorMessages())
+    }
+    let pemData: Data
+    switch crls {
+    case let .crlFile(path):
+      pemData = try Data(contentsOf: URL(fileURLWithPath: path))
+    case let .crlData(data):
+      pemData = data
+    }
+    try pemData.withUnsafeBytes { raw -> Void in
+      let bio = BIO_new_mem_buf(raw.baseAddress, CInt(raw.count))
+      defer { BIO_free(bio) }
+      guard let bio else {
+        throw Ocp1OpenSSLError(code: 0, detail: collectErrorMessages())
+      }
+      var added = 0
+      while let crl = PEM_read_bio_X509_CRL(bio, nil, nil, nil) {
+        if COpenSSL_X509_STORE_add_crl(store, crl) == 1 {
+          added += 1
+        }
+        X509_CRL_free(crl)
+      }
+      guard added > 0 else {
+        throw Ocp1OpenSSLError(code: 0, detail: collectErrorMessages())
+      }
+    }
+    var flags = COpenSSL_X509_V_FLAG_CRL_CHECK
+    if revocation.flags.contains(.checkChain) {
+      flags |= COpenSSL_X509_V_FLAG_CRL_CHECK_ALL
+    }
+    _ = COpenSSL_X509_STORE_set_flags(store, flags)
+  }
+
+  /// Wire trust anchors into the `SSL_CTX`. `nil` → platform default;
+  /// `.caFile` → OpenSSL's loader; `.caData` → push each PEM cert from the
+  /// blob into the `X509_STORE`.
+  private static func configureTrustRoots(
+    ctx: OpaquePointer,
+    trustRoots: Ocp1TLSTrustRoots?
+  ) throws {
+    switch trustRoots {
+    case nil:
+      _ = SSL_CTX_set_default_verify_paths(ctx)
+    case let .caFile(path):
+      guard path.withCString({ SSL_CTX_load_verify_locations(ctx, $0, nil) }) == 1 else {
+        throw Ocp1OpenSSLError(code: 0, detail: collectErrorMessages())
+      }
+    case let .caData(data):
+      guard let store = SSL_CTX_get_cert_store(ctx) else {
+        throw Ocp1OpenSSLError(code: 0, detail: collectErrorMessages())
+      }
+      try data.withUnsafeBytes { raw -> Void in
+        let bio = BIO_new_mem_buf(raw.baseAddress, CInt(raw.count))
+        defer { BIO_free(bio) }
+        guard let bio else {
+          throw Ocp1OpenSSLError(code: 0, detail: collectErrorMessages())
+        }
+        var added = 0
+        while let cert = PEM_read_bio_X509(bio, nil, nil, nil) {
+          if X509_STORE_add_cert(store, cert) == 1 {
+            added += 1
+          }
+          // X509_STORE_add_cert bumps the refcount; drop ours either way.
+          X509_free(cert)
+        }
+        guard added > 0 else {
+          throw Ocp1OpenSSLError(code: 0, detail: collectErrorMessages())
+        }
+      }
+    }
+  }
+
+  isolated deinit {
+    // SSL_free releases the BIOs attached via SSL_set_bio.
+    if let ssl { SSL_free(ssl) }
+    if let ctx { SSL_CTX_free(ctx) }
+  }
+
+  // MARK: - Public transport API
+
+  /// Run `body` with a freshly-cleared OpenSSL thread-local error queue
+  /// so anything `collectErrorMessages()` surfaces is attributable to this
+  /// call — Swift's cooperative pool hops actor tasks across threads.
+  private func clearingOpenSSLErrors<T>(
+    _ body: () async throws -> T
+  ) async rethrows -> T {
+    ERR_clear_error()
+    return try await body()
+  }
+
+  package func handshake(
+    read networkRead: @Sendable (Int) async throws -> Data,
+    write networkWrite: @Sendable (Data) async throws -> Void
+  ) async throws {
+    guard let ssl else { throw Ocp1Error.notConnected }
+    try await clearingOpenSSLErrors {
+      while !handshakeComplete {
+        let ret = SSL_do_handshake(ssl)
+        try await drainOutbound(write: networkWrite)
+        if ret == 1 {
+          handshakeComplete = true
+          return
+        }
+        try await serviceWantSignal(ret: ret, read: networkRead, write: networkWrite)
+      }
+    }
+  }
+
+  package func read(
+    _ count: Int,
+    read networkRead: @Sendable (Int) async throws -> Data,
+    write networkWrite: @Sendable (Data) async throws -> Void
+  ) async throws -> Data {
+    guard let ssl else { throw Ocp1Error.notConnected }
+    if !handshakeComplete {
+      try await handshake(read: networkRead, write: networkWrite)
+    }
+    return try await clearingOpenSSLErrors {
+      var result = Data()
+      result.reserveCapacity(count)
+      var buffer = [UInt8](repeating: 0, count: count)
+      while result.count < count {
+        let want = count - result.count
+        let ret = buffer.withUnsafeMutableBufferPointer { buf -> CInt in
+          SSL_read(ssl, buf.baseAddress, CInt(want))
+        }
+        try await drainOutbound(write: networkWrite)
+        if ret > 0 {
+          result.append(contentsOf: buffer.prefix(Int(ret)))
+          continue
+        }
+        try await serviceWantSignal(ret: ret, read: networkRead, write: networkWrite)
+      }
+      return result
+    }
+  }
+
+  package func write(
+    _ data: Data,
+    read networkRead: @Sendable (Int) async throws -> Data,
+    write networkWrite: @Sendable (Data) async throws -> Void
+  ) async throws -> Int {
+    guard let ssl else { throw Ocp1Error.notConnected }
+    if !handshakeComplete {
+      try await handshake(read: networkRead, write: networkWrite)
+    }
+    return try await clearingOpenSSLErrors {
+      var written = 0
+      while written < data.count {
+        let remaining = data.count - written
+        let ret = data.withUnsafeBytes { raw -> CInt in
+          let base = raw.bindMemory(to: UInt8.self).baseAddress!.advanced(by: written)
+          return SSL_write(ssl, base, CInt(remaining))
+        }
+        try await drainOutbound(write: networkWrite)
+        if ret > 0 {
+          written += Int(ret)
+          continue
+        }
+        try await serviceWantSignal(ret: ret, read: networkRead, write: networkWrite)
+      }
+      return written
+    }
+  }
+
+  package func shutdown(
+    read networkRead: @Sendable (Int) async throws -> Data,
+    write networkWrite: @Sendable (Data) async throws -> Void
+  ) async throws {
+    guard let ssl, !closed else { return }
+    closed = true
+    await clearingOpenSSLErrors {
+      // Send close_notify; we don't currently surface SSL_shutdown's
+      // 1 / 0 / <0 result to callers. Truncation-attack detection happens
+      // on the read side via SSL_R_UNEXPECTED_EOF_WHILE_READING.
+      _ = SSL_shutdown(ssl)
+      try? await drainOutbound(write: networkWrite)
+    }
+  }
+
+  /// Reset for a fresh handshake, reusing the existing `SSL_CTX`. Called
+  /// at the start of every `connectDevice` (including reconnect retries)
+  /// so an aborted handshake can't leak state into the next attempt.
+  package func reset() {
+    guard let ssl else { return }
+    if let rbio { _ = COpenSSL_BIO_reset(rbio) }
+    if let wbio { _ = COpenSSL_BIO_reset(wbio) }
+    _ = SSL_clear(ssl)
+    handshakeComplete = false
+    closed = false
+    // SSL_clear drops the connect/accept state set at init; restore it.
+    switch mode {
+    case .client: SSL_set_connect_state(ssl)
+    case .server: SSL_set_accept_state(ssl)
+    }
+    pskStore.clearAuthenticatedPSKIdentity()
+  }
+
+  package var isHandshakeComplete: Bool { handshakeComplete }
+
+  package var isDatagram: Bool { transport == .datagram }
+
+  /// Peer's authenticated identity. Returns `.anonymous` before handshake
+  /// completion or when neither PSK nor cert auth produced a binding.
+  package func peerIdentity() -> OcaPeerIdentity {
+    guard handshakeComplete else { return .anonymous }
+    if let psk = pskStore.capturedPSKIdentity() {
+      return .preSharedKey(identity: psk)
+    }
+    if let ssl, let cert = COpenSSL_SSL_get_peer_certificate(ssl) {
+      defer { X509_free(cert) }
+      let subject = Self.x509SubjectString(cert) ?? ""
+      let fingerprint = Self.x509SHA256Fingerprint(cert) ?? ""
+      if !subject.isEmpty || !fingerprint.isEmpty {
+        return .certificate(subject: subject, fingerprint: fingerprint)
+      }
+    }
+    return .anonymous
+  }
+
+  /// Legacy `/CN=alice/O=Acme` form via `X509_NAME_oneline` — good enough
+  /// for ACL matching and log output.
+  private static func x509SubjectString(_ cert: OpaquePointer) -> String? {
+    guard let name = X509_get_subject_name(cert) else { return nil }
+    guard let raw = X509_NAME_oneline(name, nil, 0) else { return nil }
+    defer { CRYPTO_free(raw, #file, #line) }
+    return String(cString: raw)
+  }
+
+  /// Lower-case hex SHA-256 fingerprint of the DER cert. Stable ACL key.
+  private static func x509SHA256Fingerprint(_ cert: OpaquePointer) -> String? {
+    var buf = [UInt8](repeating: 0, count: 32)
+    var len: CUnsignedInt = 32
+    let ok = buf.withUnsafeMutableBufferPointer { p -> CInt in
+      COpenSSL_X509_digest_sha256(cert, p.baseAddress, &len)
+    }
+    guard ok == 1, len > 0 else { return nil }
+    return buf.prefix(Int(len)).map { String(format: "%02x", $0) }.joined()
+  }
+
+  // MARK: - DTLS client-side datagram read
+
+  /// Block until one decrypted DTLS record is available. Unlike the stream
+  /// `read` we don't loop to a byte count — DTLS preserves record
+  /// boundaries and OCP.1 PDUs are framed at that level.
+  package func readDatagram(
+    read networkRead: @Sendable (Int) async throws -> Data,
+    write networkWrite: @Sendable (Data) async throws -> Void
+  ) async throws -> Data {
+    guard let ssl else { throw Ocp1Error.notConnected }
+    if !handshakeComplete {
+      try await handshake(read: networkRead, write: networkWrite)
+    }
+    return try await clearingOpenSSLErrors {
+      var buffer = [UInt8](repeating: 0, count: Self.readBufferSize)
+      while true {
+        let ret = buffer.withUnsafeMutableBufferPointer { buf -> CInt in
+          SSL_read(ssl, buf.baseAddress, CInt(buf.count))
+        }
+        try await drainOutbound(write: networkWrite)
+        if ret > 0 {
+          return Data(buffer.prefix(Int(ret)))
+        }
+        try await serviceWantSignal(ret: ret, read: networkRead, write: networkWrite)
+      }
+    }
+  }
+
+  // MARK: - DTLS server-side ingest
+
+  /// Ingest one peer datagram (the endpoint demultiplexes by source).
+  /// Returns the decrypted application payload, or `nil` if the datagram
+  /// was purely handshake.
+  package func ingestDatagram(
+    _ data: Data,
+    write networkWrite: @Sendable (Data) async throws -> Void
+  ) async throws -> Data? {
+    guard let ssl, let rbio else { throw Ocp1Error.notConnected }
+    return try await clearingOpenSSLErrors {
+      if !data.isEmpty {
+        _ = data.withUnsafeBytes { raw -> CInt in
+          BIO_write(rbio, raw.baseAddress, CInt(data.count))
+        }
+      }
+      if !handshakeComplete {
+        let ret = SSL_do_handshake(ssl)
+        try await drainOutbound(write: networkWrite)
+        if ret == 1 {
+          handshakeComplete = true
+        } else {
+          let err = SSL_get_error(ssl, ret)
+          switch err {
+          case SSL_ERROR_WANT_READ, SSL_ERROR_WANT_WRITE:
+            return nil
+          default:
+            throw Ocp1OpenSSLError(code: err, detail: Self.collectErrorMessages())
+          }
+        }
+      }
+      // One DTLS record == one application datagram, so the first non-zero
+      // SSL_read returns the whole payload.
+      var buffer = [UInt8](repeating: 0, count: Self.readBufferSize)
+      let n = buffer.withUnsafeMutableBufferPointer { buf -> CInt in
+        SSL_read(ssl, buf.baseAddress, CInt(buf.count))
+      }
+      try await drainOutbound(write: networkWrite)
+      if n > 0 {
+        return Data(buffer.prefix(Int(n)))
+      }
+      let err = SSL_get_error(ssl, n)
+      switch err {
+      case SSL_ERROR_WANT_READ, SSL_ERROR_WANT_WRITE:
+        return nil
+      case SSL_ERROR_ZERO_RETURN:
+        throw Ocp1Error.notConnected
+      default:
+        throw Ocp1OpenSSLError(code: err, detail: Self.collectErrorMessages())
+      }
+    }
+  }
+
+  /// Drive any pending DTLS retransmit. Returns the underlying
+  /// `DTLSv1_handle_timeout` result (1 = retransmitted, 0 = no timeout, < 0 = error).
+  @discardableResult
+  package func handleDatagramTimeout(
+    write networkWrite: @Sendable (Data) async throws -> Void
+  ) async throws -> Int32 {
+    guard let ssl else { return -1 }
+    let r = COpenSSL_DTLSv1_handle_timeout(ssl)
+    try await drainOutbound(write: networkWrite)
+    return Int32(r)
+  }
+
+  // MARK: - Transport internals
+
+  /// Copy pending outbound ciphertext from `wbio` to the transport. For
+  /// DTLS, one drain cycle can hold several back-to-back records; we split
+  /// at the 13-byte DTLS record header so each ships in its own datagram.
+  private func drainOutbound(
+    write networkWrite: @Sendable (Data) async throws -> Void
+  ) async throws {
+    guard let wbio else { return }
+    while COpenSSL_BIO_pending(wbio) > 0 {
+      var buffer = [UInt8](repeating: 0, count: Self.readBufferSize)
+      let n = buffer.withUnsafeMutableBufferPointer { buf -> CInt in
+        BIO_read(wbio, buf.baseAddress, CInt(buf.count))
+      }
+      if n <= 0 { break }
+      let drained = Data(buffer.prefix(Int(n)))
+      if transport == .datagram {
+        try await sendDTLSRecords(drained, write: networkWrite)
+      } else {
+        try await networkWrite(drained)
+      }
+    }
+  }
+
+  /// Walk a drained `wbio` buffer as DTLS records, sending each as its own
+  /// datagram. A truncated trailing record falls back to a single send.
+  private func sendDTLSRecords(
+    _ buffer: Data,
+    write networkWrite: @Sendable (Data) async throws -> Void
+  ) async throws {
+    let headerSize = Self.dtlsRecordHeaderSize
+    let lengthOffset = Self.dtlsRecordLengthOffset
+    var offset = buffer.startIndex
+    while offset < buffer.endIndex {
+      let remaining = buffer.endIndex - offset
+      guard remaining >= headerSize else {
+        try await networkWrite(buffer.subdata(in: offset..<buffer.endIndex))
+        return
+      }
+      let lenHigh = Int(buffer[offset + lengthOffset])
+      let lenLow = Int(buffer[offset + lengthOffset + 1])
+      let recordLength = headerSize + ((lenHigh << 8) | lenLow)
+      guard remaining >= recordLength else {
+        try await networkWrite(buffer.subdata(in: offset..<buffer.endIndex))
+        return
+      }
+      try await networkWrite(buffer.subdata(in: offset..<offset + recordLength))
+      offset += recordLength
+    }
+  }
+
+  /// Advance the transport in whichever direction OpenSSL last signaled;
+  /// throw on terminal errors. WANT_READ pulls from the network and feeds
+  /// `rbio`; WANT_WRITE drains `wbio`; ZERO_RETURN is close_notify.
+  private func serviceWantSignal(
+    ret: CInt,
+    read networkRead: @Sendable (Int) async throws -> Data,
+    write networkWrite: @Sendable (Data) async throws -> Void
+  ) async throws {
+    guard let ssl else { throw Ocp1Error.notConnected }
+    let err = SSL_get_error(ssl, ret)
+    switch err {
+    case SSL_ERROR_WANT_READ:
+      let chunk = try await networkRead(Self.readBufferSize)
+      if chunk.isEmpty {
+        throw Ocp1Error.notConnected
+      }
+      _ = chunk.withUnsafeBytes { raw -> CInt in
+        BIO_write(rbio, raw.baseAddress, CInt(chunk.count))
+      }
+    case SSL_ERROR_WANT_WRITE:
+      try await drainOutbound(write: networkWrite)
+    case SSL_ERROR_ZERO_RETURN:
+      throw Ocp1Error.notConnected
+    default:
+      throw Ocp1OpenSSLError(code: err, detail: Self.collectErrorMessages())
+    }
+  }
+
+  // MARK: - One-time setup helpers
+
+  private static func configureCredential(
+    ctx: OpaquePointer,
+    credential: Ocp1TLSCredential
+  ) throws {
+    switch credential {
+    case .preSharedKey, .preSharedKeyProvider:
+      // Restrict TLS 1.2 to PSK suites — without a configured cert, cert
+      // suites would just fail. TLS 1.3 PSK uses its own session pinning.
+      _ = SSL_CTX_set_cipher_list(ctx, Ocp1OpenSSLPSKCipherList)
+    case let .certificateFile(certPath, keyPath):
+      try certPath.withCString { cert in
+        try throwingOpenSSLError { SSL_CTX_use_certificate_chain_file(ctx, cert) }
+      }
+      try keyPath.withCString { key in
+        try throwingOpenSSLError { SSL_CTX_use_PrivateKey_file(ctx, key, SSL_FILETYPE_PEM) }
+      }
+      try throwingOpenSSLError { SSL_CTX_check_private_key(ctx) }
+      try throwingOpenSSLError { SSL_CTX_set_cipher_list(ctx, Ocp1OpenSSLCertCipherList) }
+    case let .certificatePEM(certificate, privateKey):
+      try configurePEMInMemory(ctx: ctx, certificate: certificate, privateKey: privateKey)
+      try throwingOpenSSLError { SSL_CTX_set_cipher_list(ctx, Ocp1OpenSSLCertCipherList) }
+    case let .pkcs12(data, password):
+      try configurePKCS12(ctx: ctx, data: data, password: password)
+      try throwingOpenSSLError { SSL_CTX_set_cipher_list(ctx, Ocp1OpenSSLCertCipherList) }
+    #if canImport(Security)
+    case .identity:
+      throw Ocp1Error.unknownServiceType
+    #endif
+    }
+  }
+
+  private static func configurePEMInMemory(
+    ctx: OpaquePointer,
+    certificate: Data,
+    privateKey: Data
+  ) throws {
+    try certificate.withUnsafeBytes { certBytes in
+      let certBio = try throwingOpenSSLError {
+        BIO_new_mem_buf(certBytes.baseAddress, CInt(certBytes.count))
+      }
+      defer { BIO_free(certBio) }
+      let cert = try throwingOpenSSLError { PEM_read_bio_X509(certBio, nil, nil, nil) }
+      defer { X509_free(cert) }
+      try throwingOpenSSLError { SSL_CTX_use_certificate(ctx, cert) }
+      // Pick up any intermediate certs appended to the same PEM blob.
+      // `add_extra_chain_cert` takes ownership on success; we free on failure.
+      while let extra = PEM_read_bio_X509(certBio, nil, nil, nil) {
+        do {
+          try throwingOpenSSLError { COpenSSL_SSL_CTX_add_extra_chain_cert(ctx, extra) }
+        } catch {
+          X509_free(extra)
+          throw error
+        }
+      }
+    }
+    try privateKey.withUnsafeBytes { keyBytes in
+      let keyBio = try throwingOpenSSLError {
+        BIO_new_mem_buf(keyBytes.baseAddress, CInt(keyBytes.count))
+      }
+      defer { BIO_free(keyBio) }
+      let pkey = try throwingOpenSSLError { PEM_read_bio_PrivateKey(keyBio, nil, nil, nil) }
+      defer { EVP_PKEY_free(pkey) }
+      try throwingOpenSSLError { SSL_CTX_use_PrivateKey(ctx, pkey) }
+    }
+    try throwingOpenSSLError { SSL_CTX_check_private_key(ctx) }
+  }
+
+  private static func configurePKCS12(
+    ctx: OpaquePointer,
+    data: Data,
+    password: String?
+  ) throws {
+    try data.withUnsafeBytes { raw in
+      let bio = try throwingOpenSSLError { BIO_new_mem_buf(raw.baseAddress, CInt(raw.count)) }
+      defer { BIO_free(bio) }
+      let p12 = try throwingOpenSSLError { d2i_PKCS12_bio(bio, nil) }
+      defer { PKCS12_free(p12) }
+
+      var pkey: OpaquePointer?
+      var cert: OpaquePointer?
+      var chain: OpaquePointer?
+      // Owned C buffer wipeable via OPENSSL_cleanse; no intermediate Swift
+      // Array copy of the password survives parse.
+      let pwUTF8 = (password ?? "").utf8
+      let pwLen = pwUTF8.count
+      let pwBuf = UnsafeMutableBufferPointer<CChar>.allocate(capacity: pwLen + 1)
+      defer {
+        OPENSSL_cleanse(UnsafeMutableRawPointer(pwBuf.baseAddress), pwLen + 1)
+        pwBuf.deallocate()
+      }
+      pwBuf.baseAddress!.withMemoryRebound(to: UInt8.self, capacity: pwLen + 1) { dest in
+        var i = 0
+        for byte in pwUTF8 {
+          dest[i] = byte
+          i += 1
+        }
+        dest[i] = 0
+      }
+      try throwingOpenSSLError { PKCS12_parse(p12, pwBuf.baseAddress, &pkey, &cert, &chain) }
+      defer {
+        if let pkey { EVP_PKEY_free(pkey) }
+        if let cert { X509_free(cert) }
+        if let chain { COpenSSL_sk_X509_pop_free(UnsafeMutableRawPointer(chain)) }
+      }
+      guard let pkey, let cert else {
+        throw Ocp1OpenSSLError(code: 0, detail: collectErrorMessages())
+      }
+      try throwingOpenSSLError { SSL_CTX_use_certificate(ctx, cert) }
+      try throwingOpenSSLError { SSL_CTX_use_PrivateKey(ctx, pkey) }
+      try throwingOpenSSLError { SSL_CTX_check_private_key(ctx) }
+      if let chain {
+        let chainPtr = UnsafeMutableRawPointer(chain)
+        let count = COpenSSL_sk_X509_num(chainPtr)
+        for i in 0..<count {
+          guard let intermediate = COpenSSL_sk_X509_value(chainPtr, i) else { continue }
+          // Chain owns the original ref; SSL_CTX_add_extra_chain_cert takes
+          // ownership of ours on success, otherwise we free it.
+          _ = X509_up_ref(intermediate)
+          do {
+            try throwingOpenSSLError {
+              COpenSSL_SSL_CTX_add_extra_chain_cert(ctx, intermediate)
+            }
+          } catch {
+            X509_free(intermediate)
+            throw error
+          }
+        }
+      }
+    }
+  }
+
+  /// Run an OpenSSL call returning the standard `1`-on-success integer and
+  /// throw `Ocp1OpenSSLError` carrying the queued diagnostics otherwise.
+  /// Generic over `FixedWidthInteger` so `int`-returning and the `long`-
+  /// returning `SSL_CTX_ctrl` macros both flow through the same helper.
+  ///
+  /// Clears the thread-local error queue before `body()` so that on failure
+  /// the surfaced diagnostics are only this call's — defends against
+  /// stale entries left on the same cooperative-pool thread by other tasks.
+  private static func throwingOpenSSLError(
+    _ body: () throws -> some FixedWidthInteger
+  ) throws {
+    ERR_clear_error()
+    guard try body() == 1 else {
+      throw Ocp1OpenSSLError(code: 0, detail: collectErrorMessages())
+    }
+  }
+
+  /// Run an OpenSSL call returning an optional pointer; unwrap on success
+  /// or throw `Ocp1OpenSSLError`.
+  private static func throwingOpenSSLError<T>(_ body: () throws -> T?) throws -> T {
+    ERR_clear_error()
+    guard let result = try body() else {
+      throw Ocp1OpenSSLError(code: 0, detail: collectErrorMessages())
+    }
+    return result
+  }
+
+  fileprivate static func collectErrorMessages() -> String {
+    var messages: [String] = []
+    var buf = [CChar](repeating: 0, count: 256)
+    while true {
+      let code = ERR_get_error()
+      if code == 0 { break }
+      ERR_error_string_n(code, &buf, buf.count)
+      let trimmed = buf.prefix(while: { $0 != 0 }).map { UInt8(bitPattern: $0) }
+      messages.append(String(decoding: trimmed, as: UTF8.self))
+    }
+    if messages.isEmpty {
+      return "(no detail in OpenSSL error queue)"
+    }
+    return messages.joined(separator: "; ")
+  }
+}
+
+package struct Ocp1OpenSSLError: Error, CustomStringConvertible, Sendable {
+  package let code: CInt
+  package let detail: String
+
+  package var description: String {
+    detail.isEmpty ? "OpenSSL error (\(code))" : "OpenSSL error (\(code)): \(detail)"
+  }
+}
+
+#endif

--- a/Sources/SwiftOCASecure/OCP.1/OcaPreSharedKeyProvider.swift
+++ b/Sources/SwiftOCASecure/OCP.1/OcaPreSharedKeyProvider.swift
@@ -1,0 +1,37 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+/// Sync, thread-safe lookup interface for TLS pre-shared keys. The OpenSSL
+/// PSK callback fires inside `SSL_do_handshake` and can't `await`, so the
+/// engine queries the provider directly; holding a reference (rather than
+/// snapshotting) lets later store updates take effect on the next handshake
+/// without copying secrets out of canonical storage.
+public protocol OcaPreSharedKeyProvider: Sendable {
+  /// Synchronously look up the PSK for `identity` and pass it to `body`.
+  /// Returns `nil` (without invoking `body`) if no key is registered.
+  /// Implementations MUST keep the buffer valid only for the call, and MUST
+  /// be safe to call concurrently.
+  func withPreSharedKey<T>(
+    forIdentity identity: String,
+    _ body: (UnsafeBufferPointer<UInt8>) throws -> T
+  ) rethrows -> T?
+}

--- a/Sources/SwiftOCASecure/OCP.1/Ocp1TLSTypes.swift
+++ b/Sources/SwiftOCASecure/OCP.1/Ocp1TLSTypes.swift
@@ -1,0 +1,153 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+#if canImport(Security)
+@preconcurrency import Security
+#endif
+import SwiftOCA
+
+/// Connection-prefix shown in logging for TLS-secured TCP transports.
+public let OcaSecureTcpConnectionPrefix = "ocasec/tcp"
+/// Connection-prefix shown in logging for DTLS-secured UDP transports.
+public let OcaSecureUdpConnectionPrefix = "ocasec/udp"
+
+/// Credential for OCP.1 TLS authentication. AES70-2024 mandates
+/// `TLS_DHE_PSK_WITH_AES_128_CBC_SHA` with PSK identity hint `OCA-PSK`; the
+/// cert-based variants are for future / non-spec deployments.
+public enum Ocp1TLSCredential: Sendable {
+  /// Raw PSK bytes embedded in the credential. Prefer
+  /// `.preSharedKeyProvider` when the key lives in secure storage —
+  /// otherwise the bytes sit in caller-visible heap for the whole
+  /// connection lifetime (and, on Apple, are copied into `DispatchData`).
+  case preSharedKey(identity: String, key: Data)
+
+  /// PSK fetched on-demand via an `OcaPreSharedKeyProvider`, so the bytes
+  /// stay in caller-controlled storage. The TLS backend may still make its
+  /// own internal copy.
+  case preSharedKeyProvider(identity: String, provider: any OcaPreSharedKeyProvider)
+
+  #if canImport(Security)
+  /// TLS certificate identity from Security.framework (Apple platforms).
+  case identity(SecIdentity)
+  #endif
+
+  /// PEM-encoded certificate and private key file paths.
+  case certificateFile(certPath: String, keyPath: String)
+
+  /// PEM-encoded certificate and private key in memory.
+  case certificatePEM(certificate: Data, privateKey: Data)
+
+  /// PKCS#12-encoded certificate and private key.
+  case pkcs12(data: Data, password: String?)
+}
+
+/// Well-known PSK identity hint advertised by AES70 devices (`OCA-PSK`).
+public let OcaPreSharedKeyIdentityHint: String = "OCA-PSK"
+
+/// Minimum acceptable PSK length, in bytes (RFC 9257 §6's 128-bit floor).
+public let OcaMinimumPreSharedKeyLength: Int = 16
+
+public extension Ocp1TLSCredential {
+  /// Reject weak PSK configuration up front; cert variants surface their
+  /// parse / load failures separately at the backend layer.
+  func validate() throws {
+    switch self {
+    case let .preSharedKey(identity, key):
+      guard !identity.isEmpty else {
+        throw Ocp1Error.status(.parameterError)
+      }
+      guard key.count >= OcaMinimumPreSharedKeyLength else {
+        throw Ocp1Error.status(.parameterError)
+      }
+    case let .preSharedKeyProvider(identity, provider):
+      guard !identity.isEmpty else {
+        throw Ocp1Error.status(.parameterError)
+      }
+      // Length-check via the provider without keeping a copy.
+      let ok = provider.withPreSharedKey(forIdentity: identity) { keyBuf in
+        keyBuf.count >= OcaMinimumPreSharedKeyLength
+      }
+      guard ok == true else {
+        throw Ocp1Error.status(.parameterError)
+      }
+    default:
+      break
+    }
+  }
+}
+
+/// Source of TLS trust anchors. `nil` on a connection means "use the
+/// platform default"; supply a value to re-root trust at a private CA.
+public enum Ocp1TLSTrustRoots: Sendable {
+  /// PEM CA bundle on disk.
+  case caFile(String)
+  /// PEM CA bundle held in memory.
+  case caData(Data)
+}
+
+/// CRL bundle for OpenSSL revocation checking. Apple ignores this — its
+/// Security.framework fetches CRL/OCSP responses itself.
+public enum Ocp1TLSCRLBundle: Sendable {
+  /// PEM-encoded CRL(s) on disk.
+  case crlFile(String)
+  /// PEM-encoded CRL(s) in memory.
+  case crlData(Data)
+}
+
+/// Opt-in revocation checking. Empty flags = disabled.
+public struct Ocp1TLSRevocationOptions: Sendable {
+  public struct Flags: OptionSet, Sendable {
+    public let rawValue: UInt
+    public init(rawValue: UInt) { self.rawValue = rawValue }
+
+    /// Master switch. Apple: soft-fail `SecPolicyCreateRevocation`.
+    /// OpenSSL: arms `CRL_CHECK` when `crls` are supplied.
+    public static let enabled = Flags(rawValue: 1 << 0)
+
+    /// CRL-check intermediates too (OpenSSL `X509_V_FLAG_CRL_CHECK_ALL`).
+    /// Requires every intermediate's CRL in the bundle. Ignored on Apple.
+    public static let checkChain = Flags(rawValue: 1 << 1)
+
+    /// Strictest opt-in: enable + chain-wide check. Preferred for new code.
+    public static let strict: Flags = [.enabled, .checkChain]
+  }
+
+  public var flags: Flags
+
+  /// CRLs to load into the OpenSSL trust store. Ignored on Apple
+  /// (Security.framework fetches CRL/OCSP itself).
+  public var crls: Ocp1TLSCRLBundle?
+
+  public static let disabled = Self(flags: [], crls: nil)
+
+  public init(flags: Flags = [], crls: Ocp1TLSCRLBundle? = nil) {
+    self.flags = flags
+    self.crls = crls
+  }
+}
+
+#if canImport(Network)
+public typealias Ocp1TLSStreamConnection = Ocp1NWSecureTCPConnection
+public typealias Ocp1TLSDatagramConnection = Ocp1NWSecureUDPConnection
+#elseif canImport(COpenSSL) && canImport(IORing)
+public typealias Ocp1TLSStreamConnection = Ocp1OpenSSLConnection
+public typealias Ocp1TLSDatagramConnection = Ocp1OpenSSLDTLSConnection
+#endif

--- a/Sources/SwiftOCASecureDevice/OCC/ControlClasses/Managers/OcaSecurityManager+OcaPreSharedKeyProvider.swift
+++ b/Sources/SwiftOCASecureDevice/OCC/ControlClasses/Managers/OcaSecurityManager+OcaPreSharedKeyProvider.swift
@@ -1,0 +1,67 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+import SwiftOCA
+import SwiftOCADevice
+import SwiftOCASecure
+
+/// Bridges `OcaSecurityManager`'s PSK store to the TLS engine. Lives in
+/// `SwiftOCASecureDevice` so `SwiftOCADevice` doesn't depend on TLS.
+extension SwiftOCADevice.OcaSecurityManager: OcaPreSharedKeyProvider {
+  public nonisolated func withPreSharedKey<T>(
+    forIdentity identity: String,
+    _ body: (UnsafeBufferPointer<UInt8>) throws -> T
+  ) rethrows -> T? {
+    // Copy the PSK bytes into a fresh non-COW heap buffer while holding
+    // the lock, then drop the lock and invoke `body` against that buffer.
+    // Two reasons for the extra copy:
+    //   1. No parallel `Data` reference escapes the lock, so `_add` /
+    //      `_delete` always see refcount=1 when they wipe and can clear
+    //      the stored bytes deterministically — Swift `Data`'s COW would
+    //      otherwise redirect the wipe to a temporary copy.
+    //   2. The local buffer is uniquely owned, so we can OPENSSL_cleanse-
+    //      equivalent wipe it before deallocation, bounding plaintext PSK
+    //      lifetime to the handshake that requested it.
+    let copy: UnsafeMutableBufferPointer<UInt8>? = _preSharedKeys.withLock { dict in
+      guard let data = dict[identity] else { return nil }
+      let buf = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: data.count)
+      data.withUnsafeBytes { src in
+        if let base = src.bindMemory(to: UInt8.self).baseAddress,
+           let dst = buf.baseAddress {
+          dst.update(from: base, count: data.count)
+        }
+      }
+      return buf
+    }
+    guard let copy else { return nil }
+    defer {
+      UnsafeMutableRawBufferPointer(copy).initializeMemory(as: UInt8.self, repeating: 0)
+      copy.deallocate()
+    }
+    return try body(UnsafeBufferPointer(copy))
+  }
+
+  /// Configured PSK identities — used for the Bonjour
+  /// `securityKeyIdentities` advertisement.
+  public nonisolated var preSharedKeyIdentities: [OcaString] {
+    _preSharedKeys.withLock { Array($0.keys) }
+  }
+}

--- a/Sources/SwiftOCASecureDevice/OCP.1/Backend/Network/Ocp1NWPeerIdentity.swift
+++ b/Sources/SwiftOCASecureDevice/OCP.1/Backend/Network/Ocp1NWPeerIdentity.swift
@@ -1,0 +1,53 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(Network)
+
+import CryptoKit
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+import Network
+@preconcurrency import Security
+import SwiftOCA
+
+/// Peer identity from a `.ready` `NWConnection`'s TLS metadata. Returns
+/// `.anonymous` for PSK handshakes — Network.framework's public API doesn't
+/// expose the negotiated PSK identity (only the locally-configured list).
+func Ocp1NWExtractPeerIdentity(from connection: NWConnection) -> OcaPeerIdentity {
+  guard
+    let raw = connection.metadata(definition: NWProtocolTLS.definition),
+    let tlsMeta = raw as? NWProtocolTLS.Metadata
+  else {
+    return .anonymous
+  }
+  let sec = tlsMeta.securityProtocolMetadata
+
+  var leaf: SecCertificate?
+  sec_protocol_metadata_access_peer_certificate_chain(sec, { cert in
+    if leaf == nil { leaf = sec_certificate_copy_ref(cert).takeRetainedValue() }
+  })
+  guard let leaf else { return .anonymous }
+  let subject = (SecCertificateCopySubjectSummary(leaf) as String?) ?? ""
+  let der = SecCertificateCopyData(leaf) as Data
+  let fp = SHA256.hash(data: der).map { String(format: "%02x", $0) }.joined()
+  if subject.isEmpty, fp.isEmpty { return .anonymous }
+  return .certificate(subject: subject, fingerprint: fp)
+}
+
+#endif

--- a/Sources/SwiftOCASecureDevice/OCP.1/Backend/Network/Ocp1NWSecureTCPDeviceEndpoint.swift
+++ b/Sources/SwiftOCASecureDevice/OCP.1/Backend/Network/Ocp1NWSecureTCPDeviceEndpoint.swift
@@ -1,0 +1,130 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(Network)
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+import Logging
+import Network
+#if canImport(Security)
+@preconcurrency import Security
+#endif
+@_spi(SwiftOCAPrivate)
+import SwiftOCADevice
+import SwiftOCASecure
+@_spi(SwiftOCAPrivate)
+import SwiftOCA
+
+/// TLS-secured OCP.1 stream device endpoint via Apple's Network.framework.
+/// The optional `credential` is the server's cert; PSKs come from the
+/// device's `OcaSecurityManager` at endpoint start (runtime
+/// `AddPreSharedKey` updates require a restart).
+@OcaDevice
+public final class Ocp1NWSecureTCPDeviceEndpoint: Ocp1NWStreamDeviceEndpoint {
+  private let serverCredential: Ocp1TLSCredential?
+  /// Non-nil enables mTLS — every client must present a cert that chains here.
+  private let clientCertificateTrustRoots: Ocp1TLSTrustRoots?
+  /// Pre-loaded at init so a bad CA bundle fails construction.
+  private let preloadedClientAnchors: [SecCertificate]?
+  /// Verify-block-time policy gate; returning `false` rejects the handshake
+  /// before `.ready` fires (e.g. for a subject/fingerprint allow-list).
+  private let clientCertificateValidator: Ocp1NWSecureTCPConnection
+    .PeerCertificateValidator?
+  private let revocation: Ocp1TLSRevocationOptions
+
+  public init(
+    port: UInt16,
+    credential: Ocp1TLSCredential? = nil,
+    clientCertificateTrustRoots: Ocp1TLSTrustRoots? = nil,
+    clientCertificateValidator: Ocp1NWSecureTCPConnection.PeerCertificateValidator? = nil,
+    revocation: Ocp1TLSRevocationOptions = .disabled,
+    timeout: Duration = OcaDevice.DefaultTimeout,
+    device: OcaDevice = OcaDevice.shared,
+    logger: Logger = Logger(label: "com.padl.SwiftOCASecureDevice.Ocp1NWSecureTCPDeviceEndpoint")
+  ) async throws {
+    // Validate before binding the listener so config errors don't pair
+    // with "mTLS enabled" log lines.
+    if let credential {
+      try credential.validate()
+      try credential.validateAppleLoad()
+    }
+    let preloadedAnchors = try Ocp1NWSecureTCPConnection.loadAnchorCertificates(
+      from: clientCertificateTrustRoots
+    )
+    serverCredential = credential
+    self.clientCertificateTrustRoots = clientCertificateTrustRoots
+    preloadedClientAnchors = preloadedAnchors
+    self.clientCertificateValidator = clientCertificateValidator
+    self.revocation = revocation
+    try await super.init(port: port, timeout: timeout, device: device, logger: logger)
+    if clientCertificateTrustRoots != nil {
+      logger.info("\(type(of: self)) requires client certificates (mTLS)")
+    }
+  }
+
+  /// Snapshot the peer identity onto each accepted controller once TLS
+  /// reaches `.ready`, so ACLs can read it without re-entering the actor.
+  override public nonisolated func peerIdentity(
+    for connection: NWConnection
+  ) -> OcaPeerIdentity? {
+    Ocp1NWExtractPeerIdentity(from: connection)
+  }
+
+  override public func makeParameters() async -> NWParameters {
+    let tls = NWProtocolTLS.Options()
+    let sec = tls.securityProtocolOptions
+    Ocp1TLSCredential.enforceMinimumTLSProtocol(sec)
+
+    if let serverCredential {
+      try? serverCredential.apply(to: sec)
+    }
+    if let securityManager = await device.securityManager {
+      for identity in securityManager.preSharedKeyIdentities {
+        Ocp1TLSCredential.configurePSK(sec, identity: identity, provider: securityManager)
+      }
+    }
+    if let anchors = preloadedClientAnchors {
+      // mTLS: require a client cert (without this it's optional) and
+      // anchor its chain to the supplied roots.
+      sec_protocol_options_set_peer_authentication_required(sec, true)
+      Ocp1NWSecureTCPConnection.installCustomTrustVerifyBlock(
+        sec,
+        anchors: anchors,
+        revocation: revocation,
+        peerValidator: clientCertificateValidator
+      )
+    }
+    return NWParameters(tls: tls, tcp: makeTCPOptions())
+  }
+
+  override public nonisolated var controllerConnectionPrefix: String {
+    OcaSecureTcpConnectionPrefix
+  }
+
+  override public nonisolated var controllerFlags: OcaControllerFlags {
+    [.supportsLocking, .hasTransportLayerSecurity]
+  }
+
+  override public nonisolated var serviceType: OcaNetworkAdvertisingServiceType {
+    .tcpSecure
+  }
+}
+
+#endif

--- a/Sources/SwiftOCASecureDevice/OCP.1/Backend/Network/Ocp1NWSecureUDPDeviceEndpoint.swift
+++ b/Sources/SwiftOCASecureDevice/OCP.1/Backend/Network/Ocp1NWSecureUDPDeviceEndpoint.swift
@@ -1,0 +1,122 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(Network)
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+import Logging
+import Network
+#if canImport(Security)
+@preconcurrency import Security
+#endif
+@_spi(SwiftOCAPrivate)
+import SwiftOCADevice
+import SwiftOCASecure
+@_spi(SwiftOCAPrivate)
+import SwiftOCA
+
+/// DTLS-secured OCP.1 datagram device endpoint. Sibling of
+/// `Ocp1NWSecureTCPDeviceEndpoint`; Network.framework spells DTLS as TLS
+/// options over UDP. PSKs come from the device's `OcaSecurityManager` at
+/// endpoint start (runtime `AddPreSharedKey` updates require a restart).
+@OcaDevice
+public final class Ocp1NWSecureUDPDeviceEndpoint: Ocp1NWDatagramDeviceEndpoint {
+  private let serverCredential: Ocp1TLSCredential?
+  /// Non-nil enables mTLS.
+  private let clientCertificateTrustRoots: Ocp1TLSTrustRoots?
+  /// Pre-loaded at init so a bad CA bundle fails construction.
+  private let preloadedClientAnchors: [SecCertificate]?
+  private let clientCertificateValidator: Ocp1NWSecureTCPConnection
+    .PeerCertificateValidator?
+  private let revocation: Ocp1TLSRevocationOptions
+
+  public init(
+    port: UInt16,
+    credential: Ocp1TLSCredential? = nil,
+    clientCertificateTrustRoots: Ocp1TLSTrustRoots? = nil,
+    clientCertificateValidator: Ocp1NWSecureTCPConnection.PeerCertificateValidator? = nil,
+    revocation: Ocp1TLSRevocationOptions = .disabled,
+    timeout: Duration = OcaDevice.DefaultTimeout,
+    device: OcaDevice = OcaDevice.shared,
+    logger: Logger = Logger(label: "com.padl.SwiftOCASecureDevice.Ocp1NWSecureUDPDeviceEndpoint")
+  ) async throws {
+    if let credential {
+      try credential.validate()
+      try credential.validateAppleLoad()
+    }
+    let preloadedAnchors = try Ocp1NWSecureTCPConnection.loadAnchorCertificates(
+      from: clientCertificateTrustRoots
+    )
+    serverCredential = credential
+    self.clientCertificateTrustRoots = clientCertificateTrustRoots
+    preloadedClientAnchors = preloadedAnchors
+    self.clientCertificateValidator = clientCertificateValidator
+    self.revocation = revocation
+    try await super.init(port: port, timeout: timeout, device: device, logger: logger)
+    if clientCertificateTrustRoots != nil {
+      logger.info("\(type(of: self)) requires client certificates (mTLS)")
+    }
+  }
+
+  override public nonisolated func peerIdentity(
+    for connection: NWConnection
+  ) -> OcaPeerIdentity? {
+    Ocp1NWExtractPeerIdentity(from: connection)
+  }
+
+  override public func makeParameters() async -> NWParameters {
+    let tls = NWProtocolTLS.Options()
+    let sec = tls.securityProtocolOptions
+    Ocp1TLSCredential.enforceMinimumTLSProtocol(sec)
+
+    if let serverCredential {
+      try? serverCredential.apply(to: sec)
+    }
+    if let securityManager = await device.securityManager {
+      for identity in securityManager.preSharedKeyIdentities {
+        Ocp1TLSCredential.configurePSK(sec, identity: identity, provider: securityManager)
+      }
+    }
+    if let anchors = preloadedClientAnchors {
+      sec_protocol_options_set_peer_authentication_required(sec, true)
+      Ocp1NWSecureTCPConnection.installCustomTrustVerifyBlock(
+        sec,
+        anchors: anchors,
+        revocation: revocation,
+        peerValidator: clientCertificateValidator
+      )
+    }
+    return NWParameters(dtls: tls, udp: NWProtocolUDP.Options())
+  }
+
+  override public nonisolated var controllerConnectionPrefix: String {
+    OcaSecureUdpConnectionPrefix
+  }
+
+  override public nonisolated var controllerFlags: OcaControllerFlags {
+    [.supportsLocking, .hasTransportLayerSecurity]
+  }
+
+  override public nonisolated var serviceType: OcaNetworkAdvertisingServiceType {
+    .udpSecure
+  }
+}
+
+#endif

--- a/Sources/SwiftOCASecureDevice/OCP.1/Backend/OpenSSL/IORingByteStream.swift
+++ b/Sources/SwiftOCASecureDevice/OCP.1/Backend/OpenSSL/IORingByteStream.swift
@@ -1,0 +1,43 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(COpenSSL) && canImport(IORing)
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+import IORing
+internal import IORingUtils
+
+/// `Ocp1ByteStream` adapter for an `IORing.Socket`. The fd closes when the
+/// wrapping struct is released, so `close()` is a no-op.
+struct IORingByteStream: Ocp1ByteStream {
+  let socket: Socket
+
+  func read(count: Int, awaitingAllRead: Bool) async throws -> Data {
+    try await Data(socket.read(count: count, awaitingAllRead: awaitingAllRead))
+  }
+
+  func write(_ data: Data) async throws {
+    _ = try await socket.write(Array(data), count: data.count, awaitingAllWritten: true)
+  }
+
+  func close() async {}
+}
+
+#endif

--- a/Sources/SwiftOCASecureDevice/OCP.1/Backend/OpenSSL/Ocp1ByteStream.swift
+++ b/Sources/SwiftOCASecureDevice/OCP.1/Backend/OpenSSL/Ocp1ByteStream.swift
@@ -1,0 +1,35 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+/// Stream-oriented transport the OpenSSL engine pumps `read`/`write` through.
+/// DTLS keeps its own UDP-aware abstraction — this one is TCP-like only.
+protocol Ocp1ByteStream: Sendable {
+  /// Read up to `count` bytes (or exactly `count` when `awaitingAllRead`).
+  /// Throws `Ocp1Error.notConnected` on EOF.
+  func read(count: Int, awaitingAllRead: Bool) async throws -> Data
+
+  /// Write all of `data`; throw on partial write or peer reset.
+  func write(_ data: Data) async throws
+
+  /// Idempotent close. Subsequent reads should throw `.notConnected`.
+  func close() async
+}

--- a/Sources/SwiftOCASecureDevice/OCP.1/Backend/OpenSSL/Ocp1DatagramChannel.swift
+++ b/Sources/SwiftOCASecureDevice/OCP.1/Backend/OpenSSL/Ocp1DatagramChannel.swift
@@ -1,0 +1,31 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+/// Outbound-only datagram channel bound to a single peer. The DTLS endpoint
+/// push-feeds inbound datagrams to `ingestDatagram(_:)` separately.
+protocol Ocp1DatagramChannel: Sendable {
+  /// Send one datagram to the bound peer.
+  func send(_ data: Data) async throws
+
+  /// Idempotent close. After close, `send` throws `.notConnected`.
+  func close() async
+}

--- a/Sources/SwiftOCASecureDevice/OCP.1/Backend/OpenSSL/Ocp1OpenSSLDTLSController.swift
+++ b/Sources/SwiftOCASecureDevice/OCP.1/Backend/OpenSSL/Ocp1OpenSSLDTLSController.swift
@@ -1,0 +1,193 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(COpenSSL) && canImport(IORing)
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+import AsyncExtensions
+public import IORing
+internal import IORingUtils
+import SocketAddress
+@_spi(SwiftOCAPrivate)
+import SwiftOCADevice
+import SwiftOCASecure
+@_spi(SwiftOCAPrivate)
+import SwiftOCA
+import struct SystemPackage.Errno
+import Synchronization
+
+/// Per-peer DTLS controller. The endpoint demuxes inbound datagrams by peer
+/// address and pushes each through `ingestDatagram`; the shared UDP socket
+/// is owned by the endpoint, so there's no per-controller receive loop.
+package actor Ocp1OpenSSLDTLSController: Ocp1ControllerInternal,
+  Ocp1ControllerDatagramSemantics,
+  CustomStringConvertible
+{
+  package nonisolated let flags: OcaControllerFlags
+  package nonisolated let connectionPrefix: String
+  package nonisolated let identifier: String
+  package nonisolated let peerAddress: AnySocketAddress
+  /// DTLS controllers are constructed before the handshake, so identity
+  /// starts `.anonymous` and is filled once `isHandshakeComplete` flips.
+  private let _peerIdentity = Mutex<OcaPeerIdentity>(.anonymous)
+  package nonisolated var peerIdentity: OcaPeerIdentity {
+    _peerIdentity.withLock { $0 }
+  }
+
+  package var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()
+  package var keepAliveTask: Task<(), Error>?
+  package var lastMessageReceivedTime = ContinuousClock.recentPast
+  package var lastMessageSentTime = ContinuousClock.recentPast
+  package private(set) var isOpen: Bool = false
+  package weak var endpoint: Ocp1OpenSSLDTLSDeviceEndpoint?
+
+  /// Used by the endpoint's idle GC; DTLS over UDP has no close signal,
+  /// so without it each touched peer would pin engine state forever.
+  private(set) var lastSeen: ContinuousClock.Instant = .now
+  /// Bounds how long a never-completed handshake can squat on a slot.
+  let createdAt: ContinuousClock.Instant = .now
+
+  private let engine: Ocp1OpenSSLEngine
+  private let datagramChannel: any Ocp1DatagramChannel
+  private var retransmitTask: Task<Void, Never>?
+
+  /// Endpoint feeds messages directly via `handle(messagePduData:from:)`;
+  /// no per-controller stream to consume.
+  package var messages: AnyAsyncSequence<Ocp1MessageList> {
+    AsyncEmptySequence<Ocp1MessageList>().eraseToAnyAsyncSequence()
+  }
+
+  package var heartbeatTime = Duration.seconds(1) {
+    didSet {
+      heartbeatTimeDidChange(from: oldValue)
+    }
+  }
+
+  init(
+    endpoint: Ocp1OpenSSLDTLSDeviceEndpoint,
+    peerAddress: AnySocketAddress,
+    engine: Ocp1OpenSSLEngine,
+    datagramChannel: any Ocp1DatagramChannel
+  ) {
+    self.endpoint = endpoint
+    self.peerAddress = peerAddress
+    self.engine = engine
+    self.datagramChannel = datagramChannel
+    flags = [.supportsLocking, .hasTransportLayerSecurity]
+    connectionPrefix = OcaSecureUdpConnectionPrefix
+    identifier = (try? peerAddress.presentationAddress) ?? "unknown"
+  }
+
+  /// Poll the engine's DTLS retransmit timer until handshake completion,
+  /// so a peer that goes silent mid-handshake doesn't strand pending records.
+  func startRetransmitWatchdog() {
+    guard retransmitTask == nil else { return }
+    let engine = engine
+    let channel = datagramChannel
+    retransmitTask = Task<Void, Never> {
+      while !Task.isCancelled {
+        try? await Task.sleep(for: .milliseconds(200))
+        if Task.isCancelled { return }
+        if await engine.isHandshakeComplete { return }
+        _ = try? await engine.handleDatagramTimeout { encrypted in
+          try await channel.send(encrypted)
+        }
+      }
+    }
+  }
+
+  /// Feed one inbound datagram through the engine. Returns plaintext when
+  /// the datagram completed application data, `nil` for pure handshake.
+  func ingestDatagram(_ data: Data) async throws -> Data? {
+    let channel = datagramChannel
+    lastSeen = .now
+    let plaintext = try await engine.ingestDatagram(data) { encrypted in
+      try await channel.send(encrypted)
+    }
+    // Snapshot the engine identity once so authz checks don't have to
+    // re-enter the engine actor.
+    if case .anonymous = peerIdentity, await engine.isHandshakeComplete {
+      let captured = await engine.peerIdentity()
+      _peerIdentity.withLock { $0 = captured }
+    }
+    return plaintext
+  }
+
+  /// `true` when the peer has been silent for at least `idleAfter`.
+  func isIdle(now: ContinuousClock.Instant, idleAfter: Duration) -> Bool {
+    now - lastSeen >= idleAfter
+  }
+
+  /// Surfaced so the endpoint's GC can evict stuck handshakes faster than
+  /// just-idle fully-authenticated peers.
+  func handshakeComplete() async -> Bool {
+    await engine.isHandshakeComplete
+  }
+
+  package func sendOcp1EncodedData(_ data: Data) async throws {
+    let channel = datagramChannel
+    _ = try await engine.write(
+      data,
+      // Post-handshake SSL_write should never need to pull bytes —
+      // DTLS doesn't renegotiate. Fail loudly if it ever does.
+      read: { _ in throw Ocp1Error.notConnected },
+      write: { encrypted in try await channel.send(encrypted) }
+    )
+  }
+
+  package func close() async throws {
+    retransmitTask?.cancel()
+    retransmitTask = nil
+    keepAliveTask?.cancel()
+    keepAliveTask = nil
+    await datagramChannel.close()
+  }
+
+  isolated deinit {
+    retransmitTask?.cancel()
+    keepAliveTask?.cancel()
+  }
+
+  package func didOpen() {
+    isOpen = true
+  }
+
+  package nonisolated var description: String {
+    "\(type(of: self))(\(identifier))"
+  }
+}
+
+extension Ocp1OpenSSLDTLSController: Equatable {
+  package nonisolated static func == (
+    lhs: Ocp1OpenSSLDTLSController,
+    rhs: Ocp1OpenSSLDTLSController
+  ) -> Bool {
+    lhs.peerAddress == rhs.peerAddress
+  }
+}
+
+extension Ocp1OpenSSLDTLSController: Hashable {
+  package nonisolated func hash(into hasher: inout Hasher) {
+    peerAddress.hash(into: &hasher)
+  }
+}
+
+#endif

--- a/Sources/SwiftOCASecureDevice/OCP.1/Backend/OpenSSL/Ocp1OpenSSLDTLSDeviceEndpoint.swift
+++ b/Sources/SwiftOCASecureDevice/OCP.1/Backend/OpenSSL/Ocp1OpenSSLDTLSDeviceEndpoint.swift
@@ -1,0 +1,445 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(COpenSSL) && canImport(IORing)
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+import Glibc
+public import IORing
+internal import IORingUtils
+import Logging
+import SocketAddress
+@_spi(SwiftOCAPrivate)
+import SwiftOCADevice
+import SwiftOCASecure
+@_spi(SwiftOCAPrivate)
+import SwiftOCA
+import struct SystemPackage.Errno
+
+/// DTLS-secured OCP.1 datagram device endpoint backed by OpenSSL on Linux.
+/// A single bound SOCK_DGRAM socket; inbound datagrams are demultiplexed by
+/// peer address into per-peer engines. HelloVerifyRequest cookie exchange
+/// runs in the engine but allocates per-peer state on the first ClientHello;
+/// `maxPeers`, the per-source rate limit, and the optional source-address
+/// filter below contain that exposure. We do *not* implement a stateless
+/// pre-cookie path — see Documentation/TLS.md for the rationale.
+public struct Ocp1OpenSSLDTLSEndpointOptions: Sendable {
+  /// Peers that don't finish the DTLS handshake within this window are
+  /// evicted by the GC sweep.
+  public var handshakeDeadline: Duration
+
+  /// Silence ceiling — peers evicted after this long without an inbound
+  /// datagram. GC floors against `heartbeatTime × 3` so a deployment with
+  /// long heartbeats doesn't trip on jitter.
+  public var idleTimeout: Duration
+
+  /// Soft cap on simultaneous peer engines; backstops the pre-cookie
+  /// ClientHello state-pinning vector.
+  public var maxPeers: Int
+
+  /// Pre-cookie source-address gate. Called once per new peer before any
+  /// per-peer engine is allocated; returning `false` drops the datagram.
+  /// `nil` accepts every source. The closure receives the raw `sockaddr`
+  /// bytes of the inbound peer so callers can implement subnet allowlists
+  /// or AF-specific rules.
+  public var sourceAddressFilter: (@Sendable (Data) -> Bool)?
+
+  /// IORing receive buffer pool size; `nil` uses the IORing default.
+  public var bufferCount: Int?
+
+  public init(
+    handshakeDeadline: Duration = .seconds(10),
+    idleTimeout: Duration = .seconds(300),
+    maxPeers: Int = 256,
+    sourceAddressFilter: (@Sendable (Data) -> Bool)? = nil,
+    bufferCount: Int? = nil
+  ) {
+    self.handshakeDeadline = handshakeDeadline
+    self.idleTimeout = idleTimeout
+    self.maxPeers = maxPeers
+    self.sourceAddressFilter = sourceAddressFilter
+    self.bufferCount = bufferCount
+  }
+}
+
+@OcaDevice
+public final class Ocp1OpenSSLDTLSDeviceEndpoint: Ocp1IORingDeviceEndpoint,
+  @preconcurrency OcaDeviceEndpointPrivate
+{
+  package typealias ControllerType = Ocp1OpenSSLDTLSController
+
+  private let serverCredential: Ocp1TLSCredential?
+  private let clientCertificateTrustRoots: Ocp1TLSTrustRoots?
+  private let _revocation: Ocp1TLSRevocationOptions
+  private var _serverPSKProvider: (any OcaPreSharedKeyProvider)?
+  private var _controllers: [AnySocketAddress: Ocp1OpenSSLDTLSController] = [:]
+  private let _options: Ocp1OpenSSLDTLSEndpointOptions
+  private let _firstMessageDeadline: Duration
+  private var _gcTask: Task<Void, Never>?
+
+  /// Per-source-IP engine allocation count for the current window — throttles
+  /// spoofed-source ClientHello floods, since OpenSSL allocates engine state
+  /// before its HelloVerifyRequest cookie callback fires. Keyed on IP only
+  /// (not IP+port) so attackers can't bypass by rotating source ports.
+  private var _perSourceAllocations: [String: Int] = [:]
+  private var _allocationWindowStart: ContinuousClock.Instant = .now
+  private static let allocationWindow: Duration = .seconds(10)
+  /// A legitimate peer only needs one allocation per window (it retries the
+  /// same flight inside the existing engine after cookie verify); 2 leaves
+  /// a small jitter margin for restart-and-reconnect races.
+  private static let maxAllocationsPerSourcePerWindow: Int = 2
+
+  override public var controllers: [OcaController] {
+    Array(_controllers.values)
+  }
+
+  public init(
+    address: any SocketAddress,
+    credential: Ocp1TLSCredential? = nil,
+    clientCertificateTrustRoots: Ocp1TLSTrustRoots? = nil,
+    revocation: Ocp1TLSRevocationOptions = .disabled,
+    timeout: Duration = OcaDevice.DefaultTimeout,
+    device: OcaDevice = OcaDevice.shared,
+    logger: Logger = Logger(label: "com.padl.SwiftOCASecureDevice.Ocp1OpenSSLDTLSDeviceEndpoint"),
+    options: Ocp1OpenSSLDTLSEndpointOptions = Ocp1OpenSSLDTLSEndpointOptions(),
+    firstMessageDeadline: Duration = .seconds(30),
+    ring: IORing = .shared
+  ) async throws {
+    if let credential {
+      try credential.validate()
+    }
+    try Ocp1OpenSSLEngine.validateTrustRoots(clientCertificateTrustRoots)
+    serverCredential = credential
+    self.clientCertificateTrustRoots = clientCertificateTrustRoots
+    _revocation = revocation
+    _options = options
+    _firstMessageDeadline = firstMessageDeadline
+
+    let socket = try Socket(
+      ring: ring,
+      domain: address.family,
+      type: Glibc.SOCK_DGRAM,
+      protocol: 0
+    )
+    if address.family == sa_family_t(AF_INET6) {
+      try socket.setIPv6Only()
+    }
+    try socket.bind(to: address)
+    let boundAddress = try socket.localAddress
+
+    try await super.init(
+      address: boundAddress,
+      timeout: timeout,
+      device: device,
+      logger: logger,
+      ring: ring
+    )
+    self.socket = socket
+  }
+
+  public convenience init(
+    port: UInt16,
+    credential: Ocp1TLSCredential? = nil,
+    clientCertificateTrustRoots: Ocp1TLSTrustRoots? = nil,
+    revocation: Ocp1TLSRevocationOptions = .disabled,
+    timeout: Duration = OcaDevice.DefaultTimeout,
+    device: OcaDevice = OcaDevice.shared,
+    logger: Logger = Logger(label: "com.padl.SwiftOCASecureDevice.Ocp1OpenSSLDTLSDeviceEndpoint"),
+    options: Ocp1OpenSSLDTLSEndpointOptions = Ocp1OpenSSLDTLSEndpointOptions(),
+    firstMessageDeadline: Duration = .seconds(30),
+    ring: IORing = .shared
+  ) async throws {
+    var sin = sockaddr_in()
+    sin.sin_family = sa_family_t(AF_INET)
+    sin.sin_port = port.bigEndian
+    sin.sin_addr.s_addr = UInt32(0).bigEndian // INADDR_ANY
+    try await self.init(
+      address: sin,
+      credential: credential,
+      clientCertificateTrustRoots: clientCertificateTrustRoots,
+      revocation: revocation,
+      timeout: timeout,
+      device: device,
+      logger: logger,
+      options: options,
+      firstMessageDeadline: firstMessageDeadline,
+      ring: ring
+    )
+  }
+
+  override public func run() async throws {
+    logger.info("starting \(type(of: self)) on \(address._presentationAddress)")
+    if clientCertificateTrustRoots != nil {
+      logger.info("\(type(of: self)) requires client certificates (mTLS)")
+    }
+    try await super.run()
+    _serverPSKProvider = await device.securityManager
+
+    guard let socket else {
+      throw Ocp1Error.notConnected
+    }
+
+    startGCSweep()
+
+    let receiveBufferSize = Ocp1MaximumDatagramPduSize
+
+    repeat {
+      do {
+        let messagePdus = try await socket.receiveMessages(
+          count: receiveBufferSize,
+          capacity: _options.bufferCount
+        )
+        for try await messagePdu in messagePdus {
+          let peerAddress = try AnySocketAddress(bytes: messagePdu.name)
+          let payload = Data(messagePdu.buffer)
+          guard let controller = try? controller(for: peerAddress) else { continue }
+          spawnPeerIngest(payload: payload, controller: controller, peerAddress: peerAddress)
+        }
+      } catch let error as Errno {
+        guard error == .canceled || error == .noBufferSpace else { throw error }
+      } catch {
+        logger.error(
+          "unexpected error \(error) in \(type(of: self)) on \(address._presentationAddress); no longer servicing"
+        )
+        throw error
+      }
+    } while !Task.isCancelled
+
+    _gcTask?.cancel()
+    _gcTask = nil
+    self.socket = nil
+    try await device.remove(endpoint: self)
+  }
+
+  /// Outbound datagram fan-in. Per-peer engines drain `wbio` through here.
+  func sendDatagram(_ data: Data, to peer: AnySocketAddress) async throws {
+    guard let socket else {
+      throw Ocp1Error.notConnected
+    }
+    try await socket.sendMessage(Message(address: peer, buffer: [UInt8](data)))
+  }
+
+  /// Spawn a Task that hands one datagram to its controller (serialised
+  /// there) and routes decrypted output back through the endpoint.
+  private nonisolated func spawnPeerIngest(
+    payload: Data,
+    controller: Ocp1OpenSSLDTLSController,
+    peerAddress: AnySocketAddress
+  ) {
+    Task { [weak self] in
+      guard let self else { return }
+      do {
+        let plaintext = try await controller.ingestDatagram(payload)
+        if let plaintext {
+          try await self.handle(messagePduData: plaintext, from: controller)
+        }
+      } catch {
+        await self.peerErrored(
+          controller: controller,
+          peerAddress: peerAddress,
+          error: error
+        )
+      }
+    }
+  }
+
+  private func controller(
+    for peerAddress: AnySocketAddress
+  ) throws -> Ocp1OpenSSLDTLSController? {
+    if let existing = _controllers[peerAddress] {
+      return existing
+    }
+    // Pre-cookie source filter — cheaper than per-source rate limiting,
+    // and runs before any allocation slot is consumed.
+    if let filter = _options.sourceAddressFilter, !filter(peerAddress.data) {
+      return nil
+    }
+    if !permitAllocation(for: peerAddress) {
+      logger.warning(
+        "DTLS allocation rate limit hit for \(peerAddress._presentationAddress); refusing"
+      )
+      return nil
+    }
+    if _controllers.count >= _options.maxPeers {
+      logger.warning(
+        "DTLS peer table at cap (\(_options.maxPeers)); refusing \(peerAddress._presentationAddress)"
+      )
+      creditAllocation(for: peerAddress)
+      return nil
+    }
+    let engine: Ocp1OpenSSLEngine
+    do {
+      engine = try Ocp1OpenSSLEngine(
+        mode: .server,
+        credential: serverCredential,
+        transport: .datagram,
+        serverPSKProvider: _serverPSKProvider,
+        clientTrustRoots: clientCertificateTrustRoots,
+        revocation: _revocation,
+        // Binds the HelloVerifyRequest cookie to the source address.
+        peerAddressBytes: peerAddress.data
+      )
+    } catch {
+      logger.warning("could not initialize DTLS engine for \(peerAddress._presentationAddress): \(error)")
+      creditAllocation(for: peerAddress)
+      return nil
+    }
+    let controller = Ocp1OpenSSLDTLSController(
+      endpoint: self,
+      peerAddress: peerAddress,
+      engine: engine,
+      datagramChannel: _EndpointDatagramChannel(endpoint: self, peer: peerAddress)
+    )
+    _controllers[peerAddress] = controller
+    Task { await controller.startRetransmitWatchdog() }
+    logger.info("DTLS controller added", controller: controller)
+    return controller
+  }
+
+  /// Returns `false` and refuses allocation when this source has exceeded
+  /// `maxAllocationsPerSourcePerWindow` within the current window. Fixed-
+  /// window rollover. Callers MUST `creditAllocation` when a successful
+  /// permit doesn't lead to an allocation (engine init throws, cap hit).
+  private func permitAllocation(for peerAddress: AnySocketAddress) -> Bool {
+    let now = ContinuousClock.now
+    if now - _allocationWindowStart >= Self.allocationWindow {
+      _perSourceAllocations.removeAll(keepingCapacity: true)
+      _allocationWindowStart = now
+    }
+    let key = allocationKey(for: peerAddress)
+    let current = _perSourceAllocations[key, default: 0]
+    if current >= Self.maxAllocationsPerSourcePerWindow {
+      return false
+    }
+    _perSourceAllocations[key] = current + 1
+    return true
+  }
+
+  /// Refund a slot consumed by `permitAllocation` when the allocation
+  /// didn't go through. Bounded at zero against stale post-rollover credits.
+  private func creditAllocation(for peerAddress: AnySocketAddress) {
+    let key = allocationKey(for: peerAddress)
+    if let current = _perSourceAllocations[key], current > 0 {
+      _perSourceAllocations[key] = current - 1
+    }
+  }
+
+  private func allocationKey(for peerAddress: AnySocketAddress) -> String {
+    (try? peerAddress.presentationAddressNoPort)
+      ?? (try? peerAddress.presentationAddress)
+      ?? ""
+  }
+
+  /// Log, remove the controller, and release any held resources via
+  /// `unlockAndRemove`.
+  private func peerErrored(
+    controller: Ocp1OpenSSLDTLSController,
+    peerAddress: AnySocketAddress,
+    error: Error
+  ) async {
+    logger.warning("DTLS peer \(peerAddress._presentationAddress) error: \(error)")
+    await unlockAndRemove(controller: controller)
+    _controllers.removeValue(forKey: peerAddress)
+  }
+
+  /// Periodic sweep: evicts peers stuck mid-handshake, authenticated peers
+  /// that never sent a KeepAlive, and peers that have gone silent. Cadence
+  /// is tied to `handshakeDeadline` so a stuck slot is reclaimed within
+  /// ~1.5× the deadline rather than the prior fixed 30 s (which was
+  /// 3× the new 10 s default).
+  private func startGCSweep() {
+    _gcTask?.cancel()
+    // Floor at 1 s so a misconfigured tiny deadline doesn't burn CPU.
+    let cadence = max(_options.handshakeDeadline / 2, .seconds(1))
+    _gcTask = Task<Void, Never> { [weak self] in
+      while !Task.isCancelled {
+        try? await Task.sleep(for: cadence)
+        if Task.isCancelled { return }
+        await self?.runGCSweep()
+      }
+    }
+  }
+
+  private enum EvictionReason: String {
+    case handshakeDeadline = "handshake-deadline"
+    case firstMessageDeadline = "first-message-deadline"
+    case idleTimeout = "idle-timeout"
+  }
+
+  private struct EvictionCandidate {
+    let peer: AnySocketAddress
+    let controller: Ocp1OpenSSLDTLSController
+    let reason: EvictionReason
+  }
+
+  private func runGCSweep() async {
+    let now = ContinuousClock.now
+    var victims: [EvictionCandidate] = []
+    for (peer, controller) in _controllers {
+      let completed = await controller.handshakeComplete()
+      let isOpen = await controller.isOpen
+      let lastSeen = await controller.lastSeen
+      let heartbeat = await controller.heartbeatTime
+      let createdAt = controller.createdAt
+      // Floor on three heartbeats so one missed heartbeat + jitter doesn't
+      // trip eviction.
+      let effectiveIdleTimeout = max(_options.idleTimeout, heartbeat * 3)
+      let reason: EvictionReason?
+      if !completed, now - createdAt >= _options.handshakeDeadline {
+        reason = .handshakeDeadline
+      } else if completed, !isOpen, now - createdAt >= _firstMessageDeadline {
+        reason = .firstMessageDeadline
+      } else if now - lastSeen >= effectiveIdleTimeout {
+        reason = .idleTimeout
+      } else {
+        reason = nil
+      }
+      if let reason {
+        victims.append(EvictionCandidate(peer: peer, controller: controller, reason: reason))
+      }
+    }
+    for victim in victims {
+      logger.info(
+        "DTLS GC evicting peer \(victim.peer._presentationAddress) (\(victim.reason.rawValue))"
+      )
+      await unlockAndRemove(controller: victim.controller)
+      _controllers.removeValue(forKey: victim.peer)
+    }
+  }
+
+  #if canImport(dnssd)
+  override public nonisolated var serviceType: OcaNetworkAdvertisingServiceType {
+    .udpSecure
+  }
+  #endif
+
+  package func add(controller: Ocp1OpenSSLDTLSController) async {
+    // Insertion happens in `controller(for:)`; this just satisfies the
+    // protocol surface.
+    _controllers[controller.peerAddress] = controller
+  }
+
+  package func remove(controller: Ocp1OpenSSLDTLSController) async {
+    _controllers.removeValue(forKey: controller.peerAddress)
+  }
+}
+
+#endif

--- a/Sources/SwiftOCASecureDevice/OCP.1/Backend/OpenSSL/Ocp1OpenSSLStreamController.swift
+++ b/Sources/SwiftOCASecureDevice/OCP.1/Backend/OpenSSL/Ocp1OpenSSLStreamController.swift
@@ -1,0 +1,209 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(COpenSSL) && canImport(IORing)
+
+import AsyncAlgorithms
+import AsyncExtensions
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+import Glibc
+public import IORing
+internal import IORingUtils
+import SocketAddress
+@_spi(SwiftOCAPrivate)
+import SwiftOCA
+@_spi(SwiftOCAPrivate)
+import SwiftOCADevice
+import SwiftOCASecure
+import struct SystemPackage.Errno
+
+/// Remote controller connected via TLS-wrapped TCP on Linux. The endpoint
+/// hands off the post-handshake engine; from here all bytes route through
+/// the engine's BIO pair.
+package actor Ocp1OpenSSLStreamController: Ocp1ControllerInternal, CustomStringConvertible {
+  package nonisolated let flags: OcaControllerFlags
+  package nonisolated let connectionPrefix: String
+  package nonisolated let identifier: String
+  package nonisolated let peerAddress: AnySocketAddress
+  /// Snapshotted at handshake completion, immutable thereafter.
+  package nonisolated let peerIdentity: OcaPeerIdentity
+
+  package var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()
+  package var keepAliveTask: Task<(), Error>?
+  package var lastMessageReceivedTime = ContinuousClock.recentPast
+  package var lastMessageSentTime = ContinuousClock.recentPast
+  package weak var endpoint: Ocp1OpenSSLStreamDeviceEndpoint?
+
+  /// Nilled by `close()` so subsequent sends bail with `.notConnected`.
+  /// The receive task captures its own reference at init.
+  private var _stream: (any Ocp1ByteStream)?
+  private let engine: Ocp1OpenSSLEngine
+  private let _messages: AsyncThrowingStream<Ocp1MessageList, Error>
+  private let _messagesContinuation: AsyncThrowingStream<Ocp1MessageList, Error>.Continuation
+  private var receiveMessageTask: Task<(), Never>?
+  /// Closes the connection if no message arrives within the endpoint's
+  /// `firstMessageDeadline`; cancelled on the first inbound message.
+  private var firstMessageTask: Task<Void, Never>?
+  private let createdAt: ContinuousClock.Instant = .now
+
+  package var messages: AnyAsyncSequence<Ocp1MessageList> {
+    _messages.eraseToAnyAsyncSequence()
+  }
+
+  package var heartbeatTime = Duration.seconds(0) {
+    didSet {
+      heartbeatTimeDidChange(from: oldValue)
+    }
+  }
+
+  init(
+    endpoint: Ocp1OpenSSLStreamDeviceEndpoint,
+    stream: any Ocp1ByteStream,
+    peerAddress: AnySocketAddress,
+    engine: Ocp1OpenSSLEngine
+  ) async throws {
+    self.endpoint = endpoint
+    _stream = stream
+    self.engine = engine
+    flags = [.supportsLocking, .hasTransportLayerSecurity]
+    connectionPrefix = OcaSecureTcpConnectionPrefix
+    self.peerAddress = peerAddress
+    identifier = (try? peerAddress.presentationAddress) ?? "unknown"
+    peerIdentity = await engine.peerIdentity()
+
+    (_messages, _messagesContinuation) = AsyncThrowingStream.makeStream(
+      of: Ocp1MessageList.self,
+      throwing: Error.self
+    )
+
+    // Capture refs so the receive task avoids re-entering the actor on
+    // every read. `close()` cancels the task and closes the stream.
+    let streamRef: any Ocp1ByteStream = stream
+    let engineRef = engine
+    let continuationRef = _messagesContinuation
+    receiveMessageTask = Task { [weak self] in
+      do {
+        repeat {
+          guard !Task.isCancelled else { break }
+          let messages = try await OcaDevice.receiveMessages { count in
+            try await engineRef.read(
+              count,
+              read: { c in try await streamRef.read(count: c, awaitingAllRead: false) },
+              write: { d in try await streamRef.write(d) }
+            )
+          }
+          await self?.noteMessageReceived()
+          continuationRef.yield(messages)
+        } while true
+      } catch {
+        continuationRef.finish(throwing: error)
+      }
+    }
+
+    let deadline = endpoint.firstMessageDeadline
+    firstMessageTask = Task<Void, Never> { [weak self] in
+      try? await Task.sleep(for: deadline)
+      if Task.isCancelled { return }
+      guard let self else { return }
+      await self.enforceFirstMessageDeadline()
+    }
+  }
+
+  private func noteMessageReceived() {
+    if let task = firstMessageTask {
+      task.cancel()
+      firstMessageTask = nil
+    }
+  }
+
+  private func enforceFirstMessageDeadline() async {
+    if firstMessageTask == nil { return }
+    firstMessageTask = nil
+    if lastMessageReceivedTime > createdAt { return }
+    if let endpoint = await self.endpoint {
+      endpoint.logger.warning(
+        "TLS peer \(identifier) did not send a message within first-message deadline; closing"
+      )
+    }
+    try? await close()
+  }
+
+  package func sendOcp1EncodedData(_ data: Data) async throws {
+    guard let stream = _stream else {
+      throw Ocp1Error.notConnected
+    }
+    _ = try await engine.write(
+      data,
+      read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+      write: { d in try await stream.write(d) }
+    )
+  }
+
+  package func close() async throws {
+    keepAliveTask?.cancel()
+    keepAliveTask = nil
+    firstMessageTask?.cancel()
+    firstMessageTask = nil
+
+    let stream = _stream
+    _stream = nil
+    receiveMessageTask?.cancel()
+    if let receiveMessageTask {
+      _ = await receiveMessageTask.value
+      self.receiveMessageTask = nil
+    }
+    if let stream {
+      try? await engine.shutdown(
+        read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+        write: { d in try await stream.write(d) }
+      )
+      await stream.close()
+    }
+    _messagesContinuation.finish()
+  }
+
+  deinit {
+    receiveMessageTask?.cancel()
+    keepAliveTask?.cancel()
+    firstMessageTask?.cancel()
+    _messagesContinuation.finish()
+  }
+
+  package nonisolated var description: String {
+    "\(type(of: self))(\(identifier))"
+  }
+}
+
+extension Ocp1OpenSSLStreamController: Equatable {
+  package nonisolated static func == (
+    lhs: Ocp1OpenSSLStreamController,
+    rhs: Ocp1OpenSSLStreamController
+  ) -> Bool {
+    ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
+  }
+}
+
+extension Ocp1OpenSSLStreamController: Hashable {
+  package nonisolated func hash(into hasher: inout Hasher) {
+    ObjectIdentifier(self).hash(into: &hasher)
+  }
+}
+
+#endif

--- a/Sources/SwiftOCASecureDevice/OCP.1/Backend/OpenSSL/Ocp1OpenSSLStreamDeviceEndpoint.swift
+++ b/Sources/SwiftOCASecureDevice/OCP.1/Backend/OpenSSL/Ocp1OpenSSLStreamDeviceEndpoint.swift
@@ -1,0 +1,275 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(COpenSSL) && canImport(IORing)
+
+import AsyncAlgorithms
+@preconcurrency
+import AsyncExtensions
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+import Glibc
+
+public import IORing
+internal import IORingUtils
+
+import Logging
+import SocketAddress
+@_spi(SwiftOCAPrivate)
+import SwiftOCADevice
+import SwiftOCASecure
+@_spi(SwiftOCAPrivate)
+import SwiftOCA
+import struct SystemPackage.Errno
+
+/// TLS-secured OCP.1 stream device endpoint backed by OpenSSL on Linux.
+/// Sibling of `Ocp1NWSecureTCPDeviceEndpoint`. PSKs come from
+/// `device.securityManager` and the provider is held by reference, so
+/// runtime additions take effect on the next handshake.
+@OcaDevice
+public final class Ocp1OpenSSLStreamDeviceEndpoint: Ocp1IORingDeviceEndpoint,
+  @preconcurrency OcaDeviceEndpointPrivate
+{
+  package typealias ControllerType = Ocp1OpenSSLStreamController
+
+  private let serverCredential: Ocp1TLSCredential?
+  /// Non-nil enables mTLS.
+  private let clientCertificateTrustRoots: Ocp1TLSTrustRoots?
+  private let _revocation: Ocp1TLSRevocationOptions
+  private let _maxConnections: Int
+  private let _handshakeTimeout: Duration
+  let firstMessageDeadline: Duration
+  private var _serverPSKProvider: (any OcaPreSharedKeyProvider)?
+  private var _controllers: [Ocp1OpenSSLStreamController] = []
+  /// Counted against `maxConnections` along with completed controllers so
+  /// slow-loris peers can't exhaust the engine/fd budget mid-handshake.
+  private var _pendingHandshakes: Int = 0
+
+  override public var controllers: [OcaController] { _controllers }
+
+  /// Binds the listening socket eagerly so callers passing port 0 can read
+  /// the kernel-assigned port via the inherited `port` property after init.
+  public init(
+    address: any SocketAddress,
+    credential: Ocp1TLSCredential? = nil,
+    clientCertificateTrustRoots: Ocp1TLSTrustRoots? = nil,
+    revocation: Ocp1TLSRevocationOptions = .disabled,
+    timeout: Duration = OcaDevice.DefaultTimeout,
+    device: OcaDevice = OcaDevice.shared,
+    logger: Logger = Logger(label: "com.padl.SwiftOCASecureDevice.Ocp1OpenSSLStreamDeviceEndpoint"),
+    maxConnections: Int = 1024,
+    handshakeTimeout: Duration = .seconds(10),
+    firstMessageDeadline: Duration = .seconds(30),
+    ring: IORing = .shared
+  ) async throws {
+    if let credential {
+      try credential.validate()
+    }
+    try Ocp1OpenSSLEngine.validateTrustRoots(clientCertificateTrustRoots)
+    serverCredential = credential
+    self.clientCertificateTrustRoots = clientCertificateTrustRoots
+    _revocation = revocation
+    _maxConnections = maxConnections
+    _handshakeTimeout = handshakeTimeout
+    self.firstMessageDeadline = firstMessageDeadline
+
+    let socket = try Socket(
+      ring: ring,
+      domain: address.family,
+      type: Glibc.SOCK_STREAM,
+      protocol: 0
+    )
+    switch Int32(address.family) {
+    case AF_INET6:
+      try socket.setIPv6Only()
+      fallthrough
+    case AF_INET:
+      try socket.setReuseAddr()
+      try socket.setTcpNoDelay()
+    default:
+      break
+    }
+    try socket.bind(to: address)
+    let boundAddress = try socket.localAddress
+
+    try await super.init(
+      address: boundAddress,
+      timeout: timeout,
+      device: device,
+      logger: logger,
+      ring: ring
+    )
+    self.socket = socket
+  }
+
+  public convenience init(
+    port: UInt16,
+    credential: Ocp1TLSCredential? = nil,
+    clientCertificateTrustRoots: Ocp1TLSTrustRoots? = nil,
+    revocation: Ocp1TLSRevocationOptions = .disabled,
+    timeout: Duration = OcaDevice.DefaultTimeout,
+    device: OcaDevice = OcaDevice.shared,
+    logger: Logger = Logger(label: "com.padl.SwiftOCASecureDevice.Ocp1OpenSSLStreamDeviceEndpoint"),
+    maxConnections: Int = 1024,
+    handshakeTimeout: Duration = .seconds(10),
+    firstMessageDeadline: Duration = .seconds(30),
+    ring: IORing = .shared
+  ) async throws {
+    var sin = sockaddr_in()
+    sin.sin_family = sa_family_t(AF_INET)
+    sin.sin_port = port.bigEndian
+    sin.sin_addr.s_addr = UInt32(0).bigEndian // INADDR_ANY
+    try await self.init(
+      address: sin,
+      credential: credential,
+      clientCertificateTrustRoots: clientCertificateTrustRoots,
+      revocation: revocation,
+      timeout: timeout,
+      device: device,
+      logger: logger,
+      maxConnections: maxConnections,
+      handshakeTimeout: handshakeTimeout,
+      firstMessageDeadline: firstMessageDeadline,
+      ring: ring
+    )
+  }
+
+  override public func run() async throws {
+    logger.info("starting \(type(of: self)) on \(address._presentationAddress)")
+    if clientCertificateTrustRoots != nil {
+      logger.info("\(type(of: self)) requires client certificates (mTLS)")
+    }
+    try await super.run()
+    _serverPSKProvider = await device.securityManager
+
+    guard let socket else {
+      throw Ocp1Error.notConnected
+    }
+    try socket.listen()
+
+    repeat {
+      do {
+        let clients: AnyAsyncSequence<Socket> = try await socket.accept()
+        do {
+          for try await client in clients {
+            Task { [weak self] in
+              guard let self else { return }
+              await self.runAccepted(client: client)
+            }
+          }
+        } catch let error where error as? Errno == Errno.invalidArgument {
+          logger.warning(
+            "invalid argument when accepting connections, check kernel version supports multishot accept with io_uring"
+          )
+          break
+        }
+      } catch let error where error as? Errno == Errno.canceled {
+        logger.debug("received cancelation, trying to accept() again")
+      } catch {
+        logger.info("received error \(error), bailing")
+        break
+      }
+      if Task.isCancelled {
+        logger.info("\(type(of: self)) cancelled, stopping")
+        break
+      }
+    } while true
+
+    self.socket = nil
+    try await device.remove(endpoint: self)
+  }
+
+  /// Per-connection handshake + controller handoff. Each accepted socket
+  /// gets its own engine so one handshake failure doesn't poison the listener.
+  private func runAccepted(client: Socket) async {
+    if _controllers.count + _pendingHandshakes >= _maxConnections {
+      logger.warning(
+        "TLS connection cap (\(_maxConnections)) reached (in-flight handshakes: \(_pendingHandshakes)); refusing new client"
+      )
+      return
+    }
+    _pendingHandshakes += 1
+    defer { _pendingHandshakes -= 1 }
+    let engine: Ocp1OpenSSLEngine
+    do {
+      engine = try Ocp1OpenSSLEngine(
+        mode: .server,
+        credential: serverCredential,
+        serverPSKProvider: _serverPSKProvider,
+        clientTrustRoots: clientCertificateTrustRoots,
+        revocation: _revocation
+      )
+    } catch {
+      logger.warning("could not initialize TLS engine: \(error)")
+      return
+    }
+
+    let peerAddress: AnySocketAddress
+    do {
+      peerAddress = try AnySocketAddress(client.peerAddress)
+    } catch {
+      logger.warning("could not read peer address from accepted socket: \(error)")
+      return
+    }
+
+    let stream: any Ocp1ByteStream = IORingByteStream(socket: client)
+
+    // Bound the handshake so a peer that stalls mid-flight doesn't pin
+    // engine state until the connection drops.
+    do {
+      try await withThrowingTimeout(of: _handshakeTimeout, clock: .continuous) {
+        try await engine.handshake(
+          read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+          write: { d in try await stream.write(d) }
+        )
+      }
+    } catch {
+      logger.warning("TLS handshake failed or timed out: \(error)")
+      return
+    }
+
+    do {
+      let controller = try await Ocp1OpenSSLStreamController(
+        endpoint: self,
+        stream: stream,
+        peerAddress: peerAddress,
+        engine: engine
+      )
+      await controller.handle(for: self)
+    } catch {
+      logger.warning("controller setup failed: \(error)")
+    }
+  }
+
+  #if canImport(dnssd)
+  override public nonisolated var serviceType: OcaNetworkAdvertisingServiceType {
+    .tcpSecure
+  }
+  #endif
+
+  package func add(controller: Ocp1OpenSSLStreamController) async {
+    _controllers.append(controller)
+  }
+
+  package func remove(controller: Ocp1OpenSSLStreamController) async {
+    _controllers.removeAll(where: { $0 == controller })
+  }
+}
+
+#endif

--- a/Sources/SwiftOCASecureDevice/OCP.1/Backend/OpenSSL/_EndpointDatagramChannel.swift
+++ b/Sources/SwiftOCASecureDevice/OCP.1/Backend/OpenSSL/_EndpointDatagramChannel.swift
@@ -1,0 +1,53 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(COpenSSL) && canImport(IORing)
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+import SocketAddress
+@_spi(SwiftOCAPrivate)
+import SwiftOCA
+import Synchronization
+
+/// Routes outbound datagrams to a fixed peer through the DTLS endpoint's
+/// shared UDP socket. Holds `endpoint` weakly so endpoint shutdown surfaces
+/// as `.notConnected` instead of pinning lifetime.
+final class _EndpointDatagramChannel: Ocp1DatagramChannel, @unchecked Sendable {
+  private weak var endpoint: Ocp1OpenSSLDTLSDeviceEndpoint?
+  private let peer: AnySocketAddress
+  private let closed = Mutex(false)
+
+  init(endpoint: Ocp1OpenSSLDTLSDeviceEndpoint, peer: AnySocketAddress) {
+    self.endpoint = endpoint
+    self.peer = peer
+  }
+
+  func send(_ data: Data) async throws {
+    if closed.withLock({ $0 }) { throw Ocp1Error.notConnected }
+    guard let endpoint else { throw Ocp1Error.notConnected }
+    try await endpoint.sendDatagram(data, to: peer)
+  }
+
+  func close() async {
+    closed.withLock { $0 = true }
+  }
+}
+
+#endif

--- a/Sources/SwiftOCASecureDevice/OCP.1/Ocp1TLSDeviceTypes.swift
+++ b/Sources/SwiftOCASecureDevice/OCP.1/Ocp1TLSDeviceTypes.swift
@@ -1,0 +1,26 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import SwiftOCADevice
+import SwiftOCASecure
+
+#if canImport(Network)
+public typealias Ocp1TLSStreamDeviceEndpoint = Ocp1NWSecureTCPDeviceEndpoint
+public typealias Ocp1TLSDatagramDeviceEndpoint = Ocp1NWSecureUDPDeviceEndpoint
+#elseif canImport(COpenSSL) && canImport(IORing)
+public typealias Ocp1TLSStreamDeviceEndpoint = Ocp1OpenSSLStreamDeviceEndpoint
+public typealias Ocp1TLSDatagramDeviceEndpoint = Ocp1OpenSSLDTLSDeviceEndpoint
+#endif

--- a/SwiftOCA.xcodeproj/project.pbxproj
+++ b/SwiftOCA.xcodeproj/project.pbxproj
@@ -282,6 +282,44 @@
 		D3FAC8EA2B5CFBE7009E2775 /* TaskManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FAC8E92B5CFBE7009E2775 /* TaskManager.swift */; };
 		D3FAC8EC2B5CFC11009E2775 /* TaskManagerDataTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FAC8EB2B5CFC11009E2775 /* TaskManagerDataTypes.swift */; };
 		D3FAC8EE2B5CFE3A009E2775 /* FirmwareManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FAC8ED2B5CFE3A009E2775 /* FirmwareManager.swift */; };
+		D3527EC52F00DA0100000002 /* SecurityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3527EC52F00DA0100000001 /* SecurityManager.swift */; };
+		D3527EC52F00DA0100000004 /* Ocp1NWStreamController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3527EC52F00DA0100000003 /* Ocp1NWStreamController.swift */; };
+		D3527EC52F00DA0100000006 /* Ocp1NWStreamDeviceEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3527EC52F00DA0100000005 /* Ocp1NWStreamDeviceEndpoint.swift */; };
+		D3527EC72F00DA0100000009 /* Ocp1TLSTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3527EC62F00DA0100000007 /* Ocp1TLSTypes.swift */; };
+		D3527EC72F00DA010000000A /* Ocp1NWSecureConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3527EC62F00DA0100000009 /* Ocp1NWSecureConnection.swift */; };
+		D3527EC72F00DA010000000B /* libSwiftOCA.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = D3E6E1642A3ACA0B00BF7095 /* libSwiftOCA.dylib */; };
+		D3527EC72F00DA0100000018 /* Ocp1TLSDeviceTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3527EC62F00DA0100000005 /* Ocp1TLSDeviceTypes.swift */; };
+		D3527EC72F00DA0100000019 /* Ocp1NWDatagramController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3527EC62F00DA0100000003 /* Ocp1NWDatagramController.swift */; };
+		D3527EC72F00DA010000001A /* Ocp1NWSecureUDPDeviceEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3527EC62F00DA0100000001 /* Ocp1NWSecureUDPDeviceEndpoint.swift */; };
+		D3527EC72F00DA010000001B /* Ocp1NWSecureTCPDeviceEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3527EC52F00DA0100000007 /* Ocp1NWSecureTCPDeviceEndpoint.swift */; };
+		D3527EC72F00DA010000001C /* libSwiftOCA.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = D3E6E1642A3ACA0B00BF7095 /* libSwiftOCA.dylib */; };
+		D3527EC72F00DA010000001D /* libSwiftOCASecure.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = D3527EC72F00DA0100000008 /* libSwiftOCASecure.dylib */; };
+		D3527EC72F00DA010000001E /* libSwiftOCADevice.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = D33B52812A6FD171001A1BA7 /* libSwiftOCADevice.dylib */; };
+		D3527EC72F00DA0100000020 /* libSwiftOCASecure.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = D3527EC72F00DA0100000008 /* libSwiftOCASecure.dylib */; };
+		D3527EC72F00DA0100000021 /* libSwiftOCASecureDevice.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = D3527EC72F00DA0100000017 /* libSwiftOCASecureDevice.dylib */; };
+		D3527EC72F00DA0100000022 /* libSwiftOCASecure.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = D3527EC72F00DA0100000008 /* libSwiftOCASecure.dylib */; };
+		D3527EC72F00DA0100000023 /* libSwiftOCASecureDevice.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = D3527EC72F00DA0100000017 /* libSwiftOCASecureDevice.dylib */; };
+		D3527EC72F00DA0100000040 /* Logging in Frameworks */ = {isa = PBXBuildFile; productRef = D32C49DC2B5102A300D73201 /* Logging */; };
+		D3527EC72F00DA0100000041 /* SocketAddress in Frameworks */ = {isa = PBXBuildFile; productRef = D35C9D9F2BF76E5100D680F2 /* SocketAddress */; };
+		D3527EC72F00DA0100000042 /* Logging in Frameworks */ = {isa = PBXBuildFile; productRef = D32C49DC2B5102A300D73201 /* Logging */; };
+		D3527EC72F00DA0100000043 /* SocketAddress in Frameworks */ = {isa = PBXBuildFile; productRef = D35C9D9F2BF76E5100D680F2 /* SocketAddress */; };
+		D3527EC72F00DA0100000044 /* AsyncAlgorithms in Frameworks */ = {isa = PBXBuildFile; productRef = D3E6E1ED2A3ACB0700BF7095 /* AsyncAlgorithms */; };
+		D3527EC72F00DA0100000045 /* AsyncExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = D3E6E25A2A3D28DD00BF7095 /* AsyncExtensions */; };
+		D3527EC72F00DA0100000062 /* Crypto in Frameworks */ = {isa = PBXBuildFile; productRef = D3527EC72F00DA0100000061 /* Crypto */; };
+		D3527EC72F00DA0100000071 /* BackendConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3527EC72F00DA0100000070 /* BackendConnectionTests.swift */; };
+		D3527EC72F00DA0100000073 /* FileDatasetStorageProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3527EC72F00DA0100000072 /* FileDatasetStorageProviderTests.swift */; };
+		D3527EC72F00DA0100000075 /* KeepAliveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3527EC72F00DA0100000074 /* KeepAliveTests.swift */; };
+		D3527EC72F00DA0100000077 /* MachPortConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3527EC72F00DA0100000076 /* MachPortConnectionTests.swift */; };
+		D3527EC72F00DA0100000079 /* OpenSSLConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3527EC72F00DA0100000078 /* OpenSSLConnectionTests.swift */; };
+		D3527EC72F00DA010000007B /* OpenSSLDTLSConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3527EC72F00DA010000007A /* OpenSSLDTLSConnectionTests.swift */; };
+		D3527EC72F00DA010000007D /* OpenSSLEnginePipeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3527EC72F00DA010000007C /* OpenSSLEnginePipeTests.swift */; };
+		D3527EC72F00DA010000007F /* PipeByteStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3527EC72F00DA010000007E /* PipeByteStream.swift */; };
+		D3527EC72F00DA0100000081 /* SelfSignedCertHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3527EC72F00DA0100000080 /* SelfSignedCertHelper.swift */; };
+		D3527EC72F00DA0100000083 /* SQLiteDatasetStorageProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3527EC72F00DA0100000082 /* SQLiteDatasetStorageProviderTests.swift */; };
+		D3527EC72F00DA0100000085 /* WebSocketConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3527EC72F00DA0100000084 /* WebSocketConnectionTests.swift */; };
+		D3527EC72F00DA0100000087 /* LengthTaggedDataJSONTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3527EC72F00DA0100000086 /* LengthTaggedDataJSONTests.swift */; };
+		D3527EC72F00DA0100000090 /* FlyingSocks in Frameworks */ = {isa = PBXBuildFile; productRef = D33B52D32A706FD7001A1BA7 /* FlyingSocks */; };
+		D3527EC72F00DA0100000091 /* FlyingFox in Frameworks */ = {isa = PBXBuildFile; productRef = D3B325042B4F677700C8335F /* FlyingFox */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -291,6 +329,34 @@
 			proxyType = 1;
 			remoteGlobalIDString = D3E6E1632A3ACA0B00BF7095;
 			remoteInfo = SwiftOCA;
+		};
+		D3527EC72F00DA0100000051 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D3E6E15C2A3ACA0B00BF7095 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D3E6E1632A3ACA0B00BF7095;
+			remoteInfo = SwiftOCA;
+		};
+		D3527EC72F00DA0100000053 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D3E6E15C2A3ACA0B00BF7095 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D3E6E1632A3ACA0B00BF7095;
+			remoteInfo = SwiftOCA;
+		};
+		D3527EC72F00DA0100000055 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D3E6E15C2A3ACA0B00BF7095 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D3527EC72F00DA0100000001;
+			remoteInfo = SwiftOCASecure;
+		};
+		D3527EC72F00DA0100000057 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D3E6E15C2A3ACA0B00BF7095 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D33B52802A6FD171001A1BA7;
+			remoteInfo = SwiftOCADevice;
 		};
 		D3C083102A7B01AB0020AD57 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -395,6 +461,20 @@
 		D33A35B52B2FC54C00FEDC43 /* ApplicationNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationNetwork.swift; sourceTree = "<group>"; };
 		D33A35B72B2FC9C900FEDC43 /* MediaTransportNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaTransportNetwork.swift; sourceTree = "<group>"; };
 		D33B52812A6FD171001A1BA7 /* libSwiftOCADevice.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libSwiftOCADevice.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		D3527EC72F00DA0100000008 /* libSwiftOCASecure.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libSwiftOCASecure.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		D3527EC72F00DA0100000017 /* libSwiftOCASecureDevice.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libSwiftOCASecureDevice.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		D3527EC72F00DA0100000070 /* BackendConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendConnectionTests.swift; sourceTree = "<group>"; };
+		D3527EC72F00DA0100000072 /* FileDatasetStorageProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileDatasetStorageProviderTests.swift; sourceTree = "<group>"; };
+		D3527EC72F00DA0100000074 /* KeepAliveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeepAliveTests.swift; sourceTree = "<group>"; };
+		D3527EC72F00DA0100000076 /* MachPortConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MachPortConnectionTests.swift; sourceTree = "<group>"; };
+		D3527EC72F00DA0100000078 /* OpenSSLConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSSLConnectionTests.swift; sourceTree = "<group>"; };
+		D3527EC72F00DA010000007A /* OpenSSLDTLSConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSSLDTLSConnectionTests.swift; sourceTree = "<group>"; };
+		D3527EC72F00DA010000007C /* OpenSSLEnginePipeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSSLEnginePipeTests.swift; sourceTree = "<group>"; };
+		D3527EC72F00DA010000007E /* PipeByteStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PipeByteStream.swift; sourceTree = "<group>"; };
+		D3527EC72F00DA0100000080 /* SelfSignedCertHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelfSignedCertHelper.swift; sourceTree = "<group>"; };
+		D3527EC72F00DA0100000082 /* SQLiteDatasetStorageProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteDatasetStorageProviderTests.swift; sourceTree = "<group>"; };
+		D3527EC72F00DA0100000084 /* WebSocketConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketConnectionTests.swift; sourceTree = "<group>"; };
+		D3527EC72F00DA0100000086 /* LengthTaggedDataJSONTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LengthTaggedDataJSONTests.swift; sourceTree = "<group>"; };
 		D33B528F2A6FD332001A1BA7 /* Root.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Root.swift; sourceTree = "<group>"; };
 		D33B52922A6FD3A7001A1BA7 /* DeviceProperty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceProperty.swift; sourceTree = "<group>"; };
 		D33B52A22A702CED001A1BA7 /* Block.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Block.swift; sourceTree = "<group>"; };
@@ -616,6 +696,17 @@
 		D3FAC8E92B5CFBE7009E2775 /* TaskManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskManager.swift; sourceTree = "<group>"; };
 		D3FAC8EB2B5CFC11009E2775 /* TaskManagerDataTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskManagerDataTypes.swift; sourceTree = "<group>"; };
 		D3FAC8ED2B5CFE3A009E2775 /* FirmwareManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirmwareManager.swift; sourceTree = "<group>"; };
+		D3527EC52F00DA0100000001 /* SecurityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecurityManager.swift; sourceTree = "<group>"; };
+		D3527EC52F00DA0100000003 /* Ocp1NWStreamController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Ocp1NWStreamController.swift; sourceTree = "<group>"; };
+		D3527EC52F00DA0100000005 /* Ocp1NWStreamDeviceEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Ocp1NWStreamDeviceEndpoint.swift; sourceTree = "<group>"; };
+		D3527EC52F00DA0100000007 /* Ocp1NWSecureTCPDeviceEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Ocp1NWSecureTCPDeviceEndpoint.swift; path = Sources/SwiftOCASecureDevice/OCP.1/Backend/Network/Ocp1NWSecureTCPDeviceEndpoint.swift; sourceTree = SOURCE_ROOT; };
+		D3527EC62F00DA0100000001 /* Ocp1NWSecureUDPDeviceEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Ocp1NWSecureUDPDeviceEndpoint.swift; path = Sources/SwiftOCASecureDevice/OCP.1/Backend/Network/Ocp1NWSecureUDPDeviceEndpoint.swift; sourceTree = SOURCE_ROOT; };
+		D3527EC62F00DA0100000003 /* Ocp1NWDatagramController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Ocp1NWDatagramController.swift; sourceTree = "<group>"; };
+		D3527EC72F00DA01000000A0 /* Ocp1NWDatagramDeviceEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Ocp1NWDatagramDeviceEndpoint.swift; sourceTree = "<group>"; };
+		D3527EC72F00DA01000000A1 /* Ocp1NWDatagramDeviceEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3527EC72F00DA01000000A0 /* Ocp1NWDatagramDeviceEndpoint.swift */; };
+		D3527EC62F00DA0100000005 /* Ocp1TLSDeviceTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Ocp1TLSDeviceTypes.swift; path = Sources/SwiftOCASecureDevice/OCP.1/Ocp1TLSDeviceTypes.swift; sourceTree = SOURCE_ROOT; };
+		D3527EC62F00DA0100000007 /* Ocp1TLSTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Ocp1TLSTypes.swift; path = Sources/SwiftOCASecure/OCP.1/Ocp1TLSTypes.swift; sourceTree = SOURCE_ROOT; };
+		D3527EC62F00DA0100000009 /* Ocp1NWSecureConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Ocp1NWSecureConnection.swift; path = Sources/SwiftOCASecure/OCP.1/Backend/Ocp1NWSecureConnection.swift; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -658,6 +749,8 @@
 			files = (
 				D33B52CE2A706FB9001A1BA7 /* libSwiftOCA.dylib in Frameworks */,
 				D33B52C72A706245001A1BA7 /* libSwiftOCADevice.dylib in Frameworks */,
+				D3527EC72F00DA0100000020 /* libSwiftOCASecure.dylib in Frameworks */,
+				D3527EC72F00DA0100000021 /* libSwiftOCASecureDevice.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -675,6 +768,10 @@
 			files = (
 				D3C083172A7B02360020AD57 /* libSwiftOCA.dylib in Frameworks */,
 				D3C0830F2A7B01AB0020AD57 /* libSwiftOCADevice.dylib in Frameworks */,
+				D3527EC72F00DA0100000022 /* libSwiftOCASecure.dylib in Frameworks */,
+				D3527EC72F00DA0100000023 /* libSwiftOCASecureDevice.dylib in Frameworks */,
+				D3527EC72F00DA0100000090 /* FlyingSocks in Frameworks */,
+				D3527EC72F00DA0100000091 /* FlyingFox in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -709,6 +806,31 @@
 			files = (
 				D3E6E24B2A3C0C8D00BF7095 /* libSwiftOCA.dylib in Frameworks */,
 				D3E6E2862A43BA3600BF7095 /* Sliders in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D3527EC72F00DA0100000004 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D3527EC72F00DA010000000B /* libSwiftOCA.dylib in Frameworks */,
+				D3527EC72F00DA0100000040 /* Logging in Frameworks */,
+				D3527EC72F00DA0100000041 /* SocketAddress in Frameworks */,
+				D3527EC72F00DA0100000062 /* Crypto in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D3527EC72F00DA0100000013 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D3527EC72F00DA010000001C /* libSwiftOCA.dylib in Frameworks */,
+				D3527EC72F00DA010000001D /* libSwiftOCASecure.dylib in Frameworks */,
+				D3527EC72F00DA010000001E /* libSwiftOCADevice.dylib in Frameworks */,
+				D3527EC72F00DA0100000042 /* Logging in Frameworks */,
+				D3527EC72F00DA0100000043 /* SocketAddress in Frameworks */,
+				D3527EC72F00DA0100000044 /* AsyncAlgorithms in Frameworks */,
+				D3527EC72F00DA0100000045 /* AsyncExtensions in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -756,8 +878,39 @@
 				D32229C22ABC270900B56B6B /* Local */,
 				D32229C62ABC270900B56B6B /* FlyingSocks */,
 				D32229CA2ABC270900B56B6B /* IORing */,
+				D3527EC52F00DA0100000009 /* Network */,
 			);
 			path = Backend;
+			sourceTree = "<group>";
+		};
+		D3527EC52F00DA0100000009 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				D3527EC52F00DA0100000003 /* Ocp1NWStreamController.swift */,
+				D3527EC52F00DA0100000005 /* Ocp1NWStreamDeviceEndpoint.swift */,
+				D3527EC62F00DA0100000003 /* Ocp1NWDatagramController.swift */,
+				D3527EC72F00DA01000000A0 /* Ocp1NWDatagramDeviceEndpoint.swift */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
+		D3527EC72F00DA0100000030 /* Sources/SwiftOCASecure */ = {
+			isa = PBXGroup;
+			children = (
+				D3527EC62F00DA0100000007 /* Ocp1TLSTypes.swift */,
+				D3527EC62F00DA0100000009 /* Ocp1NWSecureConnection.swift */,
+			);
+			name = Sources/SwiftOCASecure;
+			sourceTree = "<group>";
+		};
+		D3527EC72F00DA0100000031 /* Sources/SwiftOCASecureDevice */ = {
+			isa = PBXGroup;
+			children = (
+				D3527EC62F00DA0100000005 /* Ocp1TLSDeviceTypes.swift */,
+				D3527EC52F00DA0100000007 /* Ocp1NWSecureTCPDeviceEndpoint.swift */,
+				D3527EC62F00DA0100000001 /* Ocp1NWSecureUDPDeviceEndpoint.swift */,
+			);
+			name = Sources/SwiftOCASecureDevice;
 			sourceTree = "<group>";
 		};
 		D32229C22ABC270900B56B6B /* Local */ = {
@@ -923,6 +1076,7 @@
 				D33A35B02B2FC30500FEDC43 /* LockManager.swift */,
 				D33A35A82B2FB7BE00FEDC43 /* MediaClockManager.swift */,
 				D33B52A92A702D3F001A1BA7 /* NetworkManager.swift */,
+				D3527EC52F00DA0100000001 /* SecurityManager.swift */,
 				D33B52AD2A702D92001A1BA7 /* SubscriptionManager.swift */,
 			);
 			path = Managers;
@@ -1080,6 +1234,7 @@
 			isa = PBXGroup;
 			children = (
 				D35BFC7D2E89910600183358 /* Ocp1MessageBatcherTests.swift */,
+				D3527EC72F00DA0100000086 /* LengthTaggedDataJSONTests.swift */,
 				D3B396DD2BBA4AEE0001B512 /* SwiftOCATests.swift */,
 			);
 			path = Tests/SwiftOCATests;
@@ -1098,6 +1253,17 @@
 			isa = PBXGroup;
 			children = (
 				D3C083152A7B021B0020AD57 /* SwiftOCADeviceTests.swift */,
+				D3527EC72F00DA0100000070 /* BackendConnectionTests.swift */,
+				D3527EC72F00DA0100000072 /* FileDatasetStorageProviderTests.swift */,
+				D3527EC72F00DA0100000074 /* KeepAliveTests.swift */,
+				D3527EC72F00DA0100000076 /* MachPortConnectionTests.swift */,
+				D3527EC72F00DA0100000078 /* OpenSSLConnectionTests.swift */,
+				D3527EC72F00DA010000007A /* OpenSSLDTLSConnectionTests.swift */,
+				D3527EC72F00DA010000007C /* OpenSSLEnginePipeTests.swift */,
+				D3527EC72F00DA010000007E /* PipeByteStream.swift */,
+				D3527EC72F00DA0100000080 /* SelfSignedCertHelper.swift */,
+				D3527EC72F00DA0100000082 /* SQLiteDatasetStorageProviderTests.swift */,
+				D3527EC72F00DA0100000084 /* WebSocketConnectionTests.swift */,
 			);
 			path = Tests/SwiftOCADeviceTests;
 			sourceTree = "<group>";
@@ -1189,6 +1355,8 @@
 				D32EDEF02D6D7385009673D6 /* OCAEventBenchmark */,
 				D33B52C32A706235001A1BA7 /* OCADevice */,
 				D33B52852A6FD190001A1BA7 /* Sources/SwiftOCADevice */,
+				D3527EC72F00DA0100000030 /* Sources/SwiftOCASecure */,
+				D3527EC72F00DA0100000031 /* Sources/SwiftOCASecureDevice */,
 				D3E6E2472A3C0C7700BF7095 /* SwiftOCAUI */,
 				D3028C1C2A3AD57900B8DB42 /* Sources/SwiftOCA */,
 				D337B9022EC4384E00826A4B /* OCABrokerTest */,
@@ -1207,6 +1375,8 @@
 				D3E6E1F62A3ACF5900BF7095 /* OCABrowser.app */,
 				D3E6E2432A3C0BA000BF7095 /* libSwiftOCAUI.dylib */,
 				D33B52812A6FD171001A1BA7 /* libSwiftOCADevice.dylib */,
+				D3527EC72F00DA0100000008 /* libSwiftOCASecure.dylib */,
+				D3527EC72F00DA0100000017 /* libSwiftOCASecureDevice.dylib */,
 				D33B52BC2A706201001A1BA7 /* OCADevice */,
 				D3C0830B2A7B01AB0020AD57 /* SwiftOCADeviceTests.xctest */,
 				D3B396DC2BBA4AB50001B512 /* SwiftOCATests.xctest */,
@@ -1538,6 +1708,20 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D3527EC72F00DA0100000003 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D3527EC72F00DA0100000012 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
@@ -1656,6 +1840,10 @@
 				D3C083112A7B01AB0020AD57 /* PBXTargetDependency */,
 			);
 			name = SwiftOCADeviceTests;
+			packageProductDependencies = (
+				D33B52D32A706FD7001A1BA7 /* FlyingSocks */,
+				D3B325042B4F677700C8335F /* FlyingFox */,
+			);
 			productName = SwiftOCADeviceTests;
 			productReference = D3C0830B2A7B01AB0020AD57 /* SwiftOCADeviceTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -1710,6 +1898,55 @@
 			productReference = D3E6E1F62A3ACF5900BF7095 /* OCABrowser.app */;
 			productType = "com.apple.product-type.application";
 		};
+		D3527EC72F00DA0100000001 /* SwiftOCASecure */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D3527EC72F00DA0100000005 /* Build configuration list for PBXNativeTarget "SwiftOCASecure" */;
+			buildPhases = (
+				D3527EC72F00DA0100000003 /* Headers */,
+				D3527EC72F00DA0100000002 /* Sources */,
+				D3527EC72F00DA0100000004 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				D3527EC72F00DA0100000050 /* PBXTargetDependency */,
+			);
+			name = SwiftOCASecure;
+			packageProductDependencies = (
+				D32C49DC2B5102A300D73201 /* Logging */,
+				D35C9D9F2BF76E5100D680F2 /* SocketAddress */,
+				D3527EC72F00DA0100000061 /* Crypto */,
+			);
+			productName = SwiftOCASecure;
+			productReference = D3527EC72F00DA0100000008 /* libSwiftOCASecure.dylib */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+		D3527EC72F00DA0100000010 /* SwiftOCASecureDevice */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D3527EC72F00DA0100000014 /* Build configuration list for PBXNativeTarget "SwiftOCASecureDevice" */;
+			buildPhases = (
+				D3527EC72F00DA0100000012 /* Headers */,
+				D3527EC72F00DA0100000011 /* Sources */,
+				D3527EC72F00DA0100000013 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				D3527EC72F00DA0100000052 /* PBXTargetDependency */,
+				D3527EC72F00DA0100000054 /* PBXTargetDependency */,
+				D3527EC72F00DA0100000056 /* PBXTargetDependency */,
+			);
+			name = SwiftOCASecureDevice;
+			packageProductDependencies = (
+				D32C49DC2B5102A300D73201 /* Logging */,
+				D35C9D9F2BF76E5100D680F2 /* SocketAddress */,
+				D3E6E1ED2A3ACB0700BF7095 /* AsyncAlgorithms */,
+				D3E6E25A2A3D28DD00BF7095 /* AsyncExtensions */,
+			);
+			productName = SwiftOCASecureDevice;
+			productReference = D3527EC72F00DA0100000017 /* libSwiftOCASecureDevice.dylib */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
 		D3E6E2422A3C0BA000BF7095 /* SwiftOCAUI */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = D3E6E2442A3C0BA000BF7095 /* Build configuration list for PBXNativeTarget "SwiftOCAUI" */;
@@ -1749,6 +1986,12 @@
 					D33B52802A6FD171001A1BA7 = {
 						CreatedOnToolsVersion = 14.2;
 					};
+					D3527EC72F00DA0100000001 = {
+						CreatedOnToolsVersion = 16.1;
+					};
+					D3527EC72F00DA0100000010 = {
+						CreatedOnToolsVersion = 16.1;
+					};
 					D33B52BB2A706201001A1BA7 = {
 						CreatedOnToolsVersion = 14.2;
 					};
@@ -1777,6 +2020,7 @@
 			);
 			mainGroup = D3E6E15B2A3ACA0B00BF7095;
 			packageReferences = (
+				D3527EC72F00DA0100000060 /* XCRemoteSwiftPackageReference "swift-crypto" */,
 				D3E6E1EC2A3ACB0700BF7095 /* XCRemoteSwiftPackageReference "swift-async-algorithms" */,
 				D3E6E2592A3D28DD00BF7095 /* XCRemoteSwiftPackageReference "AsyncExtensions" */,
 				D3E6E2842A43B8D000BF7095 /* XCRemoteSwiftPackageReference "swiftui-sliders" */,
@@ -1798,6 +2042,8 @@
 				D3E6E1F52A3ACF5900BF7095 /* OCABrowser */,
 				D3E6E2422A3C0BA000BF7095 /* SwiftOCAUI */,
 				D33B52802A6FD171001A1BA7 /* SwiftOCADevice */,
+				D3527EC72F00DA0100000001 /* SwiftOCASecure */,
+				D3527EC72F00DA0100000010 /* SwiftOCASecureDevice */,
 				D33B52BB2A706201001A1BA7 /* OCADevice */,
 				D3C0830A2A7B01AB0020AD57 /* SwiftOCADeviceTests */,
 				D32EDEE12D6D7241009673D6 /* OCAEventBenchmark */,
@@ -1904,6 +2150,11 @@
 				D3AFD38C2B4150C800A72E9A /* SummingPoint.swift in Sources */,
 				D351F2012A7132F8008C5513 /* BoundedDeviceProperty.swift in Sources */,
 				D33B52AE2A702D92001A1BA7 /* SubscriptionManager.swift in Sources */,
+				D3527EC52F00DA0100000002 /* SecurityManager.swift in Sources */,
+				D3527EC52F00DA0100000004 /* Ocp1NWStreamController.swift in Sources */,
+				D3527EC52F00DA0100000006 /* Ocp1NWStreamDeviceEndpoint.swift in Sources */,
+				D3527EC72F00DA0100000019 /* Ocp1NWDatagramController.swift in Sources */,
+				D3527EC72F00DA01000000A1 /* Ocp1NWDatagramDeviceEndpoint.swift in Sources */,
 				D351F21C2A72A26E008C5513 /* Matrix.swift in Sources */,
 				D351F2162A729DFC008C5513 /* PolarityState.swift in Sources */,
 				D36851282EEA2700000129F3 /* IdentificationActuator.swift in Sources */,
@@ -1944,6 +2195,7 @@
 			files = (
 				D3B396DF2BBA4AEE0001B512 /* SwiftOCATests.swift in Sources */,
 				D35BFC7E2E89910600183358 /* Ocp1MessageBatcherTests.swift in Sources */,
+				D3527EC72F00DA0100000087 /* LengthTaggedDataJSONTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1952,6 +2204,17 @@
 			buildActionMask = 2147483647;
 			files = (
 				D3C083162A7B021B0020AD57 /* SwiftOCADeviceTests.swift in Sources */,
+				D3527EC72F00DA0100000071 /* BackendConnectionTests.swift in Sources */,
+				D3527EC72F00DA0100000073 /* FileDatasetStorageProviderTests.swift in Sources */,
+				D3527EC72F00DA0100000075 /* KeepAliveTests.swift in Sources */,
+				D3527EC72F00DA0100000077 /* MachPortConnectionTests.swift in Sources */,
+				D3527EC72F00DA0100000079 /* OpenSSLConnectionTests.swift in Sources */,
+				D3527EC72F00DA010000007B /* OpenSSLDTLSConnectionTests.swift in Sources */,
+				D3527EC72F00DA010000007D /* OpenSSLEnginePipeTests.swift in Sources */,
+				D3527EC72F00DA010000007F /* PipeByteStream.swift in Sources */,
+				D3527EC72F00DA0100000081 /* SelfSignedCertHelper.swift in Sources */,
+				D3527EC72F00DA0100000083 /* SQLiteDatasetStorageProviderTests.swift in Sources */,
+				D3527EC72F00DA0100000085 /* WebSocketConnectionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2105,6 +2368,25 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D3527EC72F00DA0100000002 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D3527EC72F00DA0100000009 /* Ocp1TLSTypes.swift in Sources */,
+				D3527EC72F00DA010000000A /* Ocp1NWSecureConnection.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D3527EC72F00DA0100000011 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D3527EC72F00DA0100000018 /* Ocp1TLSDeviceTypes.swift in Sources */,
+				D3527EC72F00DA010000001A /* Ocp1NWSecureUDPDeviceEndpoint.swift in Sources */,
+				D3527EC72F00DA010000001B /* Ocp1NWSecureTCPDeviceEndpoint.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D3E6E2402A3C0BA000BF7095 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2153,6 +2435,26 @@
 			isa = PBXTargetDependency;
 			target = D3E6E1632A3ACA0B00BF7095 /* SwiftOCA */;
 			targetProxy = D33B52D02A706FB9001A1BA7 /* PBXContainerItemProxy */;
+		};
+		D3527EC72F00DA0100000050 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D3E6E1632A3ACA0B00BF7095 /* SwiftOCA */;
+			targetProxy = D3527EC72F00DA0100000051 /* PBXContainerItemProxy */;
+		};
+		D3527EC72F00DA0100000052 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D3E6E1632A3ACA0B00BF7095 /* SwiftOCA */;
+			targetProxy = D3527EC72F00DA0100000053 /* PBXContainerItemProxy */;
+		};
+		D3527EC72F00DA0100000054 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D3527EC72F00DA0100000001 /* SwiftOCASecure */;
+			targetProxy = D3527EC72F00DA0100000055 /* PBXContainerItemProxy */;
+		};
+		D3527EC72F00DA0100000056 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D33B52802A6FD171001A1BA7 /* SwiftOCADevice */;
+			targetProxy = D3527EC72F00DA0100000057 /* PBXContainerItemProxy */;
 		};
 		D3C083112A7B01AB0020AD57 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -2222,6 +2524,80 @@
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 15.5;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		D3527EC72F00DA0100000006 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = T53Q9CN4T9;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				EXECUTABLE_PREFIX = lib;
+				MACH_O_TYPE = staticlib;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				OTHER_SWIFT_FLAGS = "-package-name swiftoca";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = NonEmbeddedBuild;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		D3527EC72F00DA0100000007 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = T53Q9CN4T9;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				EXECUTABLE_PREFIX = lib;
+				MACH_O_TYPE = staticlib;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				OTHER_SWIFT_FLAGS = "-package-name swiftoca";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = NonEmbeddedBuild;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		D3527EC72F00DA0100000015 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = T53Q9CN4T9;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				EXECUTABLE_PREFIX = lib;
+				MACH_O_TYPE = staticlib;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				OTHER_SWIFT_FLAGS = "-package-name swiftoca";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = NonEmbeddedBuild;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		D3527EC72F00DA0100000016 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = T53Q9CN4T9;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				EXECUTABLE_PREFIX = lib;
+				MACH_O_TYPE = staticlib;
+				MACOSX_DEPLOYMENT_TARGET = 15.0;
+				OTHER_SWIFT_FLAGS = "-package-name swiftoca";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = NonEmbeddedBuild;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
@@ -2683,6 +3059,24 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		D3527EC72F00DA0100000005 /* Build configuration list for PBXNativeTarget "SwiftOCASecure" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D3527EC72F00DA0100000006 /* Debug */,
+				D3527EC72F00DA0100000007 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D3527EC72F00DA0100000014 /* Build configuration list for PBXNativeTarget "SwiftOCASecureDevice" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D3527EC72F00DA0100000015 /* Debug */,
+				D3527EC72F00DA0100000016 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		D33B52842A6FD171001A1BA7 /* Build configuration list for PBXNativeTarget "SwiftOCADevice" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -2822,6 +3216,14 @@
 				minimumVersion = 1.2.0;
 			};
 		};
+		D3527EC72F00DA0100000060 /* XCRemoteSwiftPackageReference "swift-crypto" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-crypto";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 3.10.0;
+			};
+		};
 		D3E6E1EC2A3ACB0700BF7095 /* XCRemoteSwiftPackageReference "swift-async-algorithms" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/swift-async-algorithms";
@@ -2888,6 +3290,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = D3CFA35B2CED4D7500CAE537 /* XCRemoteSwiftPackageReference "swift-atomics" */;
 			productName = Atomics;
+		};
+		D3527EC72F00DA0100000061 /* Crypto */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D3527EC72F00DA0100000060 /* XCRemoteSwiftPackageReference "swift-crypto" */;
+			productName = Crypto;
 		};
 		D3E6E1ED2A3ACB0700BF7095 /* AsyncAlgorithms */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Tests/SwiftOCADeviceTests/AppleTLSPolicyRegressionTests.swift
+++ b/Tests/SwiftOCADeviceTests/AppleTLSPolicyRegressionTests.swift
@@ -1,0 +1,371 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Regression tests for the Apple-backend TLS findings called out in
+// Documentation/TLS-SecurityReview.md (HIGH-1, HIGH-2). The previous
+// implementations passed every legitimate cert chain to a server-cert
+// policy on the server endpoint, and let a PSK client silently accept a
+// server-cert fallback. These tests guard the fail-closed behavior added
+// by the fixes.
+//
+// Scaffolded under `(macOS || iOS) && NonEmbeddedBuild` so they compile
+// on Linux but only execute on Apple test runs.
+
+#if (os(macOS) || os(iOS)) && NonEmbeddedBuild
+
+import FlyingSocks
+@testable @_spi(SwiftOCAPrivate) import SwiftOCA
+@testable @_spi(SwiftOCAPrivate) import SwiftOCADevice
+import SwiftOCASecure
+import SwiftOCASecureDevice
+@preconcurrency import XCTest
+
+private func localhostAddress(port: UInt16) -> Data {
+  var addr = sockaddr_in()
+  addr.sin_family = sa_family_t(AF_INET)
+  addr.sin_port = port.bigEndian
+  addr.sin_addr.s_addr = UInt32(0x7F00_0001).bigEndian
+  #if canImport(Darwin)
+  addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+  #endif
+  return withUnsafeBytes(of: addr) { Data($0) }
+}
+
+/// `Ocp1NWSecureTCPConnection.init` is `@OcaConnection`-isolated; hop
+/// onto the actor to construct one from an XCTestCase method.
+@OcaConnection
+private func makePSKClientWithTrustRoots(
+  port: UInt16,
+  hostname: String,
+  caData: Data
+) throws -> Ocp1NWSecureTCPConnection {
+  try Ocp1NWSecureTCPConnection(
+    deviceAddress: localhostAddress(port: port),
+    credential: .preSharedKey(
+      identity: OcaPreSharedKeyIdentityHint,
+      key: Data(repeating: 0x42, count: 32)
+    ),
+    hostname: hostname,
+    trustRoots: .caData(caData)
+  )
+}
+
+@OcaConnection
+private func makePSKClient(
+  port: UInt16,
+  identity: String,
+  key: Data
+) throws -> Ocp1NWSecureTCPConnection {
+  try Ocp1NWSecureTCPConnection(
+    deviceAddress: localhostAddress(port: port),
+    credential: .preSharedKey(identity: identity, key: key)
+  )
+}
+
+@OcaConnection
+private func makeMTLSClient(
+  port: UInt16,
+  hostname: String,
+  p12Data: Data,
+  caData: Data
+) throws -> Ocp1NWSecureTCPConnection {
+  try Ocp1NWSecureTCPConnection(
+    deviceAddress: localhostAddress(port: port),
+    credential: .pkcs12(data: p12Data, password: testPKCS12Password),
+    hostname: hostname,
+    trustRoots: .caData(caData)
+  )
+}
+
+private func localhostUDPAddress(port: UInt16) -> Data { localhostAddress(port: port) }
+
+@OcaConnection
+private func makePSKDTLSClient(
+  port: UInt16,
+  identity: String,
+  key: Data
+) throws -> Ocp1NWSecureUDPConnection {
+  try Ocp1NWSecureUDPConnection(
+    deviceAddress: localhostUDPAddress(port: port),
+    credential: .preSharedKey(identity: identity, key: key)
+  )
+}
+
+@OcaConnection
+private func makePSKDTLSClientWithTrustRoots(
+  port: UInt16,
+  hostname: String,
+  caData: Data
+) throws -> Ocp1NWSecureUDPConnection {
+  try Ocp1NWSecureUDPConnection(
+    deviceAddress: localhostUDPAddress(port: port),
+    credential: .preSharedKey(
+      identity: OcaPreSharedKeyIdentityHint,
+      key: Data(repeating: 0x42, count: 32)
+    ),
+    hostname: hostname,
+    trustRoots: .caData(caData)
+  )
+}
+
+@OcaConnection
+private func makeMTLSDTLSClient(
+  port: UInt16,
+  hostname: String,
+  p12Data: Data,
+  caData: Data
+) throws -> Ocp1NWSecureUDPConnection {
+  try Ocp1NWSecureUDPConnection(
+    deviceAddress: localhostUDPAddress(port: port),
+    credential: .pkcs12(data: p12Data, password: testPKCS12Password),
+    hostname: hostname,
+    trustRoots: .caData(caData)
+  )
+}
+
+final class AppleTLSPolicyRegressionTests: XCTestCase {
+  /// HIGH-2 regression: a PSK-credentialled client MUST NOT silently
+  /// authenticate via the server's certificate. Even with a trusted CA
+  /// pinned, the connection must fail closed because the client opted
+  /// into PSK, not cert auth.
+  func testPSKClientRefusesCertOnlyServer() async throws {
+    guard let (caCertPath, leafCertPath, leafKeyPath) = try generateCASignedCert(
+      leafCommonName: "ocp1-test",
+      leafSubjectAltNames: "DNS:ocp1-test,IP:127.0.0.1"
+    ) else {
+      throw XCTSkip("openssl CLI not on PATH")
+    }
+    // macOS's PEM-aggregate `SecItemImport` doesn't accept OpenSSL 3's
+    // PKCS8 keys; bundle into a PKCS#12 instead.
+    guard let p12Path = try pemToPKCS12(certPath: leafCertPath, keyPath: leafKeyPath) else {
+      throw XCTSkip("openssl CLI not on PATH")
+    }
+    let p12Data = try Data(contentsOf: URL(fileURLWithPath: p12Path))
+
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    // Server credential is cert-only; no PSK loaded on the security manager.
+    let endpoint = try await Ocp1NWSecureTCPDeviceEndpoint(
+      port: 0,
+      credential: .pkcs12(data: p12Data, password: testPKCS12Password),
+      device: device
+    )
+    let task = Task { try await endpoint.run() }
+    defer { task.cancel() }
+    let port = try await endpoint.awaitBoundPort()
+
+    let caData = try Data(contentsOf: URL(fileURLWithPath: caCertPath))
+    let connection = try await makePSKClientWithTrustRoots(
+      port: port,
+      hostname: "ocp1-test",
+      caData: caData
+    )
+    // The PSK reject-cert verify block must trip during the handshake,
+    // surfaced as a thrown error from connectDevice().
+    do {
+      try await connection.connect()
+      XCTFail("PSK client should reject server's cert-only handshake")
+      try? await connection.disconnect()
+    } catch {
+      // expected
+    }
+  }
+
+  /// HIGH-1 regression: an mTLS server MUST validate client certs with
+  /// the *client-auth* SSL policy. `generateCASignedCert` mints a leaf
+  /// with `extendedKeyUsage=serverAuth` only — using it as the *client's*
+  /// cert in an mTLS handshake should be rejected by the server. Without
+  /// the policy-role fix the server would have accepted it.
+  func testMTLSServerRejectsServerAuthEKUCert() async throws {
+    guard let (caCertPath, leafCertPath, leafKeyPath) = try generateCASignedCert(
+      leafCommonName: "ocp1-test",
+      leafSubjectAltNames: "DNS:ocp1-test,IP:127.0.0.1"
+    ) else {
+      throw XCTSkip("openssl CLI not on PATH")
+    }
+    guard let p12Path = try pemToPKCS12(certPath: leafCertPath, keyPath: leafKeyPath) else {
+      throw XCTSkip("openssl CLI not on PATH")
+    }
+    let p12Data = try Data(contentsOf: URL(fileURLWithPath: p12Path))
+    let caData = try Data(contentsOf: URL(fileURLWithPath: caCertPath))
+
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    let endpoint = try await Ocp1NWSecureTCPDeviceEndpoint(
+      port: 0,
+      credential: .pkcs12(data: p12Data, password: testPKCS12Password),
+      clientCertificateTrustRoots: .caData(caData), // mTLS on
+      device: device
+    )
+    let task = Task { try await endpoint.run() }
+    defer { task.cancel() }
+    let port = try await endpoint.awaitBoundPort()
+
+    // Client presents the *same* leaf — same CA, serverAuth-only EKU.
+    let connection = try await makeMTLSClient(
+      port: port,
+      hostname: "ocp1-test",
+      p12Data: p12Data,
+      caData: caData
+    )
+    do {
+      try await connection.connect()
+      // TLS 1.3 mTLS: server validates the client cert *after* its Finished,
+      // so the client's `.ready` can win the race with the rejection alert
+      // and `connect()` returns successfully. Wait for the alert to land
+      // and the connection to tear down; on backends that validate during
+      // the handshake (OpenSSL) `connect()` throws and the catch fires.
+      try await Task.sleep(for: .seconds(1))
+      let stillConnected = await connection.isConnected
+      try? await connection.disconnect()
+      XCTAssertFalse(
+        stillConnected,
+        "server should reject client cert that has only serverAuth EKU"
+      )
+    } catch {
+      // expected
+    }
+  }
+
+  /// HIGH-2 DTLS regression: PSK DTLS client rejects cert-only server.
+  /// Mirror of `testPSKClientRefusesCertOnlyServer` for `Ocp1NWSecureUDP*`.
+  func testPSKDTLSClientRefusesCertOnlyServer() async throws {
+    guard let (caCertPath, leafCertPath, leafKeyPath) = try generateCASignedCert(
+      leafCommonName: "ocp1-test",
+      leafSubjectAltNames: "DNS:ocp1-test,IP:127.0.0.1"
+    ) else {
+      throw XCTSkip("openssl CLI not on PATH")
+    }
+    guard let p12Path = try pemToPKCS12(certPath: leafCertPath, keyPath: leafKeyPath) else {
+      throw XCTSkip("openssl CLI not on PATH")
+    }
+    let p12Data = try Data(contentsOf: URL(fileURLWithPath: p12Path))
+    let caData = try Data(contentsOf: URL(fileURLWithPath: caCertPath))
+
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    let endpoint = try await Ocp1NWSecureUDPDeviceEndpoint(
+      port: 0,
+      credential: .pkcs12(data: p12Data, password: testPKCS12Password),
+      device: device
+    )
+    let task = Task { try await endpoint.run() }
+    defer { task.cancel() }
+    let port = try await endpoint.awaitBoundPort()
+
+    let connection = try await makePSKDTLSClientWithTrustRoots(
+      port: port,
+      hostname: "ocp1-test",
+      caData: caData
+    )
+    do {
+      try await connection.connect()
+      XCTFail("DTLS PSK client should reject server's cert-only handshake")
+      try? await connection.disconnect()
+    } catch {
+      // expected
+    }
+  }
+
+  /// HIGH-1 DTLS regression: mirror of the TCP test for the UDP endpoint.
+  /// The verify helper is shared, but explicit coverage guards against a
+  /// future refactor that diverges the two.
+  func testMTLSServerRejectsServerAuthEKUCertOnDTLS() async throws {
+    guard let (caCertPath, leafCertPath, leafKeyPath) = try generateCASignedCert(
+      leafCommonName: "ocp1-test",
+      leafSubjectAltNames: "DNS:ocp1-test,IP:127.0.0.1"
+    ) else {
+      throw XCTSkip("openssl CLI not on PATH")
+    }
+    guard let p12Path = try pemToPKCS12(certPath: leafCertPath, keyPath: leafKeyPath) else {
+      throw XCTSkip("openssl CLI not on PATH")
+    }
+    let p12Data = try Data(contentsOf: URL(fileURLWithPath: p12Path))
+    let caData = try Data(contentsOf: URL(fileURLWithPath: caCertPath))
+
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    let endpoint = try await Ocp1NWSecureUDPDeviceEndpoint(
+      port: 0,
+      credential: .pkcs12(data: p12Data, password: testPKCS12Password),
+      clientCertificateTrustRoots: .caData(caData),
+      device: device
+    )
+    let task = Task { try await endpoint.run() }
+    defer { task.cancel() }
+    let port = try await endpoint.awaitBoundPort()
+
+    let connection = try await makeMTLSDTLSClient(
+      port: port,
+      hostname: "ocp1-test",
+      p12Data: p12Data,
+      caData: caData
+    )
+    do {
+      try await connection.connect()
+      try await Task.sleep(for: .seconds(1))
+      let stillConnected = await connection.isConnected
+      try? await connection.disconnect()
+      XCTAssertFalse(
+        stillConnected,
+        "DTLS server should reject client cert with only serverAuth EKU"
+      )
+    } catch {
+      // expected
+    }
+  }
+
+  /// MEDIUM-4 regression: a wrong-PSK client must throw promptly from
+  /// `connectDevice()` (via the `.waiting(error)` hook) rather than hang.
+  func testWrongPSKConnectFailsFast() async throws {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    try await device.securityManager.loadPreSharedKey(
+      identity: OcaPreSharedKeyIdentityHint,
+      key: Data(repeating: 0x42, count: 32)
+    )
+
+    let endpoint = try await Ocp1NWSecureTCPDeviceEndpoint(
+      port: 0,
+      device: device
+    )
+    let task = Task { try await endpoint.run() }
+    defer { task.cancel() }
+    let port = try await endpoint.awaitBoundPort()
+
+    let connection = try await makePSKClient(
+      port: port,
+      identity: OcaPreSharedKeyIdentityHint,
+      key: Data(repeating: 0xCD, count: 32) // wrong key
+    )
+    // Fail-fast: ≤5 s is generous; before the `.waiting(error)` fix the
+    // call would hang until the (much larger) connection timeout.
+    let start = ContinuousClock.now
+    do {
+      try await connection.connect()
+      XCTFail("wrong PSK should fail the handshake")
+      try? await connection.disconnect()
+    } catch {
+      let elapsed = ContinuousClock.now - start
+      XCTAssertLessThan(
+        elapsed, .seconds(5),
+        "wrong-PSK should fail fast via .waiting(error), not hang"
+      )
+    }
+  }
+}
+
+#endif

--- a/Tests/SwiftOCADeviceTests/BackendConnectionTests.swift
+++ b/Tests/SwiftOCADeviceTests/BackendConnectionTests.swift
@@ -14,11 +14,13 @@
 // limitations under the License.
 //
 
-#if os(macOS) || os(iOS)
+#if (os(macOS) || os(iOS)) && NonEmbeddedBuild
 
 import FlyingSocks
 @testable @_spi(SwiftOCAPrivate) import SwiftOCA
 @testable @_spi(SwiftOCAPrivate) import SwiftOCADevice
+import SwiftOCASecure
+import SwiftOCASecureDevice
 @preconcurrency import XCTest
 
 // MARK: - helpers
@@ -84,6 +86,17 @@ private func makeNWTCPConnection(
 ) throws -> Ocp1NWTCPConnection {
   let clientAddress = localhostAddress(port: port)
   return try Ocp1NWTCPConnection(
+    deviceAddress: clientAddress,
+    options: Ocp1ConnectionOptions(flags: .refreshDeviceTreeOnConnection)
+  )
+}
+
+@OcaConnection
+private func makeNWUDPConnection(
+  port: UInt16
+) throws -> Ocp1NWUDPConnection {
+  let clientAddress = localhostAddress(port: port)
+  return try Ocp1NWUDPConnection(
     deviceAddress: clientAddress,
     options: Ocp1ConnectionOptions(flags: .refreshDeviceTreeOnConnection)
   )
@@ -252,6 +265,232 @@ final class NWConnectionTests: XCTestCase {
       "Server controller was not cleaned up after NWConnection client disconnected"
     )
   }
+}
+
+@OcaConnection
+private func makeNWSecureTCPConnection(
+  port: UInt16,
+  credential: Ocp1TLSCredential
+) throws -> Ocp1NWSecureTCPConnection {
+  let clientAddress = localhostAddress(port: port)
+  return try Ocp1NWSecureTCPConnection(
+    deviceAddress: clientAddress,
+    credential: credential,
+    options: Ocp1ConnectionOptions(flags: .refreshDeviceTreeOnConnection)
+  )
+}
+
+// MARK: - Network.framework device endpoint tests
+
+final class NWStreamDeviceEndpointTests: XCTestCase {
+  private func makeServer(
+    timeout: Duration = .seconds(5)
+  ) async throws -> (Ocp1NWTCPDeviceEndpoint, UInt16, Task<Void, Error>) {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+
+    let endpoint = try await Ocp1NWTCPDeviceEndpoint(
+      port: 0,
+      timeout: timeout,
+      device: device
+    )
+    let task = Task { try await endpoint.run() }
+    let port = try await endpoint.awaitBoundPort()
+    return (endpoint, port, task)
+  }
+
+  /// Test basic connect/disconnect against an Ocp1NWTCPDeviceEndpoint.
+  func testNWTCPDeviceEndpointConnectDisconnect() async throws {
+    let (endpoint, port, task) = try await makeServer()
+    defer { task.cancel() }
+    _ = endpoint
+
+    let connection = try await makeNWTCPConnection(port: port)
+    try await connection.connect()
+
+    let connected = await connection.isConnected
+    XCTAssertTrue(connected, "NW client should be connected to NW endpoint")
+
+    let deviceManagerONo = await connection.deviceManager.objectNumber
+    XCTAssertEqual(deviceManagerONo, OcaDeviceManagerONo)
+
+    try await connection.disconnect()
+  }
+
+  /// Test round-trip command against an Ocp1NWTCPDeviceEndpoint.
+  func testNWTCPDeviceEndpointRoundTrip() async throws {
+    let (endpoint, port, task) = try await makeServer()
+    defer { task.cancel() }
+    _ = endpoint
+
+    let connection = try await makeNWTCPConnection(port: port)
+    try await connection.connect()
+
+    let members = try await connection.rootBlock.resolveActionObjects()
+    XCTAssertFalse(members.isEmpty, "rootBlock should have members")
+
+    try await Task.sleep(for: .seconds(1))
+    let membersAgain = try await connection.rootBlock.resolveActionObjects()
+    XCTAssertEqual(members.count, membersAgain.count)
+
+    try await connection.disconnect()
+  }
+
+  /// Test that an Ocp1NWTCPDeviceEndpoint releases the controller when a client disconnects.
+  func testNWTCPDeviceEndpointControllerCleanup() async throws {
+    let (endpoint, port, task) = try await makeServer(timeout: .seconds(3))
+    defer { task.cancel() }
+
+    let connection = try await makeNWTCPConnection(port: port)
+    try await connection.connect()
+
+    let controllers = await endpoint.controllers
+    XCTAssertEqual(controllers.count, 1)
+
+    try await connection.disconnect()
+
+    try await Task.sleep(for: .seconds(1))
+    let controllersAfterDisconnect = await endpoint.controllers
+    XCTAssertEqual(
+      controllersAfterDisconnect.count, 0,
+      "NW endpoint did not clean up controller after client disconnect"
+    )
+  }
+}
+
+// MARK: - Network.framework UDP endpoint tests
+
+final class NWDatagramDeviceEndpointTests: XCTestCase {
+  private func makeServer(
+    timeout: Duration = .seconds(5)
+  ) async throws -> (Ocp1NWUDPDeviceEndpoint, UInt16, Task<Void, Error>) {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+
+    let endpoint = try await Ocp1NWUDPDeviceEndpoint(
+      port: 0,
+      timeout: timeout,
+      device: device
+    )
+    let task = Task { try await endpoint.run() }
+    let port = try await endpoint.awaitBoundPort()
+    return (endpoint, port, task)
+  }
+
+  /// Connect/disconnect against a plain NW UDP endpoint.
+  func testNWUDPDeviceEndpointConnectDisconnect() async throws {
+    let (endpoint, port, task) = try await makeServer()
+    defer { task.cancel() }
+    _ = endpoint
+
+    let connection = try await makeNWUDPConnection(port: port)
+    try await connection.connect()
+
+    let connected = await connection.isConnected
+    XCTAssertTrue(connected, "NW UDP client should be connected to NW UDP endpoint")
+
+    let deviceManagerONo = await connection.deviceManager.objectNumber
+    XCTAssertEqual(deviceManagerONo, OcaDeviceManagerONo)
+
+    try await connection.disconnect()
+  }
+
+  /// Round-trip command over a plain NW UDP endpoint.
+  func testNWUDPDeviceEndpointRoundTrip() async throws {
+    let (endpoint, port, task) = try await makeServer()
+    defer { task.cancel() }
+    _ = endpoint
+
+    let connection = try await makeNWUDPConnection(port: port)
+    try await connection.connect()
+
+    let members = try await connection.rootBlock.resolveActionObjects()
+    XCTAssertFalse(members.isEmpty, "rootBlock should have members over UDP")
+
+    try await connection.disconnect()
+  }
+
+  /// The server-side controller should report TLS-less semantics for plain UDP.
+  func testNWUDPDeviceEndpointControllerFlags() async throws {
+    let (endpoint, port, task) = try await makeServer()
+    defer { task.cancel() }
+
+    let connection = try await makeNWUDPConnection(port: port)
+    try await connection.connect()
+
+    let controllers = await endpoint.controllers
+    XCTAssertEqual(controllers.count, 1)
+    if let serverController = controllers.first {
+      XCTAssertFalse(
+        serverController.flags.contains(.hasTransportLayerSecurity),
+        "plain UDP controller must not advertise TLS"
+      )
+    }
+
+    try await connection.disconnect()
+  }
+}
+
+// MARK: - Network.framework TLS endpoint tests
+
+final class NWSecureTCPDeviceEndpointTests: XCTestCase {
+  private static let testIdentity = OcaPreSharedKeyIdentityHint
+  private static let testKey = Data(repeating: 0x42, count: 32)
+
+  private func makeSecureServer(
+    timeout: Duration = .seconds(5)
+  ) async throws -> (Ocp1NWSecureTCPDeviceEndpoint, UInt16, Task<Void, Error>) {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    try await device.securityManager.loadPreSharedKey(
+      identity: Self.testIdentity,
+      key: Self.testKey
+    )
+
+    let endpoint = try await Ocp1NWSecureTCPDeviceEndpoint(
+      port: 0,
+      timeout: timeout,
+      device: device
+    )
+    let task = Task { try await endpoint.run() }
+    let port = try await endpoint.awaitBoundPort()
+    return (endpoint, port, task)
+  }
+
+  /// Connect to a TLS device endpoint using a matching PSK and exercise a round trip.
+  func testTLSConnectAndRoundTrip() async throws {
+    let (endpoint, port, task) = try await makeSecureServer()
+    defer { task.cancel() }
+    _ = endpoint
+
+    let connection = try await makeNWSecureTCPConnection(
+      port: port,
+      credential: .preSharedKey(identity: Self.testIdentity, key: Self.testKey)
+    )
+    try await connection.connect()
+
+    let connected = await connection.isConnected
+    XCTAssertTrue(connected, "TLS PSK connection should establish")
+    let hasTLS = await connection.hasTransportLayerSecurity
+    XCTAssertTrue(hasTLS, "Ocp1NWSecureTCPConnection should report hasTransportLayerSecurity")
+
+    let members = try await connection.rootBlock.resolveActionObjects()
+    XCTAssertFalse(members.isEmpty, "rootBlock round-trip over TLS should succeed")
+
+    let controllers = await endpoint.controllers
+    XCTAssertEqual(controllers.count, 1)
+    if let serverController = controllers.first {
+      XCTAssertTrue(
+        serverController.flags.contains(.hasTransportLayerSecurity),
+        "server-side controller should report hasTransportLayerSecurity"
+      )
+    }
+
+    try await connection.disconnect()
+  }
+
+  // Negative-path regressions for HIGH-1 / HIGH-2 / MEDIUM-4 live in
+  // `AppleTLSPolicyRegressionTests`.
 }
 
 #endif

--- a/Tests/SwiftOCADeviceTests/DTLSHostileTrafficTests.swift
+++ b/Tests/SwiftOCADeviceTests/DTLSHostileTrafficTests.swift
@@ -1,0 +1,311 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Hostile-network regressions for the Linux DTLS endpoint (HIGH-3 review):
+// drive the listener with raw UDP datagrams (no DTLS client engine) and
+// assert the pre-cookie defenses contain the per-peer allocation surface.
+// We craft just enough of a ClientHello to engage cookie exchange — the
+// byte-counting in this file is the kind of thing we deliberately keep
+// out of production code, so this test parser is intentionally minimal
+// and fails loudly when it doesn't recognize what it received.
+
+#if os(Linux) && canImport(COpenSSL) && canImport(IORing) && NonEmbeddedBuild
+
+import Foundation
+import Glibc
+@testable @_spi(SwiftOCAPrivate) import SwiftOCADevice
+import SwiftOCASecure
+import SwiftOCASecureDevice
+@preconcurrency import XCTest
+
+private let loopbackAFamily = sa_family_t(AF_INET)
+
+/// `127.x.0.1` is in the loopback /8 — the kernel routes traffic on every
+/// 127.0.0.0/8 address to lo, so distinct `x` values give us distinct
+/// source IPs without configuring the interface.
+private func loopback(_ thirdOctet: UInt8) -> in_addr {
+  in_addr(s_addr: UInt32(0x7F00_0001 | (UInt32(thirdOctet) << 8)).bigEndian)
+}
+
+private func sockaddr(ip: in_addr, port: UInt16) -> sockaddr_in {
+  var sin = sockaddr_in()
+  sin.sin_family = loopbackAFamily
+  sin.sin_port = port.bigEndian
+  sin.sin_addr = ip
+  return sin
+}
+
+/// Minimal UDP socket bound to `sourceIP` on an ephemeral port. Caller
+/// closes via `close(fd)`. Returns -1 only on test infrastructure failure.
+private func openUDPSocket(sourceIP: in_addr = in_addr(s_addr: UInt32(0x7F00_0001).bigEndian)) throws -> Int32 {
+  let fd = socket(AF_INET, Int32(SOCK_DGRAM.rawValue), 0)
+  guard fd >= 0 else { throw POSIXError(.EIO) }
+  var src = sockaddr(ip: sourceIP, port: 0)
+  let rc = withUnsafePointer(to: &src) {
+    $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { sap in
+      Glibc.bind(fd, sap, socklen_t(MemoryLayout<sockaddr_in>.size))
+    }
+  }
+  guard rc == 0 else {
+    let err = errno
+    close(fd)
+    throw POSIXError(POSIXErrorCode(rawValue: err) ?? .EIO)
+  }
+  // Receive timeout so a misbehaving test doesn't hang the suite.
+  var tv = timeval(tv_sec: 1, tv_usec: 0)
+  _ = withUnsafePointer(to: &tv) {
+    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, $0, socklen_t(MemoryLayout<timeval>.size))
+  }
+  return fd
+}
+
+private func sendUDP(_ fd: Int32, bytes: [UInt8], to port: UInt16) throws {
+  var dst = sockaddr(ip: in_addr(s_addr: UInt32(0x7F00_0001).bigEndian), port: port)
+  let sent = bytes.withUnsafeBufferPointer { buf -> ssize_t in
+    withUnsafePointer(to: &dst) { dstp in
+      dstp.withMemoryRebound(to: sockaddr.self, capacity: 1) { sap in
+        sendto(fd, buf.baseAddress, buf.count, 0, sap, socklen_t(MemoryLayout<sockaddr_in>.size))
+      }
+    }
+  }
+  guard sent == bytes.count else { throw POSIXError(.EIO) }
+}
+
+private func recvUDP(_ fd: Int32, capacity: Int = 1500) -> [UInt8]? {
+  var buf = [UInt8](repeating: 0, count: capacity)
+  let n = buf.withUnsafeMutableBufferPointer { Glibc.recv(fd, $0.baseAddress, $0.count, 0) }
+  return n > 0 ? Array(buf.prefix(Int(n))) : nil
+}
+
+// MARK: - DTLS record assembly (test-only; production code stays free of
+// this byte-counting). Layout per RFC 6347; we only emit ClientHello.
+
+/// Build a DTLS 1.2 ClientHello record with the supplied `cookie` bytes.
+/// Cipher suites list one PSK suite so the server's cookie exchange fires
+/// before any cipher-mismatch rejection.
+private func buildClientHello(cookie: [UInt8] = []) -> [UInt8] {
+  let dtls12: [UInt8] = [0xFE, 0xFD]
+  // Random bytes don't matter for what we test; static counter avoids
+  // pulling in a generator.
+  let random = [UInt8](repeating: 0xA5, count: 32)
+  // Body: client_version(2) random(32) sid_len(1) cookie_len(1) cookie
+  //       cipher_suites_len(2) cipher_suites(N) compression_len(1) compression(1)
+  let cipherSuites: [UInt8] = [
+    0x00, 0x8C, // TLS_PSK_WITH_AES_128_CBC_SHA — PSK suite, engages cookie path
+    0x00, 0xFF, // TLS_EMPTY_RENEGOTIATION_INFO_SCSV
+  ]
+  var body: [UInt8] = []
+  body.append(contentsOf: dtls12)
+  body.append(contentsOf: random)
+  body.append(0) // session_id length
+  body.append(UInt8(cookie.count))
+  body.append(contentsOf: cookie)
+  body.append(UInt8((cipherSuites.count >> 8) & 0xFF))
+  body.append(UInt8(cipherSuites.count & 0xFF))
+  body.append(contentsOf: cipherSuites)
+  body.append(1) // compression methods length
+  body.append(0) // null compression
+  // Handshake header: msg_type(1) length(3) message_seq(2) frag_offset(3) frag_length(3)
+  let bodyLen = body.count
+  var handshake: [UInt8] = []
+  handshake.append(0x01) // client_hello
+  handshake.append(UInt8((bodyLen >> 16) & 0xFF))
+  handshake.append(UInt8((bodyLen >> 8) & 0xFF))
+  handshake.append(UInt8(bodyLen & 0xFF))
+  handshake.append(contentsOf: [0, 0]) // message_seq
+  handshake.append(contentsOf: [0, 0, 0]) // fragment_offset
+  handshake.append(UInt8((bodyLen >> 16) & 0xFF))
+  handshake.append(UInt8((bodyLen >> 8) & 0xFF))
+  handshake.append(UInt8(bodyLen & 0xFF))
+  handshake.append(contentsOf: body)
+  // Record header: type(1) version(2) epoch(2) seq(6) length(2)
+  let recLen = handshake.count
+  var record: [UInt8] = []
+  record.append(22) // handshake
+  record.append(contentsOf: dtls12)
+  record.append(contentsOf: [0, 0]) // epoch
+  record.append(contentsOf: [0, 0, 0, 0, 0, 0]) // sequence
+  record.append(UInt8((recLen >> 8) & 0xFF))
+  record.append(UInt8(recLen & 0xFF))
+  record.append(contentsOf: handshake)
+  return record
+}
+
+/// Extract the cookie field from a HelloVerifyRequest record at the
+/// fixed offsets RFC 6347 §4.2.1 prescribes. Returns nil if the bytes
+/// don't look like a HVR.
+private func extractCookie(fromHelloVerifyRequest bytes: [UInt8]) -> [UInt8]? {
+  guard bytes.count > 28 else { return nil }
+  // Record header (13) + handshake header (12) + body version (2) +
+  // cookie length (1). Cookie starts at offset 28.
+  guard bytes[0] == 22, bytes[13] == 0x03 else { return nil } // type=handshake, msg_type=hello_verify_request
+  let cookieLen = Int(bytes[27])
+  guard bytes.count >= 28 + cookieLen else { return nil }
+  return Array(bytes[28..<(28 + cookieLen)])
+}
+
+// MARK: - Endpoint factory
+
+@OcaDevice
+private func startEndpoint(
+  options: Ocp1OpenSSLDTLSEndpointOptions = .init()
+) async throws -> (Ocp1OpenSSLDTLSDeviceEndpoint, UInt16, Task<Void, Error>) {
+  let device = OcaDevice()
+  try await device.initializeDefaultObjects()
+  try await device.securityManager.loadPreSharedKey(
+    identity: OcaPreSharedKeyIdentityHint,
+    key: Data(repeating: 0x42, count: 32)
+  )
+  var sin = sockaddr_in()
+  sin.sin_family = loopbackAFamily
+  sin.sin_port = UInt16(0).bigEndian
+  sin.sin_addr.s_addr = UInt32(0x7F00_0001).bigEndian
+  let endpoint = try await Ocp1OpenSSLDTLSDeviceEndpoint(
+    address: sin,
+    device: device,
+    options: options
+  )
+  let port = endpoint.port
+  XCTAssertNotEqual(port, 0)
+  let task = Task { try await endpoint.run() }
+  // Give the listener a moment to enter its receive loop.
+  try await Task.sleep(for: .milliseconds(100))
+  return (endpoint, port, task)
+}
+
+// MARK: - Tests
+
+final class DTLSHostileTrafficTests: XCTestCase {
+  /// Pre-cookie filter must reject before any per-peer state is allocated.
+  func testSourceFilterRejectsBeforeAllocation() async throws {
+    let options = Ocp1OpenSSLDTLSEndpointOptions(
+      sourceAddressFilter: { _ in false }
+    )
+    let (endpoint, port, task) = try await startEndpoint(options: options)
+    defer { task.cancel() }
+
+    let fd = try openUDPSocket()
+    defer { close(fd) }
+    try sendUDP(fd, bytes: buildClientHello(), to: port)
+    try await Task.sleep(for: .milliseconds(300))
+
+    let count = await endpoint.controllers.count
+    XCTAssertEqual(count, 0, "sourceAddressFilter==false must drop pre-allocation")
+  }
+
+  /// `maxPeers` caps the per-peer table even under multi-source spray.
+  /// Uses distinct loopback IPs so the per-source-IP throttle doesn't
+  /// front-stop the cap.
+  func testMaxPeersCapHoldsUnderMultiSourceSpray() async throws {
+    let cap = 4
+    let options = Ocp1OpenSSLDTLSEndpointOptions(
+      handshakeDeadline: .seconds(30),
+      maxPeers: cap
+    )
+    let (endpoint, port, task) = try await startEndpoint(options: options)
+    defer { task.cancel() }
+
+    var fds: [Int32] = []
+    defer { for fd in fds { close(fd) } }
+    // 10 distinct source IPs > cap of 4.
+    for octet in 1...10 {
+      let fd = try openUDPSocket(sourceIP: loopback(UInt8(octet)))
+      fds.append(fd)
+      try sendUDP(fd, bytes: buildClientHello(), to: port)
+    }
+    try await Task.sleep(for: .milliseconds(500))
+
+    let count = await endpoint.controllers.count
+    XCTAssertLessThanOrEqual(count, cap, "controllers must not exceed maxPeers")
+  }
+
+  /// One source IP can't allocate more than `maxAllocationsPerSourcePerWindow`
+  /// fresh controllers within the window, even by rotating ports.
+  func testPerSourceRateLimitRefusesExtras() async throws {
+    let options = Ocp1OpenSSLDTLSEndpointOptions(
+      // Long deadline so we observe the steady-state count, not a churn race.
+      handshakeDeadline: .seconds(30)
+    )
+    let (endpoint, port, task) = try await startEndpoint(options: options)
+    defer { task.cancel() }
+
+    var fds: [Int32] = []
+    defer { for fd in fds { close(fd) } }
+    for _ in 0..<10 {
+      let fd = try openUDPSocket() // same source IP (127.0.0.1), new port each time
+      fds.append(fd)
+      try sendUDP(fd, bytes: buildClientHello(), to: port)
+    }
+    try await Task.sleep(for: .milliseconds(500))
+
+    // Per-source allocation cap defaults to 2 per 10 s window.
+    let count = await endpoint.controllers.count
+    XCTAssertLessThanOrEqual(count, 2, "per-source rate limit must front-stop port rotation")
+  }
+
+  /// A ClientHello carrying a bogus cookie can still trip the per-peer
+  /// engine into allocation, but the handshake never completes and the
+  /// GC sweep evicts the slot within ~handshakeDeadline + cadence.
+  func testInvalidCookieClientHelloEvictedByDeadline() async throws {
+    let options = Ocp1OpenSSLDTLSEndpointOptions(
+      handshakeDeadline: .seconds(2)
+    )
+    let (endpoint, port, task) = try await startEndpoint(options: options)
+    defer { task.cancel() }
+
+    let fd = try openUDPSocket()
+    defer { close(fd) }
+    try sendUDP(fd, bytes: buildClientHello(cookie: [UInt8](repeating: 0xCC, count: 32)), to: port)
+
+    // Handshake deadline + sweep cadence (max(deadline/2, 1s)) + slack.
+    try await Task.sleep(for: .seconds(5))
+    let count = await endpoint.controllers.count
+    XCTAssertEqual(count, 0, "GC sweep must evict slots stuck on bad cookies")
+  }
+
+  /// HelloVerifyRequest cookies are bound to the source address; replaying
+  /// a cookie minted for source A from source B must not satisfy the
+  /// server's cookie callback.
+  func testCookieFromOneSourceRejectedFromAnother() async throws {
+    let options = Ocp1OpenSSLDTLSEndpointOptions(
+      handshakeDeadline: .seconds(2)
+    )
+    let (endpoint, port, task) = try await startEndpoint(options: options)
+    defer { task.cancel() }
+
+    // Source A: send no-cookie ClientHello, expect HVR with a cookie.
+    let fdA = try openUDPSocket(sourceIP: loopback(11))
+    defer { close(fdA) }
+    try sendUDP(fdA, bytes: buildClientHello(), to: port)
+    guard let hvr = recvUDP(fdA), let cookieFromA = extractCookie(fromHelloVerifyRequest: hvr) else {
+      throw XCTSkip("HelloVerifyRequest not received — kernel may have lost the packet")
+    }
+    XCTAssertFalse(cookieFromA.isEmpty)
+
+    // Source B replays source A's cookie.
+    let fdB = try openUDPSocket(sourceIP: loopback(12))
+    defer { close(fdB) }
+    try sendUDP(fdB, bytes: buildClientHello(cookie: cookieFromA), to: port)
+    try await Task.sleep(for: .seconds(5)) // > handshakeDeadline + sweep
+
+    // Source B's slot must have been evicted — the cookie HMAC didn't
+    // match B's source address, so the engine never completed handshake.
+    let count = await endpoint.controllers.count
+    XCTAssertEqual(count, 0, "cross-source cookie replay must not authenticate")
+  }
+}
+
+#endif

--- a/Tests/SwiftOCADeviceTests/OpenSSLConnectionTests.swift
+++ b/Tests/SwiftOCADeviceTests/OpenSSLConnectionTests.swift
@@ -1,0 +1,396 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if os(Linux)
+#if canImport(COpenSSL) && canImport(IORing)
+
+import Foundation
+import Glibc
+@testable @_spi(SwiftOCAPrivate) import SwiftOCA
+@testable @_spi(SwiftOCAPrivate) import SwiftOCADevice
+import SwiftOCASecure
+@testable import SwiftOCASecureDevice
+@preconcurrency import XCTest
+
+private func loopbackAddress(port: UInt16) -> sockaddr_in {
+  var sin = sockaddr_in()
+  sin.sin_family = sa_family_t(AF_INET)
+  sin.sin_port = port.bigEndian
+  sin.sin_addr.s_addr = UInt32(0x7F00_0001).bigEndian // 127.0.0.1
+  return sin
+}
+
+private func loopbackAddressData(port: UInt16) -> Data {
+  let sin = loopbackAddress(port: port)
+  return withUnsafeBytes(of: sin) { Data($0) }
+}
+
+@OcaConnection
+private func makeOpenSSLConnection(
+  port: UInt16,
+  credential: Ocp1TLSCredential,
+  hostname: String? = nil,
+  trustRoots: Ocp1TLSTrustRoots? = nil,
+  flags: Ocp1ConnectionFlags = .refreshDeviceTreeOnConnection
+) throws -> Ocp1OpenSSLConnection {
+  try Ocp1OpenSSLConnection(
+    deviceAddress: loopbackAddressData(port: port),
+    credential: credential,
+    hostname: hostname,
+    trustRoots: trustRoots,
+    options: Ocp1ConnectionOptions(flags: flags)
+  )
+}
+
+final class OpenSSLConnectionTests: XCTestCase {
+  private static let testIdentity = OcaPreSharedKeyIdentityHint
+  private static let testKey = Data(repeating: 0x42, count: 32)
+
+  private func makeSecureServer(
+    timeout: Duration = .seconds(5)
+  ) async throws -> (Ocp1OpenSSLStreamDeviceEndpoint, UInt16, Task<Void, Error>) {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    try await device.securityManager.loadPreSharedKey(
+      identity: Self.testIdentity,
+      key: Self.testKey
+    )
+
+    let endpoint = try await Ocp1OpenSSLStreamDeviceEndpoint(
+      address: loopbackAddress(port: 0),
+      timeout: timeout,
+      device: device
+    )
+    let port = endpoint.port
+    XCTAssertNotEqual(port, 0, "endpoint should report bound port after init")
+    let task = Task { try await endpoint.run() }
+    return (endpoint, port, task)
+  }
+
+  /// Wait for a server task to actually exit. `defer { task.cancel() }`
+  /// is fire-and-forget — the kernel socket fd may still be open when the
+  /// next test starts, racing the new endpoint's bind. Awaiting `task.value`
+  /// after cancel forces the run loop's `socket = nil` and `device.remove`
+  /// to complete before we return, so the previous endpoint is fully gone
+  /// before the next test creates its own.
+  private func awaitTeardown(_ task: Task<Void, Error>) async {
+    task.cancel()
+    _ = try? await task.value
+  }
+
+  /// Connect to a TLS device endpoint using a matching PSK and exercise a round trip.
+  func testTLSConnectAndRoundTrip() async throws {
+    let (endpoint, port, task) = try await makeSecureServer()
+    defer { task.cancel() }
+    _ = endpoint
+
+    // Give the endpoint a moment to enter accept()
+    try await Task.sleep(for: .milliseconds(100))
+
+    let connection = try await makeOpenSSLConnection(
+      port: port,
+      credential: .preSharedKey(identity: Self.testIdentity, key: Self.testKey)
+    )
+    try await connection.connect()
+
+    let connected = await connection.isConnected
+    XCTAssertTrue(connected, "TLS PSK connection should establish")
+    let hasTLS = await connection.hasTransportLayerSecurity
+    XCTAssertTrue(hasTLS, "Ocp1OpenSSLConnection should report hasTransportLayerSecurity")
+
+    let members = try await connection.rootBlock.resolveActionObjects()
+    XCTAssertFalse(members.isEmpty, "rootBlock round-trip over TLS should succeed")
+
+    let controllers = await endpoint.controllers
+    XCTAssertEqual(controllers.count, 1)
+    if let serverController = controllers.first {
+      XCTAssertTrue(
+        serverController.flags.contains(.hasTransportLayerSecurity),
+        "server-side controller should report hasTransportLayerSecurity"
+      )
+      // PSK identity captured in the OpenSSL PSK callback must surface on
+      // the controller so future ACL gates can authorize on it.
+      switch serverController.peerIdentity {
+      case .preSharedKey(let id):
+        XCTAssertEqual(
+          id,
+          Self.testIdentity,
+          "captured PSK identity should match what the client presented"
+        )
+      default:
+        XCTFail(
+          "expected .preSharedKey peer identity after PSK handshake, got \(serverController.peerIdentity)"
+        )
+      }
+    }
+
+    try await connection.disconnect()
+    await awaitTeardown(task)
+  }
+
+  /// Spin up the endpoint with a self-signed certificate, then prove the
+  /// client rejects it by default but accepts it when the caller opts into
+  /// `.disableCertificateVerification`. Covers the cert-mode verification
+  /// path end-to-end so regressions in either the engine's `SSL_VERIFY_*`
+  /// wiring or the connection-flag plumbing surface here.
+  func testTLSCertificateVerification() async throws {
+    guard let cert = try generateSelfSignedCert() else {
+      throw XCTSkip("openssl CLI not available; cannot generate self-signed cert")
+    }
+    defer { try? FileManager.default.removeItem(atPath: (cert.certPath as NSString).deletingLastPathComponent) }
+
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    let endpoint = try await Ocp1OpenSSLStreamDeviceEndpoint(
+      address: loopbackAddress(port: 0),
+      credential: .certificateFile(certPath: cert.certPath, keyPath: cert.keyPath),
+      timeout: .seconds(5),
+      device: device
+    )
+    let port = endpoint.port
+    let task = Task { try await endpoint.run() }
+    defer { task.cancel() }
+    try await Task.sleep(for: .milliseconds(100))
+
+    // Same cert used as the client credential — its content isn't what's
+    // being tested. We only care that the server's cert fails chain validation
+    // against the system trust store unless verification is disabled.
+    let clientCredential = Ocp1TLSCredential.certificateFile(
+      certPath: cert.certPath,
+      keyPath: cert.keyPath
+    )
+
+    // 1. Default flags → chain check against system roots rejects self-signed.
+    // Hostname is required when verification is enabled and the credential
+    // isn't a PSK; pass the SAN so this exercises the chain-validation path
+    // rather than the missing-hostname pre-check.
+    let strictConnection = try await makeOpenSSLConnection(
+      port: port,
+      credential: clientCredential,
+      hostname: "ocp1-test",
+      flags: []
+    )
+    do {
+      try await strictConnection.connect()
+      XCTFail("self-signed server cert should be rejected by default verification")
+      try? await strictConnection.disconnect()
+    } catch {
+      // Expected.
+    }
+
+    // 2. `.disableCertificateVerification` → handshake completes, OCP.1 works.
+    let lenientConnection = try await makeOpenSSLConnection(
+      port: port,
+      credential: clientCredential,
+      flags: [.refreshDeviceTreeOnConnection, .disableCertificateVerification]
+    )
+    try await lenientConnection.connect()
+    let connected = await lenientConnection.isConnected
+    XCTAssertTrue(connected, "connection with verification disabled should establish")
+    let members = try await lenientConnection.rootBlock.resolveActionObjects()
+    XCTAssertFalse(members.isEmpty, "OCP.1 round trip should succeed once TLS is up")
+    try await lenientConnection.disconnect()
+    await awaitTeardown(task)
+  }
+
+  /// Configure the endpoint to *require* a client certificate (mTLS) and
+  /// verify the server actually rejects clients that don't present one
+  /// while accepting clients that do. A single self-signed cert plays
+  /// three roles: server identity, server's trust anchor for client certs,
+  /// and the client's identity + server-trust-anchor — sufficient because
+  /// a self-signed cert is its own root.
+  func testTLSMutualAuthentication() async throws {
+    guard let cert = try generateSelfSignedCert() else {
+      throw XCTSkip("openssl CLI not available; cannot generate self-signed cert")
+    }
+    defer { try? FileManager.default.removeItem(atPath: (cert.certPath as NSString).deletingLastPathComponent) }
+
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    let endpoint = try await Ocp1OpenSSLStreamDeviceEndpoint(
+      address: loopbackAddress(port: 0),
+      credential: .certificateFile(certPath: cert.certPath, keyPath: cert.keyPath),
+      clientCertificateTrustRoots: .caFile(cert.certPath),
+      timeout: .seconds(5),
+      device: device
+    )
+    let port = endpoint.port
+    let task = Task { try await endpoint.run() }
+    defer { task.cancel() }
+    try await Task.sleep(for: .milliseconds(100))
+
+    let clientCredential = Ocp1TLSCredential.certificateFile(
+      certPath: cert.certPath,
+      keyPath: cert.keyPath
+    )
+
+    // Client supplies a cert that chains (== is) the server's trust anchor,
+    // and trusts the server cert via the same anchor. mTLS handshake completes.
+    // `hostname` matches the SAN minted by `generateSelfSignedCert`.
+    let mutualConnection = try await makeOpenSSLConnection(
+      port: port,
+      credential: clientCredential,
+      hostname: "ocp1-test",
+      trustRoots: .caFile(cert.certPath)
+    )
+    try await mutualConnection.connect()
+    let connected = await mutualConnection.isConnected
+    XCTAssertTrue(connected, "mTLS handshake should succeed when both sides chain to the same anchor")
+    let members = try await mutualConnection.rootBlock.resolveActionObjects()
+    XCTAssertFalse(members.isEmpty, "OCP.1 round trip should succeed over mTLS")
+    try await mutualConnection.disconnect()
+    await awaitTeardown(task)
+  }
+
+  /// Negative PSK test: server expects `Self.testKey` but client connects
+  /// with a different key. The handshake derives different session keys on
+  /// each side and the first encrypted record's MAC fails, which OpenSSL
+  /// surfaces as `bad record mac`. We only assert the throw — not the
+  /// specific error string — so future OpenSSL builds with different alert
+  /// wording don't make the test flaky.
+  func testTLSPSKWrongKeyRejected() async throws {
+    let (endpoint, port, task) = try await makeSecureServer()
+    defer { task.cancel() }
+    _ = endpoint
+    try await Task.sleep(for: .milliseconds(100))
+
+    let wrongKey = Data(repeating: 0xAA, count: 32) // different from Self.testKey
+    let connection = try await makeOpenSSLConnection(
+      port: port,
+      credential: .preSharedKey(identity: Self.testIdentity, key: wrongKey)
+    )
+    do {
+      try await connection.connect()
+      try? await connection.disconnect()
+      XCTFail("handshake should fail when PSKs don't match")
+    } catch {
+      // Expected — exact diagnostic varies by OpenSSL version.
+    }
+    await awaitTeardown(task)
+  }
+
+  /// mTLS and PSK are independent OCP.1 auth paths. A server with mTLS
+  /// configured *and* PSKs registered should still accept a client that
+  /// presents a valid PSK — PSK already provides mutual authentication via
+  /// the shared secret, so cert-based mTLS doesn't apply to that handshake.
+  /// (A peer that presents *neither* a valid PSK nor a valid client cert
+  /// is rejected, but those failure modes are covered by other tests.)
+  func testTLSMutualAuthAllowsPSKClient() async throws {
+    guard let cert = try generateSelfSignedCert() else {
+      throw XCTSkip("openssl CLI not available; cannot generate self-signed cert")
+    }
+    defer { try? FileManager.default.removeItem(atPath: (cert.certPath as NSString).deletingLastPathComponent) }
+
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    try await device.securityManager.loadPreSharedKey(
+      identity: Self.testIdentity,
+      key: Self.testKey
+    )
+    let endpoint = try await Ocp1OpenSSLStreamDeviceEndpoint(
+      address: loopbackAddress(port: 0),
+      credential: .certificateFile(certPath: cert.certPath, keyPath: cert.keyPath),
+      clientCertificateTrustRoots: .caFile(cert.certPath),
+      timeout: .seconds(5),
+      device: device
+    )
+    let port = endpoint.port
+    let task = Task { try await endpoint.run() }
+    defer { task.cancel() }
+    try await Task.sleep(for: .milliseconds(100))
+
+    let connection = try await makeOpenSSLConnection(
+      port: port,
+      credential: .preSharedKey(identity: Self.testIdentity, key: Self.testKey)
+    )
+    try await connection.connect()
+    let connected = await connection.isConnected
+    XCTAssertTrue(connected, "PSK handshake should succeed even when mTLS is configured for cert clients")
+    let members = try await connection.rootBlock.resolveActionObjects()
+    XCTAssertFalse(members.isEmpty, "OCP.1 round trip should succeed over PSK against a dual-mode endpoint")
+    try await connection.disconnect()
+    await awaitTeardown(task)
+  }
+
+  /// Hostname verification test: cert has SAN `ocp1-test` / `127.0.0.1`,
+  /// but the client asks the engine to verify against `wrong-host`.
+  /// OpenSSL's hostname check (via `SSL_set1_host`) should reject it
+  /// even though chain validation against the same self-signed anchor
+  /// would otherwise pass.
+  func testTLSCertificateVerificationRejectsWrongHostname() async throws {
+    guard let cert = try generateSelfSignedCert() else {
+      throw XCTSkip("openssl CLI not available; cannot generate self-signed cert")
+    }
+    defer { try? FileManager.default.removeItem(atPath: (cert.certPath as NSString).deletingLastPathComponent) }
+
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    let endpoint = try await Ocp1OpenSSLStreamDeviceEndpoint(
+      address: loopbackAddress(port: 0),
+      credential: .certificateFile(certPath: cert.certPath, keyPath: cert.keyPath),
+      timeout: .seconds(5),
+      device: device
+    )
+    let port = endpoint.port
+    let task = Task { try await endpoint.run() }
+    defer { task.cancel() }
+    try await Task.sleep(for: .milliseconds(100))
+
+    let clientCredential = Ocp1TLSCredential.certificateFile(
+      certPath: cert.certPath,
+      keyPath: cert.keyPath
+    )
+
+    // Anchor at the self-signed cert (so chain validation succeeds) but
+    // demand a hostname the cert doesn't carry — the verifier should
+    // reject on SAN/CN mismatch.
+    let connection = try await Ocp1OpenSSLConnection.makeForHostname(
+      port: port,
+      credential: clientCredential,
+      hostname: "wrong-host",
+      trustRoots: .caFile(cert.certPath)
+    )
+    do {
+      try await connection.connect()
+      try? await connection.disconnect()
+      XCTFail("hostname-mismatched cert should be rejected by SSL_set1_host check")
+    } catch {
+      // Expected.
+    }
+    await awaitTeardown(task)
+  }
+}
+
+private extension Ocp1OpenSSLConnection {
+  @OcaConnection
+  static func makeForHostname(
+    port: UInt16,
+    credential: Ocp1TLSCredential,
+    hostname: String,
+    trustRoots: Ocp1TLSTrustRoots?
+  ) throws -> Ocp1OpenSSLConnection {
+    try Ocp1OpenSSLConnection(
+      deviceAddress: loopbackAddressData(port: port),
+      credential: credential,
+      hostname: hostname,
+      trustRoots: trustRoots,
+      options: Ocp1ConnectionOptions(flags: .refreshDeviceTreeOnConnection)
+    )
+  }
+}
+
+#endif
+#endif

--- a/Tests/SwiftOCADeviceTests/OpenSSLDTLSConnectionTests.swift
+++ b/Tests/SwiftOCADeviceTests/OpenSSLDTLSConnectionTests.swift
@@ -1,0 +1,147 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if os(Linux)
+#if canImport(COpenSSL) && canImport(IORing)
+
+import Foundation
+import Glibc
+@testable @_spi(SwiftOCAPrivate) import SwiftOCA
+@testable @_spi(SwiftOCAPrivate) import SwiftOCADevice
+import SwiftOCASecure
+@testable import SwiftOCASecureDevice
+@preconcurrency import XCTest
+
+private func dtlsLoopbackAddress(port: UInt16) -> sockaddr_in {
+  var sin = sockaddr_in()
+  sin.sin_family = sa_family_t(AF_INET)
+  sin.sin_port = port.bigEndian
+  sin.sin_addr.s_addr = UInt32(0x7F00_0001).bigEndian
+  return sin
+}
+
+private func dtlsLoopbackAddressData(port: UInt16) -> Data {
+  let sin = dtlsLoopbackAddress(port: port)
+  return withUnsafeBytes(of: sin) { Data($0) }
+}
+
+@OcaConnection
+private func makeDTLSConnection(
+  port: UInt16,
+  credential: Ocp1TLSCredential
+) throws -> Ocp1OpenSSLDTLSConnection {
+  try Ocp1OpenSSLDTLSConnection(
+    deviceAddress: dtlsLoopbackAddressData(port: port),
+    credential: credential,
+    options: Ocp1ConnectionOptions(flags: .refreshDeviceTreeOnConnection)
+  )
+}
+
+final class OpenSSLDTLSConnectionTests: XCTestCase {
+  private static let testIdentity = OcaPreSharedKeyIdentityHint
+  private static let testKey = Data(repeating: 0x42, count: 32)
+
+  private func makeSecureServer(
+    timeout: Duration = .seconds(5)
+  ) async throws -> (Ocp1OpenSSLDTLSDeviceEndpoint, UInt16, Task<Void, Error>) {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    try await device.securityManager.loadPreSharedKey(
+      identity: Self.testIdentity,
+      key: Self.testKey
+    )
+
+    let endpoint = try await Ocp1OpenSSLDTLSDeviceEndpoint(
+      address: dtlsLoopbackAddress(port: 0),
+      timeout: timeout,
+      device: device
+    )
+    let port = endpoint.port
+    XCTAssertNotEqual(port, 0, "endpoint should report bound port after init")
+    let task = Task { try await endpoint.run() }
+    return (endpoint, port, task)
+  }
+
+  /// PSK handshake + round-trip over DTLS. Confirms the engine selects
+  /// DTLS_*_method when transport is .datagram, that the per-peer demux on
+  /// the server feeds records into the right engine, and that the message
+  /// round-trip survives the BIO pump.
+  func testDTLSConnectAndRoundTrip() async throws {
+    let (endpoint, port, task) = try await makeSecureServer()
+    defer { task.cancel() }
+    _ = endpoint
+
+    try await Task.sleep(for: .milliseconds(100))
+
+    let connection = try await makeDTLSConnection(
+      port: port,
+      credential: .preSharedKey(identity: Self.testIdentity, key: Self.testKey)
+    )
+    try await connection.connect()
+
+    let connected = await connection.isConnected
+    XCTAssertTrue(connected, "DTLS PSK connection should establish")
+    let hasTLS = await connection.hasTransportLayerSecurity
+    XCTAssertTrue(hasTLS, "Ocp1OpenSSLDTLSConnection should report hasTransportLayerSecurity")
+    let isDatagram = await connection.isDatagram
+    XCTAssertTrue(isDatagram, "Ocp1OpenSSLDTLSConnection should report isDatagram")
+
+    let members = try await connection.rootBlock.resolveActionObjects()
+    XCTAssertFalse(members.isEmpty, "rootBlock round-trip over DTLS should succeed")
+
+    let controllers = await endpoint.controllers
+    XCTAssertEqual(controllers.count, 1)
+    if let serverController = controllers.first {
+      XCTAssertTrue(
+        serverController.flags.contains(.hasTransportLayerSecurity),
+        "server-side controller should report hasTransportLayerSecurity"
+      )
+    }
+
+    try await connection.disconnect()
+  }
+
+  /// Wrong PSK key on the client side must not complete the DTLS handshake.
+  /// With OpenSSL silently dropping bad-binder ClientHellos rather than
+  /// alerting (a deliberate DoS-amplification mitigation), the client's
+  /// `connect()` should hit the connection-timeout path and fail.
+  func testDTLSPSKWrongKeyRejected() async throws {
+    let (endpoint, port, task) = try await makeSecureServer()
+    defer { task.cancel() }
+    _ = endpoint
+
+    try await Task.sleep(for: .milliseconds(100))
+
+    let wrongKey = Data(repeating: 0x11, count: 32)
+    let connection = try await Ocp1OpenSSLDTLSConnection(
+      deviceAddress: dtlsLoopbackAddressData(port: port),
+      credential: .preSharedKey(identity: Self.testIdentity, key: wrongKey),
+      options: Ocp1ConnectionOptions(
+        flags: .refreshDeviceTreeOnConnection,
+        connectionTimeout: .seconds(2)
+      )
+    )
+    do {
+      try await connection.connect()
+      XCTFail("Wrong-PSK client should not have completed the DTLS handshake")
+    } catch {
+      // expected: handshake never completes, connect times out
+    }
+  }
+}
+
+#endif
+#endif

--- a/Tests/SwiftOCADeviceTests/OpenSSLEnginePipeTests.swift
+++ b/Tests/SwiftOCADeviceTests/OpenSSLEnginePipeTests.swift
@@ -1,0 +1,383 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+
+#if os(Linux)
+#if canImport(COpenSSL) && canImport(IORing)
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+@_spi(SwiftOCAPrivate)
+import SwiftOCA
+import SwiftOCASecure
+@preconcurrency import XCTest
+
+/// Engine-level round-trip tests that drive `Ocp1OpenSSLEngine` against an
+/// in-memory `PipeByteStream` pair — no real socket, no kernel state, no
+/// port reuse, no flake from accept-loop overlap. Validates the engine's
+/// handshake and read/write paths in isolation from the IORing transport.
+final class OpenSSLEnginePipeTests: XCTestCase {
+  private static let pskIdentity = "test-id"
+  private static let pskKey = Data(repeating: 0xCD, count: 32)
+
+  /// Drive `clientFn` and `serverFn` concurrently against a connected pipe
+  /// pair, returning the `(client, server)` results once both finish.
+  private func driveBoth<C: Sendable, S: Sendable>(
+    client clientFn: @Sendable @escaping (PipeByteStream) async throws -> C,
+    server serverFn: @Sendable @escaping (PipeByteStream) async throws -> S
+  ) async throws -> (C, S) {
+    let (clientPipe, serverPipe) = PipeByteStream.makePair()
+    async let clientResult = clientFn(clientPipe)
+    async let serverResult = serverFn(serverPipe)
+    return try await (clientResult, serverResult)
+  }
+
+  // MARK: - PSK round-trip
+
+  func testEnginePSKHandshakeAndRoundTrip() async throws {
+    let payload = Data("hello tls".utf8)
+
+    let (clientReceived, serverReceived): (Data, Data) = try await driveBoth(
+      client: { stream in
+        let engine = try Ocp1OpenSSLEngine(
+          mode: .client,
+          credential: .preSharedKey(identity: Self.pskIdentity, key: Self.pskKey)
+        )
+        try await engine.handshake(
+          read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+          write: { d in try await stream.write(d) }
+        )
+        // Send our payload then read the server's reply.
+        _ = try await engine.write(
+          payload,
+          read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+          write: { d in try await stream.write(d) }
+        )
+        return try await engine.read(
+          payload.count,
+          read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+          write: { d in try await stream.write(d) }
+        )
+      },
+      server: { stream in
+        let engine = try Ocp1OpenSSLEngine(
+          mode: .server,
+          credential: nil,
+          serverPSKProvider: TestPSKProvider(keys: [Self.pskIdentity: Self.pskKey])
+        )
+        try await engine.handshake(
+          read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+          write: { d in try await stream.write(d) }
+        )
+        // Echo whatever we receive.
+        let inbound = try await engine.read(
+          payload.count,
+          read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+          write: { d in try await stream.write(d) }
+        )
+        _ = try await engine.write(
+          inbound,
+          read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+          write: { d in try await stream.write(d) }
+        )
+        return inbound
+      }
+    )
+
+    XCTAssertEqual(serverReceived, payload, "server should receive exact client payload")
+    XCTAssertEqual(clientReceived, payload, "client should receive echoed payload")
+  }
+
+  // MARK: - PSK mismatch
+
+  func testEnginePSKMismatchFailsHandshake() async throws {
+    let wrongKey = Data(repeating: 0x11, count: 32)
+
+    do {
+      _ = try await driveBoth(
+        client: { stream in
+          let engine = try Ocp1OpenSSLEngine(
+            mode: .client,
+            credential: .preSharedKey(identity: Self.pskIdentity, key: wrongKey)
+          )
+          try await engine.handshake(
+            read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+            write: { d in try await stream.write(d) }
+          )
+          return ()
+        },
+        server: { stream in
+          let engine = try Ocp1OpenSSLEngine(
+            mode: .server,
+            credential: nil,
+            serverPSKProvider: TestPSKProvider(keys: [Self.pskIdentity: Self.pskKey])
+          )
+          try await engine.handshake(
+            read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+            write: { d in try await stream.write(d) }
+          )
+          return ()
+        }
+      )
+      XCTFail("PSK mismatch should have failed the handshake")
+    } catch {
+      // Expected — either side may raise the failure first.
+    }
+  }
+
+  // MARK: - Certificate verification
+
+  /// Server presents a self-signed cert; a strict client (verifyPeer = true,
+  /// no trust roots → defaults to system store) refuses the chain.
+  /// Engine-level mirror of `OpenSSLConnectionTests.testTLSCertificateVerification`'s
+  /// strict path — runs against an in-memory pipe so it can't suffer the
+  /// suite-overlap accept-loop flake.
+  func testEngineCertVerificationStrictRejectsSelfSigned() async throws {
+    guard let cert = try generateSelfSignedCert() else {
+      throw XCTSkip("openssl CLI not available; cannot generate self-signed cert")
+    }
+    defer {
+      try? FileManager.default.removeItem(
+        atPath: (cert.certPath as NSString).deletingLastPathComponent
+      )
+    }
+
+    do {
+      _ = try await driveBoth(
+        client: { stream in
+          // Hostname matches the cert's SAN so we exercise the actual
+          // chain-validation path (which fails because the self-signed
+          // cert isn't in the system trust store), rather than tripping
+          // the engine's hostname-required pre-check.
+          let engine = try Ocp1OpenSSLEngine(
+            mode: .client,
+            credential: .certificateFile(certPath: cert.certPath, keyPath: cert.keyPath),
+            verifyPeer: true,
+            hostname: "ocp1-test"
+          )
+          try await engine.handshake(
+            read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+            write: { d in try await stream.write(d) }
+          )
+          return ()
+        },
+        server: { stream in
+          let engine = try Ocp1OpenSSLEngine(
+            mode: .server,
+            credential: .certificateFile(certPath: cert.certPath, keyPath: cert.keyPath)
+          )
+          try await engine.handshake(
+            read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+            write: { d in try await stream.write(d) }
+          )
+          return ()
+        }
+      )
+      XCTFail("strict client should reject self-signed server cert")
+    } catch {
+      // Expected — error wording varies by OpenSSL version; we only assert
+      // the throw, mirroring the full-stack test's contract.
+    }
+  }
+
+  /// Same self-signed server, but the client opts out of verification
+  /// (`verifyPeer: false`) — handshake should succeed. Engine-level mirror
+  /// of `OpenSSLConnectionTests.testTLSCertificateVerification`'s lenient path.
+  func testEngineCertVerificationDisabledAcceptsSelfSigned() async throws {
+    guard let cert = try generateSelfSignedCert() else {
+      throw XCTSkip("openssl CLI not available; cannot generate self-signed cert")
+    }
+    defer {
+      try? FileManager.default.removeItem(
+        atPath: (cert.certPath as NSString).deletingLastPathComponent
+      )
+    }
+
+    let payload = Data("hello".utf8)
+    let (clientReceived, serverReceived): (Data, Data) = try await driveBoth(
+      client: { stream in
+        let engine = try Ocp1OpenSSLEngine(
+          mode: .client,
+          credential: .certificateFile(certPath: cert.certPath, keyPath: cert.keyPath),
+          verifyPeer: false
+        )
+        try await engine.handshake(
+          read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+          write: { d in try await stream.write(d) }
+        )
+        _ = try await engine.write(
+          payload,
+          read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+          write: { d in try await stream.write(d) }
+        )
+        return try await engine.read(
+          payload.count,
+          read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+          write: { d in try await stream.write(d) }
+        )
+      },
+      server: { stream in
+        let engine = try Ocp1OpenSSLEngine(
+          mode: .server,
+          credential: .certificateFile(certPath: cert.certPath, keyPath: cert.keyPath)
+        )
+        try await engine.handshake(
+          read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+          write: { d in try await stream.write(d) }
+        )
+        let inbound = try await engine.read(
+          payload.count,
+          read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+          write: { d in try await stream.write(d) }
+        )
+        _ = try await engine.write(
+          inbound,
+          read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+          write: { d in try await stream.write(d) }
+        )
+        return inbound
+      }
+    )
+    XCTAssertEqual(serverReceived, payload)
+    XCTAssertEqual(clientReceived, payload)
+  }
+
+  // MARK: - mTLS (mutual cert authentication)
+
+  /// Both ends present the same self-signed cert and trust the same CA file
+  /// (the cert is its own root). Mirror of
+  /// `OpenSSLConnectionTests.testTLSMutualAuthentication`.
+  func testEngineMutualAuthentication() async throws {
+    guard let cert = try generateSelfSignedCert() else {
+      throw XCTSkip("openssl CLI not available; cannot generate self-signed cert")
+    }
+    defer {
+      try? FileManager.default.removeItem(
+        atPath: (cert.certPath as NSString).deletingLastPathComponent
+      )
+    }
+
+    let payload = Data("mtls hello".utf8)
+    let (_, serverReceived): (Data, Data) = try await driveBoth(
+      client: { stream in
+        // Hostname matches the cert's SAN so the verifier chain check
+        // succeeds (the cert is its own anchor and bears the SAN).
+        let engine = try Ocp1OpenSSLEngine(
+          mode: .client,
+          credential: .certificateFile(certPath: cert.certPath, keyPath: cert.keyPath),
+          verifyPeer: true,
+          hostname: "ocp1-test",
+          trustRoots: .caFile(cert.certPath)
+        )
+        try await engine.handshake(
+          read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+          write: { d in try await stream.write(d) }
+        )
+        _ = try await engine.write(
+          payload,
+          read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+          write: { d in try await stream.write(d) }
+        )
+        return Data()
+      },
+      server: { stream in
+        let engine = try Ocp1OpenSSLEngine(
+          mode: .server,
+          credential: .certificateFile(certPath: cert.certPath, keyPath: cert.keyPath),
+          clientTrustRoots: .caFile(cert.certPath)
+        )
+        try await engine.handshake(
+          read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+          write: { d in try await stream.write(d) }
+        )
+        return try await engine.read(
+          payload.count,
+          read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+          write: { d in try await stream.write(d) }
+        )
+      }
+    )
+    XCTAssertEqual(serverReceived, payload)
+  }
+
+  /// mTLS-configured server should still accept a PSK client — PSK provides
+  /// mutual authentication via the shared secret, so cert-based mTLS doesn't
+  /// apply to that handshake. Mirror of
+  /// `OpenSSLConnectionTests.testTLSMutualAuthAllowsPSKClient`.
+  func testEngineMutualAuthAllowsPSKClient() async throws {
+    guard let cert = try generateSelfSignedCert() else {
+      throw XCTSkip("openssl CLI not available; cannot generate self-signed cert")
+    }
+    defer {
+      try? FileManager.default.removeItem(
+        atPath: (cert.certPath as NSString).deletingLastPathComponent
+      )
+    }
+
+    let payload = Data("psk over mtls server".utf8)
+    let (_, serverReceived): (Data, Data) = try await driveBoth(
+      client: { stream in
+        let engine = try Ocp1OpenSSLEngine(
+          mode: .client,
+          credential: .preSharedKey(identity: Self.pskIdentity, key: Self.pskKey)
+        )
+        try await engine.handshake(
+          read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+          write: { d in try await stream.write(d) }
+        )
+        _ = try await engine.write(
+          payload,
+          read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+          write: { d in try await stream.write(d) }
+        )
+        return Data()
+      },
+      server: { stream in
+        let engine = try Ocp1OpenSSLEngine(
+          mode: .server,
+          credential: .certificateFile(certPath: cert.certPath, keyPath: cert.keyPath),
+          serverPSKProvider: TestPSKProvider(keys: [Self.pskIdentity: Self.pskKey]),
+          clientTrustRoots: .caFile(cert.certPath)
+        )
+        try await engine.handshake(
+          read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+          write: { d in try await stream.write(d) }
+        )
+        return try await engine.read(
+          payload.count,
+          read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+          write: { d in try await stream.write(d) }
+        )
+      }
+    )
+    XCTAssertEqual(serverReceived, payload)
+  }
+}
+
+/// In-memory `OcaPreSharedKeyProvider` used by engine pipe tests. Stores a
+/// dictionary of identity → key bytes; reads serve directly from that dict.
+private struct TestPSKProvider: OcaPreSharedKeyProvider {
+  let keys: [String: Data]
+
+  func withPreSharedKey<T>(
+    forIdentity identity: String,
+    _ body: (UnsafeBufferPointer<UInt8>) throws -> T
+  ) rethrows -> T? {
+    guard let key = keys[identity] else { return nil }
+    return try key.withUnsafeBytes { raw in
+      try body(raw.bindMemory(to: UInt8.self))
+    }
+  }
+}
+
+#endif
+#endif

--- a/Tests/SwiftOCADeviceTests/OpenSSLHandshakeFailureCleanupTests.swift
+++ b/Tests/SwiftOCADeviceTests/OpenSSLHandshakeFailureCleanupTests.swift
@@ -1,0 +1,108 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if os(Linux)
+#if canImport(COpenSSL) && canImport(IORing)
+
+import Foundation
+import Glibc
+@testable @_spi(SwiftOCAPrivate) import SwiftOCA
+@testable @_spi(SwiftOCAPrivate) import SwiftOCADevice
+import SwiftOCASecure
+@testable import SwiftOCASecureDevice
+@preconcurrency import XCTest
+
+/// After a TLS handshake failure, the Ocp1OpenSSLConnection must report
+/// itself as not-connected and a subsequent disconnect must be a clean
+/// no-op — the fix at Ocp1OpenSSLConnection.connectDevice nils `_socket`
+/// in the throw path so stale transport state isn't visible to callers.
+final class OpenSSLHandshakeFailureCleanupTests: XCTestCase {
+  private static let serverIdentity = OcaPreSharedKeyIdentityHint
+  private static let serverKey = Data(repeating: 0x42, count: 32)
+  private static let wrongKey = Data(repeating: 0x55, count: 32)
+
+  private func loopbackAddress(port: UInt16) -> sockaddr_in {
+    var sin = sockaddr_in()
+    sin.sin_family = sa_family_t(AF_INET)
+    sin.sin_port = port.bigEndian
+    sin.sin_addr.s_addr = UInt32(0x7F00_0001).bigEndian
+    return sin
+  }
+
+  private func loopbackAddressData(port: UInt16) -> Data {
+    let sin = loopbackAddress(port: port)
+    return withUnsafeBytes(of: sin) { Data($0) }
+  }
+
+  func testWrongPSKLeavesConnectionClean() async throws {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    try await device.securityManager.loadPreSharedKey(
+      identity: Self.serverIdentity,
+      key: Self.serverKey
+    )
+    let endpoint = try await Ocp1OpenSSLStreamDeviceEndpoint(
+      address: loopbackAddress(port: 0),
+      timeout: .seconds(5),
+      device: device
+    )
+    let port = endpoint.port
+    XCTAssertNotEqual(port, 0)
+    let serverTask = Task { try await endpoint.run() }
+    defer {
+      serverTask.cancel()
+      _ = try? Task { try? await serverTask.value }
+    }
+    try await Task.sleep(for: .milliseconds(100))
+
+    let connection = try await Ocp1OpenSSLConnection(
+      deviceAddress: loopbackAddressData(port: port),
+      credential: .preSharedKey(identity: Self.serverIdentity, key: Self.wrongKey),
+      hostname: nil,
+      trustRoots: nil,
+      options: Ocp1ConnectionOptions()
+    )
+
+    // The handshake must reject our wrong key.
+    await XCTAssertThrowsErrorAsync(try await connection.connect())
+
+    // After the failure the connection should look "not connected", not
+    // half-initialised. The previous behaviour stashed the socket before
+    // the handshake threw, so disconnect-after-failure / read-after-failure
+    // would touch dead transport state.
+    let connected = await connection.isConnected
+    XCTAssertFalse(connected, "wrong-PSK connect must leave isConnected == false")
+
+    // Disconnect on an already-failed connection must be a safe no-op.
+    try? await connection.disconnect()
+  }
+}
+
+private func XCTAssertThrowsErrorAsync(
+  _ expression: @autoclosure () async throws -> some Any,
+  file: StaticString = #filePath,
+  line: UInt = #line
+) async {
+  do {
+    _ = try await expression()
+    XCTFail("expected error was not thrown", file: file, line: line)
+  } catch {
+    // expected
+  }
+}
+
+#endif
+#endif

--- a/Tests/SwiftOCADeviceTests/PipeByteStream.swift
+++ b/Tests/SwiftOCADeviceTests/PipeByteStream.swift
@@ -1,0 +1,149 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+
+#if os(Linux)
+#if canImport(COpenSSL) && canImport(IORing)
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+@_spi(SwiftOCAPrivate)
+import SwiftOCA
+import SwiftOCASecure
+@testable import SwiftOCASecureDevice
+import Synchronization
+
+/// In-memory bidirectional `Ocp1ByteStream` pair used by tests to exercise
+/// `Ocp1OpenSSLEngine` end-to-end without opening a real socket. Each call
+/// to `write(_:)` on one end becomes available on the partner's `read(...)`
+/// in chunk order. Reads suspend until data arrives or the partner closes
+/// (EOF surfaces as `Ocp1Error.notConnected`, matching real-socket
+/// semantics).
+///
+/// Each direction is backed by a shared `PipeChannel` (see below) — one
+/// per partner pair, two per stream. That way `read` and `write` on the
+/// same end never block each other (they touch *different* channels) and
+/// concurrent reads from competing tasks are serialised by the channel's
+/// internal lock.
+actor PipeByteStream: Ocp1ByteStream {
+  private let inbound: PipeChannel
+  private let outbound: PipeChannel
+
+  private init(inbound: PipeChannel, outbound: PipeChannel) {
+    self.inbound = inbound
+    self.outbound = outbound
+  }
+
+  /// Make a connected pair `(a, b)` such that bytes written to `a` appear
+  /// on reads from `b`, and vice versa.
+  static func makePair() -> (PipeByteStream, PipeByteStream) {
+    let aToB = PipeChannel()
+    let bToA = PipeChannel()
+    let a = PipeByteStream(inbound: bToA, outbound: aToB)
+    let b = PipeByteStream(inbound: aToB, outbound: bToA)
+    return (a, b)
+  }
+
+  func write(_ data: Data) async throws {
+    try outbound.send(data)
+  }
+
+  func read(count: Int, awaitingAllRead: Bool) async throws -> Data {
+    if !awaitingAllRead {
+      return try await inbound.receive(maxBytes: count)
+    }
+    var result = Data()
+    result.reserveCapacity(count)
+    while result.count < count {
+      let chunk = try await inbound.receive(maxBytes: count - result.count)
+      result.append(chunk)
+    }
+    return result
+  }
+
+  func close() async {
+    outbound.finish()
+  }
+}
+
+// MARK: - PipeChannel
+
+/// Continuation-based byte channel used by `PipeByteStream`. Producers
+/// `send` chunks; consumers `receive` up to `maxBytes` from the head.
+/// One pending consumer at a time (single-task-per-direction matches
+/// `OcaByteStream`'s contract); concurrent receivers serialise.
+final class PipeChannel: Sendable {
+  private struct State {
+    var buffer = Data()
+    var finished = false
+    var pending: CheckedContinuation<Void, Never>?
+  }
+
+  private let state = Mutex(State())
+
+  func send(_ data: Data) throws {
+    let toResume: CheckedContinuation<Void, Never>? = try state.withLock {
+      (state: inout State) -> CheckedContinuation<Void, Never>? in
+      if state.finished { throw Ocp1Error.notConnected }
+      state.buffer.append(data)
+      let p = state.pending
+      state.pending = nil
+      return p
+    }
+    toResume?.resume()
+  }
+
+  func finish() {
+    let toResume = state.withLock { (state: inout State) -> CheckedContinuation<Void, Never>? in
+      state.finished = true
+      let p = state.pending
+      state.pending = nil
+      return p
+    }
+    toResume?.resume()
+  }
+
+  func receive(maxBytes: Int) async throws -> Data {
+    while true {
+      enum Outcome { case data(Data); case eof; case wait }
+      let outcome: Outcome = state.withLock { (state: inout State) -> Outcome in
+        if !state.buffer.isEmpty {
+          let n = Swift.min(maxBytes, state.buffer.count)
+          let slice = Data(state.buffer.prefix(n))
+          state.buffer = state.buffer.dropFirst(n)
+          return .data(slice)
+        }
+        if state.finished { return .eof }
+        return .wait
+      }
+      switch outcome {
+      case let .data(slice): return slice
+      case .eof: throw Ocp1Error.notConnected
+      case .wait:
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+          state.withLock { (state: inout State) in
+            // If a producer raced with us between the first lock and here,
+            // re-check before parking — otherwise the resume is lost.
+            if !state.buffer.isEmpty || state.finished {
+              cont.resume()
+            } else {
+              state.pending = cont
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+#endif
+#endif

--- a/Tests/SwiftOCADeviceTests/SelfSignedCertHelper.swift
+++ b/Tests/SwiftOCADeviceTests/SelfSignedCertHelper.swift
@@ -1,0 +1,315 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+
+// Shells out to the `openssl` CLI. Available on Linux (where it backs the
+// OpenSSL-engine TLS tests) and macOS (where it backs the
+// Network.framework-engine regression tests).
+#if (os(Linux) || os(macOS)) && NonEmbeddedBuild
+
+import Foundation
+
+/// Locate the system `openssl` CLI, or return `nil` so callers can
+/// `XCTSkip` rather than fail spuriously on minimal CI images.
+func locateOpenSSLBinary() -> String? {
+  let candidates = ["/usr/bin/openssl", "/usr/local/bin/openssl", "/opt/homebrew/bin/openssl"]
+  return candidates.first(where: { FileManager.default.fileExists(atPath: $0) })
+}
+
+/// Shell out to the `openssl` CLI to mint a short-lived self-signed cert
+/// and matching private key. Returns `nil` when `openssl` isn't on PATH.
+/// Default produces `CN=ocp1-test` with SAN `DNS:ocp1-test,IP:127.0.0.1`,
+/// valid for one day — the parameters cover negative-path variants.
+///
+/// - Parameters:
+///   - commonName: subject CN.
+///   - subjectAltNames: SANs in `openssl -addext` form, e.g. `"DNS:foo,IP:1.2.3.4"`.
+///   - daysValid: validity window in days from "now". Ignored when an
+///     explicit validity window is supplied via `notBefore`/`notAfter`.
+///   - notBefore: explicit ASN.1 `notBefore` time in `YYYYMMDDHHMMSSZ` form
+///     (e.g. `"20200101000000Z"`). Pair with `notAfter` to mint an already-
+///     expired cert.
+///   - notAfter: explicit ASN.1 `notAfter` time in the same form.
+func generateSelfSignedCert(
+  commonName: String = "ocp1-test",
+  subjectAltNames: String = "DNS:ocp1-test,IP:127.0.0.1",
+  daysValid: Int = 1,
+  notBefore: String? = nil,
+  notAfter: String? = nil
+) throws -> (certPath: String, keyPath: String)? {
+  guard let opensslPath = locateOpenSSLBinary() else { return nil }
+
+  let tempDir = NSTemporaryDirectory() + "ocp1-tls-\(UUID().uuidString)"
+  try FileManager.default.createDirectory(
+    atPath: tempDir,
+    withIntermediateDirectories: true
+  )
+  let certPath = tempDir + "/cert.pem"
+  let keyPath = tempDir + "/key.pem"
+
+  var args: [String] = [
+    "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+    "-keyout", keyPath, "-out", certPath,
+    "-subj", "/CN=\(commonName)",
+    "-addext", "subjectAltName=\(subjectAltNames)",
+  ]
+  if let notBefore, let notAfter {
+    // OpenSSL 3 accepts explicit validity windows; format is the ASN.1
+    // GeneralizedTime form. Used by the expired-cert tests so the cert
+    // is unambiguously past its validity at the moment of minting.
+    args.append(contentsOf: ["-not_before", notBefore, "-not_after", notAfter])
+  } else {
+    args.append(contentsOf: ["-days", String(daysValid)])
+  }
+
+  let process = Process()
+  process.executableURL = URL(fileURLWithPath: opensslPath)
+  process.arguments = args
+  process.standardOutput = Pipe()
+  let errPipe = Pipe()
+  process.standardError = errPipe
+  try process.run()
+  process.waitUntilExit()
+  guard process.terminationStatus == 0 else {
+    let stderr = (try? errPipe.fileHandleForReading.readToEnd())
+      .flatMap { String(data: $0, encoding: .utf8) } ?? ""
+    throw NSError(
+      domain: "SelfSignedCertHelper",
+      code: Int(process.terminationStatus),
+      userInfo: [NSLocalizedDescriptionKey: "openssl req failed: \(stderr)"]
+    )
+  }
+  return (certPath, keyPath)
+}
+
+/// Mint a private CA and a leaf certificate signed by it. The two are
+/// returned in distinct sub-directories so the caller can hand the leaf
+/// to one role and the CA cert to another (e.g. "server cert signed by
+/// CA-A; client trustRoots = CA-B" by minting two of these).
+///
+/// Returns `nil` when `openssl` isn't on PATH.
+func generateCASignedCert(
+  caCommonName: String = "ocp1-test-ca",
+  leafCommonName: String = "ocp1-test",
+  leafSubjectAltNames: String = "DNS:ocp1-test,IP:127.0.0.1",
+  daysValid: Int = 1
+) throws -> (caCertPath: String, leafCertPath: String, leafKeyPath: String)? {
+  guard let opensslPath = locateOpenSSLBinary() else { return nil }
+
+  let tempDir = NSTemporaryDirectory() + "ocp1-tls-ca-\(UUID().uuidString)"
+  try FileManager.default.createDirectory(
+    atPath: tempDir,
+    withIntermediateDirectories: true
+  )
+  let caKey = tempDir + "/ca.key"
+  let caCert = tempDir + "/ca.crt"
+  let leafKey = tempDir + "/leaf.key"
+  let leafCSR = tempDir + "/leaf.csr"
+  let leafCert = tempDir + "/leaf.crt"
+  let extFile = tempDir + "/ext.cnf"
+
+  // Step 1: mint a self-signed CA.
+  try runOpenSSL(at: opensslPath, args: [
+    "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+    "-keyout", caKey, "-out", caCert,
+    "-days", String(daysValid),
+    "-subj", "/CN=\(caCommonName)",
+  ])
+
+  // Step 2: leaf key + CSR.
+  try runOpenSSL(at: opensslPath, args: [
+    "req", "-newkey", "rsa:2048", "-nodes",
+    "-keyout", leafKey, "-out", leafCSR,
+    "-subj", "/CN=\(leafCommonName)",
+  ])
+
+  // Step 3: write a v3 ext file carrying the leaf SAN (the CLI doesn't
+  // accept -addext when signing, only when minting a self-signed cert).
+  let ext = """
+  subjectAltName=\(leafSubjectAltNames)
+  basicConstraints=CA:FALSE
+  keyUsage=digitalSignature,keyEncipherment
+  extendedKeyUsage=serverAuth
+  """
+  try ext.write(toFile: extFile, atomically: true, encoding: .utf8)
+
+  // Step 4: sign the leaf with the CA.
+  try runOpenSSL(at: opensslPath, args: [
+    "x509", "-req", "-in", leafCSR,
+    "-CA", caCert, "-CAkey", caKey, "-CAcreateserial",
+    "-out", leafCert,
+    "-days", String(daysValid),
+    "-extfile", extFile,
+  ])
+
+  return (caCert, leafCert, leafKey)
+}
+
+/// Mint a CA, a leaf cert signed by it, and a CRL signed by the CA that
+/// lists the leaf as revoked. Used by revocation-enforcement regression
+/// tests — a strict client given (caCert, crl) must reject a handshake
+/// presenting the leaf.
+///
+/// Returns `nil` when `openssl` isn't on PATH.
+func generateCASignedCertWithCRL(
+  caCommonName: String = "ocp1-test-ca",
+  leafCommonName: String = "ocp1-test",
+  leafSubjectAltNames: String = "DNS:ocp1-test,IP:127.0.0.1",
+  daysValid: Int = 1
+) throws -> (caCertPath: String, leafCertPath: String, leafKeyPath: String, crlPath: String)? {
+  guard let opensslPath = locateOpenSSLBinary() else { return nil }
+
+  let tempDir = NSTemporaryDirectory() + "ocp1-tls-crl-\(UUID().uuidString)"
+  try FileManager.default.createDirectory(
+    atPath: tempDir,
+    withIntermediateDirectories: true
+  )
+  let caKey = tempDir + "/ca.key"
+  let caCert = tempDir + "/ca.crt"
+  let leafKey = tempDir + "/leaf.key"
+  let leafCSR = tempDir + "/leaf.csr"
+  let leafCert = tempDir + "/leaf.crt"
+  let leafExt = tempDir + "/leaf.ext"
+  let crlPath = tempDir + "/crl.pem"
+  let caCfg = tempDir + "/ca.cnf"
+  let indexFile = tempDir + "/index.txt"
+  let attrFile = tempDir + "/index.txt.attr"
+  let serialFile = tempDir + "/serial"
+  let crlNumberFile = tempDir + "/crlnumber"
+  let newCertsDir = tempDir + "/newcerts"
+  try FileManager.default.createDirectory(atPath: newCertsDir, withIntermediateDirectories: true)
+
+  // CA-signing config — `openssl ca` needs this layout regardless of how
+  // little of it we actually populate.
+  let caCfgContent = """
+  [ ca ]
+  default_ca = CA_default
+
+  [ CA_default ]
+  dir              = \(tempDir)
+  database         = \(indexFile)
+  new_certs_dir    = \(newCertsDir)
+  serial           = \(serialFile)
+  crlnumber        = \(crlNumberFile)
+  certificate      = \(caCert)
+  private_key      = \(caKey)
+  default_md       = sha256
+  default_crl_days = 30
+  default_days     = \(daysValid)
+  policy           = policy_any
+  email_in_dn      = no
+  unique_subject   = no
+  copy_extensions  = none
+
+  [ policy_any ]
+  commonName              = supplied
+  """
+  try caCfgContent.write(toFile: caCfg, atomically: true, encoding: .utf8)
+  try "".write(toFile: indexFile, atomically: true, encoding: .utf8)
+  try "unique_subject = no\n".write(toFile: attrFile, atomically: true, encoding: .utf8)
+  try "1000\n".write(toFile: serialFile, atomically: true, encoding: .utf8)
+  try "1000\n".write(toFile: crlNumberFile, atomically: true, encoding: .utf8)
+
+  // Step 1: self-signed CA.
+  try runOpenSSL(at: opensslPath, args: [
+    "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+    "-keyout", caKey, "-out", caCert,
+    "-days", String(daysValid),
+    "-subj", "/CN=\(caCommonName)",
+  ])
+
+  // Step 2: leaf key + CSR.
+  try runOpenSSL(at: opensslPath, args: [
+    "req", "-newkey", "rsa:2048", "-nodes",
+    "-keyout", leafKey, "-out", leafCSR,
+    "-subj", "/CN=\(leafCommonName)",
+  ])
+
+  // Step 3: leaf extensions.
+  let leafExtContent = """
+  subjectAltName=\(leafSubjectAltNames)
+  basicConstraints=CA:FALSE
+  keyUsage=digitalSignature,keyEncipherment
+  extendedKeyUsage=serverAuth
+  """
+  try leafExtContent.write(toFile: leafExt, atomically: true, encoding: .utf8)
+
+  // Step 4: sign leaf via `openssl ca` so the index.txt records the
+  // issuance — required for the subsequent `-revoke` step.
+  try runOpenSSL(at: opensslPath, args: [
+    "ca", "-batch", "-config", caCfg,
+    "-in", leafCSR, "-out", leafCert,
+    "-extfile", leafExt,
+    "-days", String(daysValid),
+  ])
+
+  // Step 5: revoke the freshly-issued leaf and emit a CRL covering it.
+  try runOpenSSL(at: opensslPath, args: [
+    "ca", "-batch", "-config", caCfg, "-revoke", leafCert,
+  ])
+  try runOpenSSL(at: opensslPath, args: [
+    "ca", "-batch", "-config", caCfg, "-gencrl", "-out", crlPath,
+  ])
+
+  return (caCert, leafCert, leafKey, crlPath)
+}
+
+/// Passphrase used by `pemToPKCS12` and the matching `SecPKCS12Import`
+/// call. macOS's `SecPKCS12Import` reliably refuses empty-passphrase P12s,
+/// so we pick a fixed short one. Test-only — these P12s never leave the
+/// process.
+let testPKCS12Password = "ocp1-test"
+
+/// Bundle a PEM cert + key into a PKCS#12 file encrypted with
+/// `testPKCS12Password`. macOS's `SecItemImport` PEM-aggregate path is
+/// finicky with OpenSSL 3's PKCS8-PEM keys; PKCS#12 imports cleanly via
+/// `SecPKCS12Import`. Returns `nil` when `openssl` isn't on PATH.
+func pemToPKCS12(certPath: String, keyPath: String) throws -> String? {
+  guard let opensslPath = locateOpenSSLBinary() else { return nil }
+  let dir = (certPath as NSString).deletingLastPathComponent
+  let p12Path = dir + "/bundle.p12"
+  // Pin PBE-SHA1-3DES + SHA1 MAC. macOS's `SecPKCS12Import` accepts modern
+  // PBES2/AES output in current releases but historic builds and the
+  // bundled LibreSSL writer interact badly — the legacy algorithms are
+  // bulletproof across the matrix.
+  try runOpenSSL(at: opensslPath, args: [
+    "pkcs12", "-export",
+    "-keypbe", "PBE-SHA1-3DES",
+    "-certpbe", "PBE-SHA1-3DES",
+    "-macalg", "sha1",
+    "-inkey", keyPath,
+    "-in", certPath,
+    "-out", p12Path,
+    "-passout", "pass:\(testPKCS12Password)",
+  ])
+  return p12Path
+}
+
+private func runOpenSSL(at path: String, args: [String]) throws {
+  let process = Process()
+  process.executableURL = URL(fileURLWithPath: path)
+  process.arguments = args
+  process.standardOutput = Pipe()
+  let errPipe = Pipe()
+  process.standardError = errPipe
+  try process.run()
+  process.waitUntilExit()
+  guard process.terminationStatus == 0 else {
+    let stderr = (try? errPipe.fileHandleForReading.readToEnd())
+      .flatMap { String(data: $0, encoding: .utf8) } ?? ""
+    throw NSError(
+      domain: "SelfSignedCertHelper",
+      code: Int(process.terminationStatus),
+      userInfo: [NSLocalizedDescriptionKey:
+        "openssl \(args.first ?? "") failed (\(process.terminationStatus)): \(stderr)"]
+    )
+  }
+}
+
+#endif

--- a/Tests/SwiftOCADeviceTests/TLSFailClosedTests.swift
+++ b/Tests/SwiftOCADeviceTests/TLSFailClosedTests.swift
@@ -1,0 +1,111 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if os(Linux)
+#if canImport(COpenSSL) && canImport(IORing)
+
+import Foundation
+import Glibc
+@_spi(SwiftOCAPrivate) import SwiftOCA
+@testable @_spi(SwiftOCAPrivate) import SwiftOCADevice
+import SwiftOCASecure
+import SwiftOCASecureDevice
+@preconcurrency import XCTest
+
+/// Fail-closed configuration checks for the OpenSSL backend: a missing /
+/// unreadable CA bundle must surface as a configuration error at
+/// connection / endpoint init, not silently drop the verify policy.
+final class TLSFailClosedTests: XCTestCase {
+  private static let testIdentity = OcaPreSharedKeyIdentityHint
+  private static let testKey = Data(repeating: 0x42, count: 32)
+  private static let nonexistentCAPath = "/nonexistent/no-such-ca-\(UUID().uuidString).pem"
+
+  private func loopbackAddress(port: UInt16) -> sockaddr_in {
+    var sin = sockaddr_in()
+    sin.sin_family = sa_family_t(AF_INET)
+    sin.sin_port = port.bigEndian
+    sin.sin_addr.s_addr = UInt32(0x7F00_0001).bigEndian // 127.0.0.1
+    return sin
+  }
+
+  private func loopbackAddressData(port: UInt16) -> Data {
+    let sin = loopbackAddress(port: port)
+    return withUnsafeBytes(of: sin) { Data($0) }
+  }
+
+  /// Cert-mode client init with a non-existent CA file must throw rather
+  /// than silently fall back to "any cert from any CA passes."
+  @OcaConnection
+  func testClientWithMissingCAFileThrows() async throws {
+    guard let (certPath, keyPath) = try generateSelfSignedCert() else {
+      throw XCTSkip("openssl CLI not available")
+    }
+    defer {
+      let dir = (certPath as NSString).deletingLastPathComponent
+      try? FileManager.default.removeItem(atPath: dir)
+    }
+    XCTAssertThrowsError(
+      try Ocp1OpenSSLConnection(
+        deviceAddress: loopbackAddressData(port: 65535),
+        credential: .certificateFile(certPath: certPath, keyPath: keyPath),
+        hostname: "ocp1-test",
+        trustRoots: .caFile(Self.nonexistentCAPath),
+        options: Ocp1ConnectionOptions()
+      ),
+      "init must throw when the configured CA file is unreadable"
+    )
+  }
+
+  /// Server-side mTLS endpoint init with a non-existent client CA file
+  /// must throw — the alternative is logging "mTLS enabled" while every
+  /// client cert is accepted.
+  func testServerWithMissingClientCAFileThrows() async throws {
+    guard let (certPath, keyPath) = try generateSelfSignedCert() else {
+      throw XCTSkip("openssl CLI not available")
+    }
+    defer {
+      let dir = (certPath as NSString).deletingLastPathComponent
+      try? FileManager.default.removeItem(atPath: dir)
+    }
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+
+    await XCTAssertThrowsErrorAsync(try await Ocp1OpenSSLStreamDeviceEndpoint(
+      address: loopbackAddress(port: 0),
+      credential: .certificateFile(certPath: certPath, keyPath: keyPath),
+      clientCertificateTrustRoots: .caFile(Self.nonexistentCAPath),
+      timeout: .seconds(5),
+      device: device
+    ))
+  }
+}
+
+private func XCTAssertThrowsErrorAsync(
+  _ expression: @autoclosure () async throws -> some Any,
+  _ message: String = "",
+  file: StaticString = #filePath,
+  line: UInt = #line
+) async {
+  do {
+    _ = try await expression()
+    XCTFail(message.isEmpty ? "expected error was not thrown" : message, file: file, line: line)
+  } catch {
+    // expected
+  }
+}
+
+#endif
+#endif

--- a/Tests/SwiftOCADeviceTests/TLSNegativePathTests.swift
+++ b/Tests/SwiftOCADeviceTests/TLSNegativePathTests.swift
@@ -1,0 +1,720 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if os(Linux)
+#if canImport(COpenSSL) && canImport(IORing)
+
+import Foundation
+@_spi(SwiftOCAPrivate) import SwiftOCA
+import SwiftOCASecure
+@preconcurrency import XCTest
+
+/// Negative-path TLS coverage for the OpenSSL engine and connection
+/// surface. Sister to `OpenSSLEnginePipeTests` (engine-level happy paths)
+/// and `OpenSSLConnectionTests` (socket-level happy paths) — every test
+/// here proves that some attacker-visible failure mode produces a clean
+/// `throw`, not a silent accept.
+///
+/// Engine-level tests run against `PipeByteStream` so they don't suffer
+/// the socket/port-reuse flake of the full-stack tests.
+final class TLSNegativePathTests: XCTestCase {
+  private static let pskIdentity = "test-id"
+  private static let pskKey = Data(repeating: 0xCD, count: 32)
+
+  /// Drive `clientFn` and `serverFn` concurrently against a connected pipe
+  /// pair. Mirrors `OpenSSLEnginePipeTests.driveBoth`.
+  private func driveBoth<C: Sendable, S: Sendable>(
+    client clientFn: @Sendable @escaping (PipeByteStream) async throws -> C,
+    server serverFn: @Sendable @escaping (PipeByteStream) async throws -> S
+  ) async throws -> (C, S) {
+    let (clientPipe, serverPipe) = PipeByteStream.makePair()
+    async let clientResult = clientFn(clientPipe)
+    async let serverResult = serverFn(serverPipe)
+    return try await (clientResult, serverResult)
+  }
+
+  // MARK: - Expired certificate
+
+  /// Server presents a cert whose `notAfter` is already in the past.
+  /// A strict client must refuse the chain — regardless of whether the
+  /// signing CA is otherwise trusted.
+  func testStrictClientRejectsExpiredServerCert() async throws {
+    // Mint with a validity window that's already entirely in the past.
+    // Requires OpenSSL 3's `-not_before` / `-not_after` flags; on older
+    // builds the helper falls back to `-days` (which doesn't accept
+    // negatives) and this test will skip via the throw -> XCTSkip below.
+    let cert: (certPath: String, keyPath: String)?
+    do {
+      cert = try generateSelfSignedCert(
+        notBefore: "20200101000000Z",
+        notAfter: "20200102000000Z"
+      )
+    } catch {
+      throw XCTSkip("openssl CLI doesn't support explicit validity windows: \(error)")
+    }
+    guard let cert else {
+      throw XCTSkip("openssl CLI not available; cannot generate test cert")
+    }
+    defer {
+      try? FileManager.default.removeItem(
+        atPath: (cert.certPath as NSString).deletingLastPathComponent
+      )
+    }
+    do {
+      _ = try await driveBoth(
+        client: { stream in
+          let engine = try Ocp1OpenSSLEngine(
+            mode: .client,
+            credential: .certificateFile(certPath: cert.certPath, keyPath: cert.keyPath),
+            verifyPeer: true,
+            hostname: "ocp1-test",
+            // Anchor at the expired self-signed cert so chain validation
+            // would succeed but for the expiry.
+            trustRoots: .caFile(cert.certPath)
+          )
+          try await engine.handshake(
+            read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+            write: { d in try await stream.write(d) }
+          )
+          return ()
+        },
+        server: { stream in
+          let engine = try Ocp1OpenSSLEngine(
+            mode: .server,
+            credential: .certificateFile(certPath: cert.certPath, keyPath: cert.keyPath)
+          )
+          try await engine.handshake(
+            read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+            write: { d in try await stream.write(d) }
+          )
+          return ()
+        }
+      )
+      XCTFail("expired server cert should be rejected by strict verification")
+    } catch {
+      // Expected — exact error string varies by OpenSSL build.
+    }
+  }
+
+  // MARK: - Hostname mismatch
+
+  /// Server cert SAN doesn't include the hostname the client verified
+  /// against — strict verify must refuse. Without this check a cert
+  /// minted for `other-host` could be replayed against `our-host`
+  /// (assuming a chain-trusted issuer).
+  func testStrictClientRejectsHostnameMismatch() async throws {
+    guard let cert = try generateSelfSignedCert(
+      commonName: "other-host",
+      subjectAltNames: "DNS:other-host"
+    ) else {
+      throw XCTSkip("openssl CLI not available; cannot generate test cert")
+    }
+    defer {
+      try? FileManager.default.removeItem(
+        atPath: (cert.certPath as NSString).deletingLastPathComponent
+      )
+    }
+    do {
+      _ = try await driveBoth(
+        client: { stream in
+          let engine = try Ocp1OpenSSLEngine(
+            mode: .client,
+            credential: .certificateFile(certPath: cert.certPath, keyPath: cert.keyPath),
+            verifyPeer: true,
+            // Verify against `our-host`, but the cert is for `other-host`.
+            hostname: "our-host",
+            trustRoots: .caFile(cert.certPath)
+          )
+          try await engine.handshake(
+            read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+            write: { d in try await stream.write(d) }
+          )
+          return ()
+        },
+        server: { stream in
+          let engine = try Ocp1OpenSSLEngine(
+            mode: .server,
+            credential: .certificateFile(certPath: cert.certPath, keyPath: cert.keyPath)
+          )
+          try await engine.handshake(
+            read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+            write: { d in try await stream.write(d) }
+          )
+          return ()
+        }
+      )
+      XCTFail("hostname mismatch should be rejected")
+    } catch {
+      // Expected.
+    }
+  }
+
+  // MARK: - Untrusted CA
+
+  /// Server cert is signed by CA-A; client trustRoots = CA-B. Chain
+  /// validation must fail even though both certs are well-formed and
+  /// in-validity.
+  func testStrictClientRejectsUntrustedCA() async throws {
+    guard let serverChain = try generateCASignedCert(
+      caCommonName: "ca-A",
+      leafCommonName: "ocp1-test"
+    ) else {
+      throw XCTSkip("openssl CLI not available; cannot generate test certs")
+    }
+    guard let otherCA = try generateCASignedCert(
+      caCommonName: "ca-B",
+      leafCommonName: "ocp1-test"
+    ) else {
+      throw XCTSkip("openssl CLI not available; cannot generate test certs")
+    }
+    defer {
+      try? FileManager.default.removeItem(
+        atPath: (serverChain.leafCertPath as NSString).deletingLastPathComponent
+      )
+      try? FileManager.default.removeItem(
+        atPath: (otherCA.leafCertPath as NSString).deletingLastPathComponent
+      )
+    }
+    do {
+      _ = try await driveBoth(
+        client: { stream in
+          // Client uses its own leaf as the client credential — not
+          // important here; only the server-cert verification is being
+          // tested. Trust roots point to CA-B; the server is signed by CA-A.
+          let engine = try Ocp1OpenSSLEngine(
+            mode: .client,
+            credential: .certificateFile(
+              certPath: otherCA.leafCertPath,
+              keyPath: otherCA.leafKeyPath
+            ),
+            verifyPeer: true,
+            hostname: "ocp1-test",
+            trustRoots: .caFile(otherCA.caCertPath)
+          )
+          try await engine.handshake(
+            read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+            write: { d in try await stream.write(d) }
+          )
+          return ()
+        },
+        server: { stream in
+          let engine = try Ocp1OpenSSLEngine(
+            mode: .server,
+            credential: .certificateFile(
+              certPath: serverChain.leafCertPath,
+              keyPath: serverChain.leafKeyPath
+            )
+          )
+          try await engine.handshake(
+            read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+            write: { d in try await stream.write(d) }
+          )
+          return ()
+        }
+      )
+      XCTFail("server cert signed by an untrusted CA should be rejected")
+    } catch {
+      // Expected.
+    }
+  }
+
+  // MARK: - mTLS missing client cert
+
+  /// Server requires a client cert (mTLS); client doesn't present one
+  /// (no credential at all). Engine init refuses to construct a client
+  /// without a credential, so we exercise the failure on the server side
+  /// by sending a credential-less client into an mTLS-required server.
+  ///
+  /// A client that authenticates only via PSK against an mTLS-required
+  /// server is allowed by design (the PSK callback overrides verify per-
+  /// SSL); the failure case here is "client cert handshake without a
+  /// cert", which OpenSSL surfaces from the server as
+  /// `SSL_VERIFY_FAIL_IF_NO_PEER_CERT`.
+  func testServerMTLSRefusesAnonymousCertClient() async throws {
+    guard let chain = try generateCASignedCert(
+      caCommonName: "ocp1-test-ca",
+      leafCommonName: "ocp1-test"
+    ) else {
+      throw XCTSkip("openssl CLI not available; cannot generate test certs")
+    }
+    guard let otherChain = try generateCASignedCert(
+      caCommonName: "intruder-ca",
+      leafCommonName: "intruder"
+    ) else {
+      throw XCTSkip("openssl CLI not available; cannot generate test certs")
+    }
+    defer {
+      try? FileManager.default.removeItem(
+        atPath: (chain.leafCertPath as NSString).deletingLastPathComponent
+      )
+      try? FileManager.default.removeItem(
+        atPath: (otherChain.leafCertPath as NSString).deletingLastPathComponent
+      )
+    }
+    do {
+      _ = try await driveBoth(
+        client: { stream in
+          // Client presents a cert from an entirely different CA — the
+          // mTLS-required server should reject it during chain validation
+          // against `clientTrustRoots = chain.caCertPath`.
+          let engine = try Ocp1OpenSSLEngine(
+            mode: .client,
+            credential: .certificateFile(
+              certPath: otherChain.leafCertPath,
+              keyPath: otherChain.leafKeyPath
+            ),
+            verifyPeer: false,
+            hostname: "ocp1-test"
+          )
+          try await engine.handshake(
+            read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+            write: { d in try await stream.write(d) }
+          )
+          return ()
+        },
+        server: { stream in
+          let engine = try Ocp1OpenSSLEngine(
+            mode: .server,
+            credential: .certificateFile(
+              certPath: chain.leafCertPath,
+              keyPath: chain.leafKeyPath
+            ),
+            clientTrustRoots: .caFile(chain.caCertPath)
+          )
+          try await engine.handshake(
+            read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+            write: { d in try await stream.write(d) }
+          )
+          return ()
+        }
+      )
+      XCTFail("mTLS server should reject a client cert from an untrusted CA")
+    } catch {
+      // Expected.
+    }
+  }
+
+  // MARK: - Revoked leaf via CRL
+
+  /// Server cert is well-formed, in validity, signed by a CA the client
+  /// trusts — but listed on the CRL the client loads. Strict revocation
+  /// (`.strict` = `.enabled` + `.checkChain`) must refuse the handshake.
+  func testStrictClientRejectsRevokedServerCert() async throws {
+    guard let chain = try generateCASignedCertWithCRL(
+      caCommonName: "ocp1-test-ca",
+      leafCommonName: "ocp1-test"
+    ) else {
+      throw XCTSkip("openssl CLI not available; cannot generate test certs")
+    }
+    defer {
+      try? FileManager.default.removeItem(
+        atPath: (chain.leafCertPath as NSString).deletingLastPathComponent
+      )
+    }
+    do {
+      _ = try await driveBoth(
+        client: { stream in
+          let engine = try Ocp1OpenSSLEngine(
+            mode: .client,
+            credential: .certificateFile(
+              certPath: chain.leafCertPath,
+              keyPath: chain.leafKeyPath
+            ),
+            verifyPeer: true,
+            hostname: "ocp1-test",
+            trustRoots: .caFile(chain.caCertPath),
+            revocation: Ocp1TLSRevocationOptions(
+              flags: .strict,
+              crls: .crlFile(chain.crlPath)
+            )
+          )
+          try await engine.handshake(
+            read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+            write: { d in try await stream.write(d) }
+          )
+          return ()
+        },
+        server: { stream in
+          let engine = try Ocp1OpenSSLEngine(
+            mode: .server,
+            credential: .certificateFile(
+              certPath: chain.leafCertPath,
+              keyPath: chain.leafKeyPath
+            )
+          )
+          try await engine.handshake(
+            read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+            write: { d in try await stream.write(d) }
+          )
+          return ()
+        }
+      )
+      XCTFail("revoked server cert must be rejected by strict revocation client")
+    } catch {
+      // Expected — handshake aborts on CRL-listed leaf.
+    }
+  }
+
+  /// Same chain but no CRL — `.disabled` revocation must accept the
+  /// handshake. Pairs with the positive case so the revocation reject
+  /// above is unambiguously CRL-driven rather than a chain failure.
+  func testRevocationDisabledAcceptsLeafEvenIfCRLExists() async throws {
+    guard let chain = try generateCASignedCertWithCRL(
+      caCommonName: "ocp1-test-ca",
+      leafCommonName: "ocp1-test"
+    ) else {
+      throw XCTSkip("openssl CLI not available; cannot generate test certs")
+    }
+    defer {
+      try? FileManager.default.removeItem(
+        atPath: (chain.leafCertPath as NSString).deletingLastPathComponent
+      )
+    }
+    _ = try await driveBoth(
+      client: { stream in
+        let engine = try Ocp1OpenSSLEngine(
+          mode: .client,
+          credential: .certificateFile(
+            certPath: chain.leafCertPath,
+            keyPath: chain.leafKeyPath
+          ),
+          verifyPeer: true,
+          hostname: "ocp1-test",
+          trustRoots: .caFile(chain.caCertPath),
+          revocation: .disabled
+        )
+        try await engine.handshake(
+          read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+          write: { d in try await stream.write(d) }
+        )
+        return ()
+      },
+      server: { stream in
+        let engine = try Ocp1OpenSSLEngine(
+          mode: .server,
+          credential: .certificateFile(
+            certPath: chain.leafCertPath,
+            keyPath: chain.leafKeyPath
+          )
+        )
+        try await engine.handshake(
+          read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+          write: { d in try await stream.write(d) }
+        )
+        return ()
+      }
+    )
+  }
+
+  // MARK: - Oversized PSK identity
+
+  /// A client sends a PSK identity beyond OpenSSL's `PSK_MAX_IDENTITY_LEN`
+  /// (128) and our defence-in-depth bound (256). The engine's PSK callback
+  /// must return 0, failing the handshake — guarding against memory bloat
+  /// and out-of-bounds reads on the identity copy path.
+  ///
+  /// We rely on OpenSSL itself to enforce the 128-byte identity limit on
+  /// the client side: passing a longer identity to the client callback
+  /// causes OpenSSL to refuse advertising it, which aborts the handshake
+  /// before any bytes traverse the wire.
+  func testOversizedPSKIdentityFailsHandshake() async throws {
+    let oversizedIdentity = String(repeating: "X", count: 4096)
+    do {
+      _ = try await driveBoth(
+        client: { stream in
+          let engine = try Ocp1OpenSSLEngine(
+            mode: .client,
+            credential: .preSharedKey(identity: oversizedIdentity, key: Self.pskKey)
+          )
+          try await engine.handshake(
+            read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+            write: { d in try await stream.write(d) }
+          )
+          return ()
+        },
+        server: { stream in
+          let engine = try Ocp1OpenSSLEngine(
+            mode: .server,
+            credential: nil,
+            serverPSKProvider: SinglePSKProvider(
+              identity: oversizedIdentity,
+              key: Self.pskKey
+            )
+          )
+          try await engine.handshake(
+            read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+            write: { d in try await stream.write(d) }
+          )
+          return ()
+        }
+      )
+      XCTFail("oversized PSK identity should fail the handshake")
+    } catch {
+      // Expected — at minimum OpenSSL rejects the >128-byte identity.
+    }
+  }
+
+  // MARK: - PSK identity carry-through across reset
+
+  /// `engine.reset()` discards the previously-captured PSK identity so a
+  /// reconnect that re-handshakes can't see a stale identity if the second
+  /// handshake hasn't run yet. After a fresh handshake completes, the new
+  /// identity must be captured cleanly.
+  func testEngineResetClearsAndRecapturesPSKIdentity() async throws {
+    let identity1 = "client-A"
+    let identity2 = "client-B"
+    let key = Data(repeating: 0x88, count: 32)
+    let provider = SinglePSKMutableProvider(identities: [identity1: key, identity2: key])
+
+    // Build a server engine and run a first handshake against a PSK client
+    // claiming identity1. Then reset; run a second handshake claiming
+    // identity2 and assert the captured identity reflects the second.
+
+    // First handshake.
+    let server = try Ocp1OpenSSLEngine(
+      mode: .server,
+      credential: nil,
+      serverPSKProvider: provider
+    )
+    let (firstIdentity, _): (OcaPeerIdentity, Void) = try await driveBoth(
+      client: { stream in
+        let engine = try Ocp1OpenSSLEngine(
+          mode: .client,
+          credential: .preSharedKey(identity: identity1, key: key)
+        )
+        try await engine.handshake(
+          read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+          write: { d in try await stream.write(d) }
+        )
+        return await engine.peerIdentity()
+      },
+      server: { stream in
+        try await server.handshake(
+          read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+          write: { d in try await stream.write(d) }
+        )
+      }
+    )
+    XCTAssertEqual(firstIdentity, .anonymous, "client peerIdentity is .anonymous (no server cert)")
+
+    let serverIdentityAfterFirst = await server.peerIdentity()
+    XCTAssertEqual(serverIdentityAfterFirst, .preSharedKey(identity: identity1))
+
+    // Reset wipes the captured identity.
+    await server.reset()
+    let serverIdentityAfterReset = await server.peerIdentity()
+    XCTAssertEqual(serverIdentityAfterReset, .anonymous,
+                   "reset must discard the previously-captured PSK identity")
+
+    // Second handshake captures the new identity.
+    _ = try await driveBoth(
+      client: { stream in
+        let engine = try Ocp1OpenSSLEngine(
+          mode: .client,
+          credential: .preSharedKey(identity: identity2, key: key)
+        )
+        try await engine.handshake(
+          read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+          write: { d in try await stream.write(d) }
+        )
+      },
+      server: { stream in
+        try await server.handshake(
+          read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+          write: { d in try await stream.write(d) }
+        )
+      }
+    )
+    let serverIdentityAfterSecond = await server.peerIdentity()
+    XCTAssertEqual(serverIdentityAfterSecond, .preSharedKey(identity: identity2))
+  }
+
+  // MARK: - Plaintext-before-handshake
+
+  /// A client that sends raw, non-TLS bytes at a server engine must NOT
+  /// see those bytes succeed as if a handshake had completed. The engine's
+  /// `SSL_do_handshake` should reject the malformed record and the
+  /// handshake call should throw — fail-closed on plaintext injection.
+  func testServerRejectsPlaintextBeforeHandshake() async throws {
+    // The bytes we feed in are deliberately arbitrary: a few OCP.1-like
+    // octets that share no prefix with a TLS ClientHello (0x16 0x03 ...).
+    let plaintext = Data([0x3B, 0x00, 0x10, 0x00, 0x01, 0x03, 0x07, 0xFF])
+
+    do {
+      _ = try await driveBoth(
+        client: { stream in
+          // Pump junk into the server's read side then close our write side.
+          try await stream.write(plaintext)
+          await stream.close()
+          return ()
+        },
+        server: { stream in
+          let engine = try Ocp1OpenSSLEngine(
+            mode: .server,
+            credential: nil,
+            serverPSKProvider: SinglePSKProvider(
+              identity: Self.pskIdentity,
+              key: Self.pskKey
+            )
+          )
+          try await engine.handshake(
+            read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+            write: { d in try await stream.write(d) }
+          )
+          return ()
+        }
+      )
+      XCTFail("server engine must refuse a handshake driven by plaintext garbage")
+    } catch {
+      // Expected — fail-closed.
+    }
+  }
+
+  // MARK: - .preSharedKeyProvider client variant
+
+  /// PSK client using `.preSharedKeyProvider` instead of `.preSharedKey`
+  /// — the key bytes only live in the provider's storage. A round-trip
+  /// proves the engine's client PSK callbacks read from the provider on
+  /// demand and the captured server-side identity matches.
+  func testEnginePSKProviderClientHandshakeAndIdentityCapture() async throws {
+    let identity = "provider-id"
+    let key = Data(repeating: 0xA1, count: 32)
+    let clientProvider = SinglePSKProvider(identity: identity, key: key)
+    let serverProvider = SinglePSKProvider(identity: identity, key: key)
+
+    let (clientIdentity, serverIdentity): (OcaPeerIdentity, OcaPeerIdentity) = try await driveBoth(
+      client: { stream in
+        let engine = try Ocp1OpenSSLEngine(
+          mode: .client,
+          credential: .preSharedKeyProvider(identity: identity, provider: clientProvider)
+        )
+        try await engine.handshake(
+          read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+          write: { d in try await stream.write(d) }
+        )
+        return await engine.peerIdentity()
+      },
+      server: { stream in
+        let engine = try Ocp1OpenSSLEngine(
+          mode: .server,
+          credential: nil,
+          serverPSKProvider: serverProvider
+        )
+        try await engine.handshake(
+          read: { c in try await stream.read(count: c, awaitingAllRead: false) },
+          write: { d in try await stream.write(d) }
+        )
+        return await engine.peerIdentity()
+      }
+    )
+    XCTAssertEqual(clientIdentity, .anonymous)
+    XCTAssertEqual(serverIdentity, .preSharedKey(identity: identity))
+  }
+
+  /// Credential `validate()` rejects `.preSharedKeyProvider` when the
+  /// configured identity isn't known to the provider — caller misuse
+  /// surfaces at construction rather than handshake.
+  func testPreSharedKeyProviderValidateRejectsUnknownIdentity() throws {
+    let provider = SinglePSKProvider(
+      identity: "registered",
+      key: Data(repeating: 0xEE, count: 32)
+    )
+    let cred = Ocp1TLSCredential.preSharedKeyProvider(
+      identity: "different-identity",
+      provider: provider
+    )
+    XCTAssertThrowsError(try cred.validate())
+  }
+
+  /// Same shape, but the provider's key is shorter than the minimum.
+  /// Should also throw at validate time.
+  func testPreSharedKeyProviderValidateRejectsShortKey() throws {
+    let provider = SinglePSKProvider(
+      identity: "id",
+      key: Data(repeating: 0xEE, count: OcaMinimumPreSharedKeyLength - 1)
+    )
+    let cred = Ocp1TLSCredential.preSharedKeyProvider(
+      identity: "id",
+      provider: provider
+    )
+    XCTAssertThrowsError(try cred.validate())
+  }
+
+  // MARK: - DTLS server requires non-empty peerAddressBytes
+
+  /// `Ocp1OpenSSLEngine` rejects a DTLS server with empty `peerAddressBytes`
+  /// at construction time — otherwise the cookie HMAC collapses to a
+  /// constant per server, defeating RFC 6347 §4.2.1 source-address
+  /// verification.
+  func testDTLSServerRejectsEmptyPeerAddressBytes() {
+    XCTAssertThrowsError(
+      try Ocp1OpenSSLEngine(
+        mode: .server,
+        credential: nil,
+        transport: .datagram,
+        serverPSKProvider: SinglePSKProvider(
+          identity: Self.pskIdentity,
+          key: Self.pskKey
+        ),
+        peerAddressBytes: Data()
+      )
+    ) { error in
+      // Must surface as a `.parameterError` so callers see a config
+      // problem, not a generic OpenSSL error.
+      guard case let Ocp1Error.status(status) = error else {
+        XCTFail("expected Ocp1Error.status, got \(error)")
+        return
+      }
+      XCTAssertEqual(status, .parameterError)
+    }
+  }
+}
+
+/// Single-entry PSK provider — minimal `OcaPreSharedKeyProvider` that
+/// answers exactly one identity. Mirrors `OpenSSLEnginePipeTests`'
+/// `TestPSKProvider` but lives here too so the negative-path file is
+/// self-contained.
+private struct SinglePSKProvider: OcaPreSharedKeyProvider {
+  let identity: String
+  let key: Data
+
+  func withPreSharedKey<T>(
+    forIdentity identity: String,
+    _ body: (UnsafeBufferPointer<UInt8>) throws -> T
+  ) rethrows -> T? {
+    guard identity == self.identity else { return nil }
+    return try key.withUnsafeBytes { raw in
+      try body(raw.bindMemory(to: UInt8.self))
+    }
+  }
+}
+
+private struct SinglePSKMutableProvider: OcaPreSharedKeyProvider {
+  let identities: [String: Data]
+
+  func withPreSharedKey<T>(
+    forIdentity identity: String,
+    _ body: (UnsafeBufferPointer<UInt8>) throws -> T
+  ) rethrows -> T? {
+    guard let key = identities[identity] else { return nil }
+    return try key.withUnsafeBytes { raw in
+      try body(raw.bindMemory(to: UInt8.self))
+    }
+  }
+}
+
+#endif
+#endif

--- a/Tests/SwiftOCADeviceTests/TLSPolicyTests.swift
+++ b/Tests/SwiftOCADeviceTests/TLSPolicyTests.swift
@@ -1,0 +1,114 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if NonEmbeddedBuild
+
+import Foundation
+@_spi(SwiftOCAPrivate) import SwiftOCA
+@testable import SwiftOCADevice
+import SwiftOCASecure
+import SwiftOCASecureDevice
+@preconcurrency import XCTest
+
+/// Policy-level checks for `Ocp1TLSCredential.validate()` and the security
+/// manager's PSK admission path. RFC 9257 §6 mandates ≥128-bit PSKs and
+/// non-empty identities; these enforce that at configuration time so the
+/// misconfiguration is caught before any handshake runs.
+final class TLSPolicyTests: XCTestCase {
+  func testValidateRejectsEmptyIdentity() {
+    let cred = Ocp1TLSCredential.preSharedKey(
+      identity: "",
+      key: Data(repeating: 0x42, count: 32)
+    )
+    XCTAssertThrowsError(try cred.validate())
+  }
+
+  func testValidateRejectsShortKey() {
+    let cred = Ocp1TLSCredential.preSharedKey(
+      identity: OcaPreSharedKeyIdentityHint,
+      key: Data(repeating: 0x42, count: OcaMinimumPreSharedKeyLength - 1)
+    )
+    XCTAssertThrowsError(try cred.validate())
+  }
+
+  func testValidateAcceptsBoundary() {
+    let cred = Ocp1TLSCredential.preSharedKey(
+      identity: OcaPreSharedKeyIdentityHint,
+      key: Data(repeating: 0x42, count: OcaMinimumPreSharedKeyLength)
+    )
+    XCTAssertNoThrow(try cred.validate())
+  }
+
+  func testValidateAcceptsNonPSK() {
+    // Cert variants don't carry length / identity bytes — `validate()`
+    // is a no-op for them. Parse failures surface at TLS-backend load
+    // time, not here.
+    let cred = Ocp1TLSCredential.certificateFile(
+      certPath: "/nonexistent.crt",
+      keyPath: "/nonexistent.key"
+    )
+    XCTAssertNoThrow(try cred.validate())
+  }
+
+  func testSecurityManagerRejectsShortPSK() async throws {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    let shortKey = Data(repeating: 0x00, count: 8) // 64 bits
+    await XCTAssertThrowsErrorAsync(try await device.securityManager.loadPreSharedKey(
+      identity: OcaPreSharedKeyIdentityHint,
+      key: shortKey
+    ))
+  }
+
+  func testSecurityManagerRejectsEmptyIdentity() async throws {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    let validKey = Data(repeating: 0x00, count: 32)
+    await XCTAssertThrowsErrorAsync(try await device.securityManager.loadPreSharedKey(
+      identity: "",
+      key: validKey
+    ))
+  }
+
+  func testSecurityManagerAcceptsValidPSK() async throws {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    let validKey = Data(repeating: 0x00, count: 32)
+    try await device.securityManager.loadPreSharedKey(
+      identity: OcaPreSharedKeyIdentityHint,
+      key: validKey
+    )
+    let stored = await device.securityManager.withPreSharedKey(
+      forIdentity: OcaPreSharedKeyIdentityHint
+    ) { Data(buffer: $0) }
+    XCTAssertEqual(stored, validKey)
+  }
+}
+
+private func XCTAssertThrowsErrorAsync(
+  _ expression: @autoclosure () async throws -> some Any,
+  file: StaticString = #filePath,
+  line: UInt = #line
+) async {
+  do {
+    _ = try await expression()
+    XCTFail("expected error was not thrown", file: file, line: line)
+  } catch {
+    // expected
+  }
+}
+
+#endif


### PR DESCRIPTION
## Summary

Apple-only TLS-secured OCP.1 stream transports on both controller and device sides, plus the supporting `OcaSecurityManager` and `hasTransportLayerSecurity` capability flag.

- `Ocp1TLSCredential` enum (preSharedKey + cert variants reserved for future use)
- `Ocp1NWSecureTCPConnection` — client-side TLS via `NWConnection`
- `Ocp1NWStreamDeviceEndpoint` (base) + `Ocp1NWTCPDeviceEndpoint` (plaintext) + `Ocp1NWSecureTCPDeviceEndpoint` (TLS, PSKs sourced from device's `OcaSecurityManager`)
- Device-side `OcaSecurityManager` (ClassID 1.3.2) — writes denied for now (scaffolding), reads require TLS transport
- `OcaControllerFlags.hasTransportLayerSecurity` and `Ocp1Connection.hasTransportLayerSecurity` 
- `Ocp1TLSStream{Connection,DeviceEndpoint,Controller}` type aliases + `OcaPreSharedKeyIdentityHint` (`"OCA-PSK"`)
- `_ocasec._tcp.` Bonjour service type on TLS endpoints

### TLS configuration

Uses TLS 1.3 external PSK (RFC 8773 style) via `sec_protocol_options_add_pre_shared_key`. The AES70-mandated `TLS_DHE_PSK_WITH_AES_128_CBC_SHA` (IANA 0x0090) is appended via raw `tls_ciphersuite_t` construction, but Apple's public enum doesn't expose it — negotiation falls back to `TLS_AES_128_GCM_SHA256`. Spec divergence accepted.

## Test plan

- [x] `NWStreamDeviceEndpointTests` (plain TCP): connect/disconnect, round-trip, controller cleanup on disconnect
- [x] `NWSecureTCPDeviceEndpointTests.testTLSConnectAndRoundTrip`: TLS PSK handshake + round-trip; asserts `hasTransportLayerSecurity` on both client connection and server controller flags, and the `ocasec/tcp/…` connection prefix
- [x] `swift build` + `swift test` clean on macOS 15 / Swift 6.3.1

## Known follow-ups

- Wrong-PSK negative test omitted: `Ocp1Connection.connectDevice()` doesn't observe `NWConnection` state transitions so a failed handshake hangs the client. Wiring NW state into the connect path is the fix.
- PSKs loaded once at endpoint start; runtime `AddPreSharedKey` commands won't take effect until restart. A PSK selection block would resolve this.
- Local transport (`OcaLocalController`) could legitimately carry `.hasTransportLayerSecurity` since it never leaves the host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)