### PR TITLE
Don't schedule a reconnect on device address change while disconnected

### DIFF
--- a/Sources/SwiftOCA/OCA/Browsing/ConnectionBroker.swift
+++ b/Sources/SwiftOCA/OCA/Browsing/ConnectionBroker.swift
@@ -355,8 +355,9 @@ public actor OcaConnectionBroker {
         if firstAddressChanged,
            let mutableConnection = existingConnection as? Ocp1MutableConnection
         {
+          // the setter fires deviceAddressDidChange() itself (gated on there
+          // being a live connection to migrate)
           mutableConnection.deviceAddress = try device.firstAddress
-          await existingConnection.deviceAddressDidChange()
         }
 
         // if reconnection was temporarily disabled by _onBrowserDeviceRemoved, reenable it

--- a/Sources/SwiftOCA/OCP.1/Backend/Ocp1CFSocketConnection.swift
+++ b/Sources/SwiftOCA/OCP.1/Backend/Ocp1CFSocketConnection.swift
@@ -436,8 +436,8 @@ public class Ocp1CFSocketConnection: Ocp1Connection, Ocp1MutableConnection {
       do {
         try _deviceAddress.withLock {
           $0 = try AnySocketAddress(bytes: Array(newValue))
-          Task { [weak self] in await self?.deviceAddressDidChange() }
         }
+        deviceAddressDidChange()
       } catch {}
     }
   }

--- a/Sources/SwiftOCA/OCP.1/Backend/Ocp1FlyingSocksConnection.swift
+++ b/Sources/SwiftOCA/OCP.1/Backend/Ocp1FlyingSocksConnection.swift
@@ -224,8 +224,8 @@ public class Ocp1FlyingSocksConnection: Ocp1Connection, Ocp1MutableConnection {
       do {
         try _deviceAddress.withLock {
           $0 = try FlyingSocks.AnySocketAddress(data: newValue)
-          Task { [weak self] in await self?.deviceAddressDidChange() }
         }
+        deviceAddressDidChange()
       } catch {}
     }
   }

--- a/Sources/SwiftOCA/OCP.1/Backend/Ocp1IORingConnection.swift
+++ b/Sources/SwiftOCA/OCP.1/Backend/Ocp1IORingConnection.swift
@@ -126,8 +126,8 @@ public class Ocp1IORingConnection: Ocp1Connection, Ocp1MutableConnection {
       do {
         try _deviceAddress.withLock {
           $0 = try AnySocketAddress(bytes: Array(newValue))
-          Task { [weak self] in await self?.deviceAddressDidChange() }
         }
+        deviceAddressDidChange()
       } catch {}
     }
   }

--- a/Sources/SwiftOCA/OCP.1/Backend/Ocp1NWConnection.swift
+++ b/Sources/SwiftOCA/OCP.1/Backend/Ocp1NWConnection.swift
@@ -138,8 +138,8 @@ open class Ocp1NWConnection: Ocp1Connection, Ocp1MutableConnection {
       do {
         try _deviceAddress.withLock {
           $0 = try AnySocketAddress(bytes: Array(newValue))
-          Task { [weak self] in await self?.deviceAddressDidChange() }
         }
+        deviceAddressDidChange()
       } catch {}
     }
   }

--- a/Sources/SwiftOCA/OCP.1/Ocp1Connection+Connect.swift
+++ b/Sources/SwiftOCA/OCP.1/Ocp1Connection+Connect.swift
@@ -420,14 +420,24 @@ extension Ocp1Connection {
     }
   }
 
-  package func deviceAddressDidChange() {
+  /// Notify the connection that its `deviceAddress` was mutated underneath it
+  /// (e.g. a reconnect loop re-resolving a hostname, or the connection broker
+  /// following a device that changed address).
+  ///
+  /// A device-address change only needs to tear down and re-establish a *live*
+  /// connection. When we are not connected there is nothing to migrate — the
+  /// next `connectDevice()` reads the new address anyway — and scheduling a
+  /// reconnect here would race a caller that rebinds-then-connects: the
+  /// `.deviceAddressChanged` monitor error is recoverable, so were it to land
+  /// after a concurrent connect had already succeeded it would force a spurious
+  /// disconnect/reconnect. The connection state is therefore snapshotted
+  /// synchronously, at mutation time, so the decision cannot be invalidated by a
+  /// concurrent connect; `onMonitorError` re-checks once it runs on the actor.
+  package nonisolated func deviceAddressDidChange() {
+    guard _connectionState.value != .notConnected else { return }
     Task { [weak self] in
       try await self?.onMonitorError(id: -1, Ocp1Error.deviceAddressChanged)
     }
-  }
-
-  package func deviceAddressDidChange() async {
-    try? await onMonitorError(id: -1, Ocp1Error.deviceAddressChanged)
   }
 
   func onMonitorError(id: Int, _ error: Error) async throws {

--- a/Sources/SwiftOCADevice/OCP.1/Backend/NW/Ocp1NWQUICController.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/NW/Ocp1NWQUICController.swift
@@ -1,0 +1,162 @@
+//
+// Copyright (c) 2025 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(Network)
+
+import AsyncAlgorithms
+import AsyncExtensions
+import Foundation
+import Network
+@_spi(SwiftOCAPrivate)
+import SwiftOCA
+
+@available(macOS 14.0, iOS 17.0, *)
+actor Ocp1NWQUICController: Ocp1ControllerInternal, CustomStringConvertible {
+  nonisolated var flags: OcaControllerFlags { .supportsLocking }
+  nonisolated let connectionPrefix: String
+
+  var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()
+  var keepAliveTask: Task<(), Error>?
+  var lastMessageReceivedTime = ContinuousClock.recentPast
+  var lastMessageSentTime = ContinuousClock.recentPast
+  weak var endpoint: Ocp1NWQUICDeviceEndpoint?
+
+  private let _connection: NWConnection
+  private let _queue: DispatchQueue
+  private let _messages: AsyncThrowingStream<Ocp1MessageList, Error>
+  private nonisolated let _identifier: String
+
+  var messages: AnyAsyncSequence<Ocp1MessageList> {
+    _messages.eraseToAnyAsyncSequence()
+  }
+
+  init(
+    endpoint: Ocp1NWQUICDeviceEndpoint,
+    connection: NWConnection,
+    queue: DispatchQueue
+  ) throws {
+    self.endpoint = endpoint
+    self._connection = connection
+    self._queue = queue
+    self.connectionPrefix = OcaQuicConnectionPrefix
+
+    _identifier = Self.makeIdentifier(from: connection)
+    _messages = Self.decodingMessages(from: connection, timeout: endpoint.timeout)
+
+    connection.start(queue: queue)
+  }
+
+  var heartbeatTime = Duration.seconds(0) {
+    didSet {
+      heartbeatTimeDidChange(from: oldValue)
+    }
+  }
+
+  func sendOcp1EncodedData(_ data: Data) async throws {
+    try await withUnsafeThrowingContinuation { (continuation: UnsafeContinuation<Void, Error>) in
+      _connection.send(
+        content: data,
+        isComplete: false,
+        completion: .contentProcessed { error in
+          if let error {
+            continuation.resume(throwing: error)
+          } else {
+            continuation.resume()
+          }
+        }
+      )
+    }
+  }
+
+  func close() async throws {
+    _connection.cancel()
+    keepAliveTask?.cancel()
+    keepAliveTask = nil
+  }
+
+  deinit {
+    keepAliveTask?.cancel()
+  }
+
+  nonisolated var identifier: String {
+    _identifier
+  }
+
+  nonisolated var description: String {
+    "\(type(of: self))(address: \(_identifier))"
+  }
+}
+
+@available(macOS 14.0, iOS 17.0, *)
+extension Ocp1NWQUICController: Equatable {
+  nonisolated static func == (
+    lhs: Ocp1NWQUICController,
+    rhs: Ocp1NWQUICController
+  ) -> Bool {
+    lhs._identifier == rhs._identifier
+  }
+}
+
+@available(macOS 14.0, iOS 17.0, *)
+extension Ocp1NWQUICController: Hashable {
+  nonisolated func hash(into hasher: inout Hasher) {
+    _identifier.hash(into: &hasher)
+  }
+}
+
+@available(macOS 14.0, iOS 17.0, *)
+private extension Ocp1NWQUICController {
+  static func makeIdentifier(from connection: NWConnection) -> String {
+    switch connection.endpoint {
+    case let .hostPort(host, port):
+      "\(host):\(port)"
+    default:
+      "\(connection.endpoint)"
+    }
+  }
+
+  static func decodingMessages(
+    from connection: NWConnection,
+    timeout: Duration
+  ) -> AsyncThrowingStream<Ocp1MessageList, Error> {
+    AsyncThrowingStream<Ocp1MessageList, Error> {
+      do {
+        return try await withThrowingTimeout(of: timeout, clock: .continuous) {
+          try await OcaDevice.receiveMessages { count in
+            try await withUnsafeThrowingContinuation { (continuation: UnsafeContinuation<Data, Error>) in
+              connection.receive(
+                minimumIncompleteLength: count,
+                maximumLength: max(count, Ocp1MaximumDatagramPduSize)
+              ) { data, _, _, error in
+                if let error {
+                  continuation.resume(throwing: error)
+                } else if let data {
+                  continuation.resume(returning: data)
+                } else {
+                  continuation.resume(throwing: Ocp1Error.notConnected)
+                }
+              }
+            }
+          }
+        }
+      } catch {
+        throw error
+      }
+    }
+  }
+}
+
+#endif

--- a/Sources/SwiftOCADevice/OCP.1/Backend/NW/Ocp1NWQUICDeviceEndpoint.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/NW/Ocp1NWQUICDeviceEndpoint.swift
@@ -1,0 +1,165 @@
+//
+// Copyright (c) 2025 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(Network)
+
+import AsyncExtensions
+import Foundation
+import Logging
+import Network
+import SocketAddress
+import Synchronization
+@_spi(SwiftOCAPrivate)
+import SwiftOCA
+
+@available(macOS 14.0, iOS 17.0, *)
+@OcaDevice
+public final class Ocp1NWQUICDeviceEndpoint: OcaDeviceEndpointPrivate,
+  OcaBonjourRegistrableDeviceEndpoint,
+  CustomStringConvertible
+{
+  typealias ControllerType = Ocp1NWQUICController
+
+  public var controllers: [OcaController] {
+    _controllers
+  }
+
+  let timeout: Duration
+  let device: OcaDevice
+  let logger: Logger
+  nonisolated(unsafe) var enableMessageTracing = false
+
+  private var _controllers = [Ocp1NWQUICController]()
+  private let _listener: NWListener
+  private let _queue: DispatchQueue
+  private let _port: UInt16
+  #if canImport(dnssd)
+  private var _endpointRegistrarTask: Task<(), Error>?
+  #endif
+
+  /// Create a QUIC device endpoint.
+  ///
+  /// - Parameters:
+  ///   - port: The port to listen on (0 for ephemeral).
+  ///   - credential: QUIC credential (`.identity` or `.psk`).
+  ///   - timeout: Idle/heartbeat timeout.
+  ///   - device: The OCA device to attach to.
+  ///   - logger: Logger instance.
+  public init(
+    port: UInt16,
+    credential: Ocp1TLSCredential,
+    timeout: Duration = OcaDevice.DefaultTimeout,
+    device: OcaDevice = OcaDevice.shared,
+    logger: Logger = Logger(label: "com.padl.SwiftOCADevice.Ocp1NWQUICDeviceEndpoint")
+  ) async throws {
+    self._port = port
+    self.timeout = timeout
+    self.device = device
+    self.logger = logger
+    self._queue = DispatchQueue(
+      label: "com.padl.SwiftOCADevice.Ocp1NWQUICDeviceEndpoint",
+      attributes: .concurrent
+    )
+
+    let options = NWProtocolQUIC.Options(alpn: ["oca"])
+    options.idleTimeout = Int(timeout.seconds)
+    credential.apply(to: options.securityProtocolOptions)
+    let parameters = NWParameters(quic: options)
+    parameters.requiredLocalEndpoint = NWEndpoint.hostPort(
+      host: .ipv6(.any),
+      port: NWEndpoint.Port(integerLiteral: port)
+    )
+
+    _listener = try NWListener(using: parameters)
+
+    try await device.add(endpoint: self)
+  }
+
+  public nonisolated var description: String {
+    "\(type(of: self))(port: \(_port), timeout: \(timeout))"
+  }
+
+  public func run() async throws {
+    logger.info("starting \(type(of: self)) on port \(_port)")
+
+    return try await withCheckedThrowingContinuation { continuation in
+      let resumed = Mutex(false)
+
+      _listener.stateUpdateHandler = { [weak self] state in
+        guard let self else { return }
+        switch state {
+        case .ready:
+          if _port != 0 {
+            #if canImport(dnssd)
+            Task { try await self.runBonjourEndpointRegistrar(for: self.device) }
+            #endif
+          }
+        case let .failed(error):
+          self.logger.critical("listener failed: \(error)")
+          resumed.withLock {
+            guard !$0 else { return }
+            $0 = true
+            continuation.resume(throwing: error)
+          }
+        case .cancelled:
+          resumed.withLock {
+            guard !$0 else { return }
+            $0 = true
+            continuation.resume(returning: ())
+          }
+        default:
+          break
+        }
+      }
+
+      _listener.newConnectionHandler = { [weak self] nwConnection in
+        guard let self else { return }
+        Task {
+          do {
+            let controller = try await Ocp1NWQUICController(
+              endpoint: self,
+              connection: nwConnection,
+              queue: self._queue
+            )
+            await controller.handle(for: self)
+          } catch {
+            self.logger.error("failed to create controller: \(error)")
+          }
+        }
+      }
+
+      _listener.start(queue: _queue)
+    }
+  }
+
+  public nonisolated var serviceType: OcaNetworkAdvertisingServiceType {
+    .quic
+  }
+
+  public nonisolated var port: UInt16 {
+    _listener.port?.rawValue ?? _port
+  }
+
+  func add(controller: ControllerType) async {
+    _controllers.append(controller)
+  }
+
+  func remove(controller: ControllerType) async {
+    _controllers.removeAll(where: { $0 == controller })
+  }
+}
+
+#endif

--- a/Sources/SwiftOCASecure/OCP.1/Backend/Ocp1OpenSSLConnection.swift
+++ b/Sources/SwiftOCASecure/OCP.1/Backend/Ocp1OpenSSLConnection.swift
@@ -132,8 +132,8 @@ public final class Ocp1OpenSSLConnection: Ocp1Connection, Ocp1MutableConnection 
       do {
         try _deviceAddress.withLock {
           $0 = try AnySocketAddress(bytes: Array(newValue))
-          Task { [weak self] in await self?.deviceAddressDidChange() }
         }
+        deviceAddressDidChange()
       } catch {}
     }
   }

--- a/Sources/SwiftOCASecure/OCP.1/Backend/Ocp1OpenSSLDTLSConnection.swift
+++ b/Sources/SwiftOCASecure/OCP.1/Backend/Ocp1OpenSSLDTLSConnection.swift
@@ -116,8 +116,8 @@ public final class Ocp1OpenSSLDTLSConnection: Ocp1Connection, Ocp1MutableConnect
       do {
         try _deviceAddress.withLock {
           $0 = try AnySocketAddress(bytes: Array(newValue))
-          Task { [weak self] in await self?.deviceAddressDidChange() }
         }
+        deviceAddressDidChange()
       } catch {}
     }
   }

--- a/Sources/dnssd/shim.c
+++ b/Sources/dnssd/shim.c
@@ -1,0 +1,39 @@
+#include "dnssd.h"
+
+#ifndef __APPLE__
+#include <Block/Block.h>
+#endif
+
+static void DNSSD_API
+DNSServiceRegisterReplyBlockThunk(DNSServiceRef sdRef,
+                                  DNSServiceFlags flags,
+                                  DNSServiceErrorType errorCode,
+                                  const char *name,
+                                  const char *regtype,
+                                  const char *domain,
+                                  void *context) {
+    DNSServiceRegisterReplyBlock block = (DNSServiceRegisterReplyBlock)context;
+    if (block) {
+        block(sdRef, flags, errorCode, name, regtype, domain);
+        _Block_release(block);
+    }
+}
+
+DNSSD_EXPORT
+DNSServiceErrorType DNSSD_API
+DNSServiceRegisterBlock(DNSServiceRef *sdRef,
+                        DNSServiceFlags flags,
+                        uint32_t interfaceIndex,
+                        const char *name, /* may be NULL */
+                        const char *regtype,
+                        const char *domain, /* may be NULL */
+                        const char *host,   /* may be NULL */
+                        uint16_t port,      /* In network byte order */
+                        uint16_t txtLen,
+                        const void *txtRecord, /* may be NULL */
+                        DNSServiceRegisterReplyBlock block) {
+    return DNSServiceRegister(sdRef, flags, interfaceIndex, name, regtype,
+                              domain, host, port, txtLen, txtRecord,
+                              block ? DNSServiceRegisterReplyBlockThunk : NULL,
+                              block ? _Block_copy(block) : NULL);
+}


### PR DESCRIPTION
## Problem

`deviceAddressDidChange()` unconditionally scheduled an `onMonitorError(.deviceAddressChanged)` reconnect whenever a mutable connection's `deviceAddress` was set. `.deviceAddressChanged` is classified **recoverable**, so under `automaticReconnect` it triggers a tear-down + backoff reconnect.

That races a caller that **re-resolves a hostname and re-points a live connection immediately before connecting** — e.g. a reconnect loop that comes up off a deferred/placeholder address (`0.0.0.0`) and `rebind`s to the real address each attempt before calling `connect()`. The setter spawned the notification on a detached `Task`, so it checked the connection state *late* (when the task ran). If it ran **after** the connect had already succeeded, `onMonitorError` saw `.connected` and forced a spurious disconnect → reconnect flap.

## Fix

The notification only matters when there is a **live connection to migrate**. When `notConnected`, the next `connectDevice()` reads the new address anyway, so no notification is needed.

- `deviceAddressDidChange()` is now `nonisolated` and gates on `_connectionState.value != .notConnected`, **snapshotting the state synchronously at mutation time** so a concurrent connect can't invalidate the decision. `onMonitorError` still re-checks once it runs on the actor.
- The six backend `deviceAddress` setters (`NW`, `IORing`, `CFSocket`, `FlyingSocks`, `OpenSSL`, `OpenSSLDTLS`) now call `deviceAddressDidChange()` **directly** instead of hopping through a `Task` — that hop is exactly what made the state check race the connect.
- Dropped the redundant explicit `deviceAddressDidChange()` call in `OcaConnectionBroker`; the setter now fires it (gated) on its own.

The previous `async` overload of `deviceAddressDidChange()` is removed (its only caller was the broker line above).

## Behavior

- **Connected** address change (broker following a device that moved, mid-connection re-resolve): unchanged — notification fires, reconnect to the new address.
- **Disconnected** address change (reconnect loop rebinding before connect): notification is now skipped; the subsequent `connectDevice()` picks up the new address. No spurious reconnect.

When `notConnected`, `onMonitorError` was already a no-op (it returns early unless `currentConnectionState != .notConnected`), so this only removes the racing reconnect, not any real one.

## Testing

`swift build` clean. Surfaced while reviewing a downstream retry-on-initial-connect change (inferno_ui) that relies on `DeviceEndpointInfo.rebind` re-pointing the connection between attempts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)