### PR TITLE
Add refreshBrowsing() to OcaConnectionBroker

### DIFF
--- a/Sources/SwiftOCA/OCA/Browsing/ConnectionBroker.swift
+++ b/Sources/SwiftOCA/OCA/Browsing/ConnectionBroker.swift
@@ -616,6 +616,28 @@ public actor OcaConnectionBroker {
       _eventsContinuation.yield(event)
     }
   }
+
+  /// Restarts the DNS-SD browsers, forcing a fresh re-discovery of currently
+  /// advertised services.
+  ///
+  /// Useful when there is evidence the broker's view is stale — for example
+  /// after a device firmware update, when a device has been re-advertised
+  /// under the same instance name with a changed address.
+  /// `NetServiceBrowser` does not fire `didFind` callbacks when an existing
+  /// service's A record changes; a refresh causes a fresh browser to scan
+  /// `mDNSResponder`'s current state, which picks up address changes via
+  /// the existing `_onBrowserDeviceAdded` path.
+  ///
+  /// Stale `_devices` entries for services that are no longer advertised
+  /// are not cleared by this call; they linger until the underlying DNS-SD
+  /// browser sees them go away or the caller deregisters them explicitly.
+  public func refreshBrowsing() {
+    for serviceType in Array(_browsers.keys) {
+      if let newMonitor = try? BrowserMonitor(serviceType: serviceType, broker: self) {
+        _browsers[serviceType] = newMonitor
+      }
+    }
+  }
 }
 
 extension OcaConnectionBroker.DeviceIdentifier {


### PR DESCRIPTION
## Summary

- Adds `OcaConnectionBroker.refreshBrowsing()` — recreates each `BrowserMonitor`, causing a fresh DNS-SD browser to query `mDNSResponder` from scratch and re-fire `didFind` for currently advertised services.
- Resolves the long-standing gap that `NetServiceBrowser` does not fire callbacks when an existing service's A record changes (services are identified by name+type+domain, not address). After a device firmware update that puts it back at a different IP under the same Bonjour instance name, callers can invoke this to pick the new address up.
- The existing `_onBrowserDeviceAdded` path handles the address update via `mutableConnection.deviceAddress = … ; deviceAddressDidChange()`, so no other changes are needed.

## Caveats

- Stale `_devices` entries for services that aren't currently advertised are not cleared — they linger until the browser sees them go away or the caller deregisters them.
- Each refresh emits a `.deviceUpdated` event for every still-advertised service (because `isExistingDevice` is true). Cheap, but UI handlers will see the burst.

## Test plan

- [ ] Trigger a firmware update on a device, observe Monitor Two Control rediscovering the rebooted device after calling `refreshBrowsing()`.
- [ ] Verify normal startup (browser construction at init) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)