### PR TITLE
Fix: declare FlyingFox/FlyingSocks on SwiftOCADeviceTests for Apple

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -307,6 +307,19 @@ let CommonTargets: [Target] = [
       .target(name: "SwiftOCADevice"),
       .target(name: "SwiftOCASecure", condition: .when(traits: ["NonEmbeddedBuild"])),
       .target(name: "SwiftOCASecureDevice", condition: .when(traits: ["NonEmbeddedBuild"])),
+      // Apple-only test files (WebSocketConnectionTests, AppleTLSPolicyRegressionTests)
+      // import these directly. SwiftPM doesn't re-export a target's deps, so
+      // we have to declare them on the test target too.
+      .product(
+        name: "FlyingSocks",
+        package: "FlyingFox",
+        condition: .when(platforms: [.macOS, .iOS])
+      ),
+      .product(
+        name: "FlyingFox",
+        package: "FlyingFox",
+        condition: .when(platforms: [.macOS, .iOS], traits: ["NonEmbeddedBuild"])
+      ),
     ],
     swiftSettings: [
       .unsafeFlags(ASANSwiftFlags),


### PR DESCRIPTION
## Summary
`WebSocketConnectionTests.swift` and `AppleTLSPolicyRegressionTests.swift` (both added in e70d8748) `import FlyingFox` / `FlyingSocks` under `#if os(macOS) || os(iOS)`. The `SwiftOCADeviceTests` target doesn't declare these products — SwiftPM doesn't re-export a target's deps, so `swift test` on macOS fails to compile with `no such module 'FlyingFox'`.

Linux silently passed because both test files are platform-gated, so the imports were never reached.

## Test plan
- [x] `swift build --build-tests` on Linux — still clean
- [ ] `swift test` on macOS — test target now compiles; existing Apple-side TLS/WebSocket tests run

🤖 Generated with [Claude Code](https://claude.com/claude-code)