### PR TITLE
Conform Ocp1FlyingSocksConnection to Ocp1MutableConnection

### DIFF
--- a/Sources/SwiftOCA/OCP.1/Backend/Ocp1FlyingSocksConnection.swift
+++ b/Sources/SwiftOCA/OCP.1/Backend/Ocp1FlyingSocksConnection.swift
@@ -190,7 +190,7 @@ private actor AsyncSocketPoolMonitor {
   }
 }
 
-public class Ocp1FlyingSocksConnection: Ocp1Connection {
+public class Ocp1FlyingSocksConnection: Ocp1Connection, Ocp1MutableConnection {
   fileprivate let _deviceAddress: Mutex<FlyingSocks.AnySocketAddress>
   fileprivate var _asyncSocket: AsyncSocket?
 
@@ -216,7 +216,7 @@ public class Ocp1FlyingSocksConnection: Ocp1Connection {
     try? _asyncSocket?.close()
   }
 
-  nonisolated var deviceAddress: Data {
+  public nonisolated var deviceAddress: Data {
     get {
       _deviceAddress.criticalValue.data
     }


### PR DESCRIPTION
The CFSocket, NWConnection and IORing backends conform to
Ocp1MutableConnection; FlyingSocks has the same machinery (a Mutex-held
device address that fires deviceAddressDidChange() on update) but never
declared the conformance and kept its deviceAddress setter internal.

Adds the conformance and makes the setter public, so a live FlyingSocks
connection can be re-pointed (e.g. via ConnectionBroker) like every other
backend. No other behaviour change.

Tested: re-pointing a live FlyingSocks connection's address now takes
effect — the socket reconnects to the new address.