### PR TITLE
Hostname-resolved connections; consolidate device address state

### DIFF
--- a/Sources/SwiftOCA/OCA/Helpers/HostnameResolution.swift
+++ b/Sources/SwiftOCA/OCA/Helpers/HostnameResolution.swift
@@ -1,0 +1,88 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Dispatch
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+import SocketAddress
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Android)
+import Android
+#endif
+
+/// `getaddrinfo` is a blocking syscall with no portable async form, so run it on
+/// a dedicated queue — never on the `OcaConnection` global actor — and present an
+/// `async` interface. This keeps name resolution asynchronous from the caller's
+/// perspective: the actor (and the Swift cooperative pool) is never blocked.
+private let _resolverQueue = DispatchQueue(
+  label: "com.padl.SwiftOCA.hostname-resolver",
+  attributes: .concurrent
+)
+
+package func _resolveDeviceAddresses(
+  host: String,
+  port: UInt16,
+  isDatagram: Bool
+) async -> [AnySocketAddress] {
+  await withCheckedContinuation { continuation in
+    _resolverQueue.async {
+      continuation.resume(returning: _resolveDeviceAddressesBlocking(
+        host: host,
+        port: port,
+        isDatagram: isDatagram
+      ))
+    }
+  }
+}
+
+/// Resolve `host`:`port` to `sockaddr` candidates in the system's preferred order
+/// (RFC 6724 on a modern resolver). Returns an empty array when the name does not
+/// resolve — the caller treats that as "not reachable yet" and retries.
+private func _resolveDeviceAddressesBlocking(
+  host: String,
+  port: UInt16,
+  isDatagram: Bool
+) -> [AnySocketAddress] {
+  var hints = addrinfo()
+  hints.ai_family = AF_UNSPEC // both IPv4 and IPv6
+  hints.ai_socktype = isDatagram ? SOCK_DGRAM : SOCK_STREAM
+  hints.ai_flags = AI_ADDRCONFIG // only families with a configured local address
+
+  var result: UnsafeMutablePointer<addrinfo>?
+  guard getaddrinfo(host, String(port), &hints, &result) == 0, let result else {
+    return []
+  }
+  defer { freeaddrinfo(result) }
+
+  var addresses: [AnySocketAddress] = []
+  var candidate: UnsafeMutablePointer<addrinfo>? = result
+  while let info = candidate {
+    if let sa = info.pointee.ai_addr {
+      let bytes = UnsafeRawBufferPointer(start: sa, count: Int(info.pointee.ai_addrlen))
+      if let address = try? AnySocketAddress(bytes: Array(bytes)) {
+        addresses.append(address)
+      }
+    }
+    candidate = info.pointee.ai_next
+  }
+  return addresses
+}

--- a/Sources/SwiftOCA/OCP.1/Backend/Ocp1CFSocketConnection.swift
+++ b/Sources/SwiftOCA/OCP.1/Backend/Ocp1CFSocketConnection.swift
@@ -395,8 +395,7 @@ Sendable, CustomStringConvertible, Hashable {
 }
 
 public class Ocp1CFSocketConnection: Ocp1Connection, Ocp1MutableSocketAddressConnection {
-  package let _deviceAddresses: Mutex<[AnySocketAddress]>
-  package let _connectedDeviceAddress = Mutex<AnySocketAddress?>(nil)
+  package let _deviceAddressState: Mutex<Ocp1DeviceAddressState>
   fileprivate var _socket: _CFSocketWrapper?
   fileprivate var _type: Int32 {
     fatalError("must be implemented by subclass")
@@ -406,7 +405,7 @@ public class Ocp1CFSocketConnection: Ocp1Connection, Ocp1MutableSocketAddressCon
     deviceAddresses: [AnySocketAddress],
     options: Ocp1ConnectionOptions = Ocp1ConnectionOptions()
   ) throws {
-    _deviceAddresses = Mutex(deviceAddresses)
+    _deviceAddressState = Mutex(Ocp1DeviceAddressState(addresses: deviceAddresses))
     super.init(options: options)
   }
 

--- a/Sources/SwiftOCA/OCP.1/Backend/Ocp1FlyingSocksConnection.swift
+++ b/Sources/SwiftOCA/OCP.1/Backend/Ocp1FlyingSocksConnection.swift
@@ -198,19 +198,28 @@ private actor AsyncSocketPoolMonitor {
 public class Ocp1FlyingSocksConnection: Ocp1Connection, Ocp1MutableSocketAddressConnection {
   // The bare `AnySocketAddress` here is the PADL struct (selectively imported
   // above); `FlyingSocks.AnySocketAddress` stays fully qualified everywhere else.
-  package let _deviceAddresses: Mutex<[AnySocketAddress]>
-  package let _connectedDeviceAddress = Mutex<AnySocketAddress?>(nil)
+  package let _deviceAddressState: Mutex<Ocp1DeviceAddressState>
   fileprivate var _asyncSocket: AsyncSocket?
 
-  public init(
+  package init(
+    addressState: Ocp1DeviceAddressState,
+    options: Ocp1ConnectionOptions = Ocp1ConnectionOptions()
+  ) throws {
+    _deviceAddressState = Mutex(addressState)
+    super.init(options: options)
+  }
+
+  public convenience init(
     deviceAddresses: [Data],
     options: Ocp1ConnectionOptions = Ocp1ConnectionOptions()
   ) throws {
     // Drop any candidate that won't parse rather than discarding the whole list.
-    _deviceAddresses = Mutex(deviceAddresses.compactMap {
-      try? AnySocketAddress(bytes: Array($0))
-    })
-    super.init(options: options)
+    try self.init(
+      addressState: Ocp1DeviceAddressState(
+        addresses: deviceAddresses.compactMap { try? AnySocketAddress(bytes: Array($0)) }
+      ),
+      options: options
+    )
   }
 
   public convenience init(
@@ -218,6 +227,19 @@ public class Ocp1FlyingSocksConnection: Ocp1Connection, Ocp1MutableSocketAddress
     options: Ocp1ConnectionOptions = Ocp1ConnectionOptions()
   ) throws {
     try self.init(deviceAddresses: [deviceAddress], options: options)
+  }
+
+  /// Connect to `host`:`port`, resolved to candidate addresses on each connect
+  /// attempt. An unresolved name is treated as "not reachable yet" and retried.
+  public convenience init(
+    host: String,
+    port: UInt16,
+    options: Ocp1ConnectionOptions = Ocp1ConnectionOptions()
+  ) throws {
+    try self.init(
+      addressState: Ocp1DeviceAddressState(networkAddress: Ocp1NetworkAddress(address: host, port: port)),
+      options: options
+    )
   }
 
   deinit {

--- a/Sources/SwiftOCA/OCP.1/Backend/Ocp1IORingConnection.swift
+++ b/Sources/SwiftOCA/OCP.1/Backend/Ocp1IORingConnection.swift
@@ -55,14 +55,13 @@ package extension Errno {
 
 public class Ocp1IORingConnection: Ocp1Connection, Ocp1MutableSocketAddressConnection {
   fileprivate let _ring: IORing
-    package let _deviceAddresses: Mutex<[AnySocketAddress]>
-    package let _connectedDeviceAddress = Mutex<AnySocketAddress?>(nil)
+  package let _deviceAddressState: Mutex<Ocp1DeviceAddressState>
   fileprivate var _socket: Socket?
   fileprivate var _type: Int32 {
     fatalError("must be implemented by subclass")
   }
 
-    package func _connectDevice(to deviceAddress: AnySocketAddress) async throws {
+  package func _connectDevice(to deviceAddress: AnySocketAddress) async throws {
     fatalError("must be implemented by subclass")
   }
 
@@ -71,7 +70,13 @@ public class Ocp1IORingConnection: Ocp1Connection, Ocp1MutableSocketAddressConne
     options: Ocp1ConnectionOptions = Ocp1ConnectionOptions(),
     ring: IORing = .shared
   ) throws {
-    try self.init(socketAddresses: [deviceAddress.socketAddress], options: options, ring: ring)
+    try self.init(
+      addressState: Ocp1DeviceAddressState(
+        addresses: [AnySocketAddress(deviceAddress.socketAddress)]
+      ),
+      options: options,
+      ring: ring
+    )
   }
 
   public convenience init(
@@ -80,20 +85,27 @@ public class Ocp1IORingConnection: Ocp1Connection, Ocp1MutableSocketAddressConne
     ring: IORing = .shared
   ) throws {
     try self.init(
-      socketAddresses: deviceAddresses.compactMap { try? $0.socketAddress },
+      addressState: Ocp1DeviceAddressState(
+        addresses: deviceAddresses.compactMap { try? $0.socketAddress }.map { AnySocketAddress($0) }
+      ),
       options: options,
       ring: ring
     )
   }
 
-  fileprivate init(
-    socketAddresses: [any SocketAddress],
-    options: Ocp1ConnectionOptions,
+  /// Connect to `host`:`port`, resolved to candidate addresses on each connect
+  /// attempt. An unresolved name is treated as "not reachable yet" and retried.
+  public convenience init(
+    host: String,
+    port: UInt16,
+    options: Ocp1ConnectionOptions = Ocp1ConnectionOptions(),
     ring: IORing = .shared
   ) throws {
-    _deviceAddresses = Mutex(socketAddresses.map { AnySocketAddress($0) })
-    _ring = ring
-    super.init(options: options)
+    try self.init(
+      addressState: Ocp1DeviceAddressState(networkAddress: Ocp1NetworkAddress(address: host, port: port)),
+      options: options,
+      ring: ring
+    )
   }
 
   public convenience init(
@@ -102,13 +114,23 @@ public class Ocp1IORingConnection: Ocp1Connection, Ocp1MutableSocketAddressConne
     ring: IORing = .shared
   ) throws {
     try self.init(
-      socketAddresses: [sockaddr_un(
+      addressState: Ocp1DeviceAddressState(addresses: [AnySocketAddress(sockaddr_un(
         family: sa_family_t(AF_LOCAL),
         presentationAddress: path
-      )],
+      ))]),
       options: options,
       ring: ring
     )
+  }
+
+  fileprivate init(
+    addressState: Ocp1DeviceAddressState,
+    options: Ocp1ConnectionOptions,
+    ring: IORing = .shared
+  ) throws {
+    _deviceAddressState = Mutex(addressState)
+    _ring = ring
+    super.init(options: options)
   }
 
   fileprivate func _cleanupConnection() {
@@ -153,13 +175,13 @@ public final class Ocp1IORingDatagramConnection: Ocp1IORingConnection {
   }
 
   override fileprivate init(
-    socketAddresses: [any SocketAddress],
+    addressState: Ocp1DeviceAddressState,
     options: Ocp1ConnectionOptions,
     ring: IORing
   ) throws {
-    guard socketAddresses.allSatisfy({ $0.family == AF_INET || $0.family == AF_INET6 })
+    guard addressState.addresses.allSatisfy({ $0.family == AF_INET || $0.family == AF_INET6 })
     else { throw Errno.addressFamilyNotSupported }
-    try super.init(socketAddresses: socketAddresses, options: options, ring: ring)
+    try super.init(addressState: addressState, options: options, ring: ring)
   }
 
   override public func connectDevice() async throws {
@@ -213,14 +235,14 @@ public final class Ocp1IORingDomainSocketDatagramConnection: Ocp1IORingConnectio
   }
 
   override fileprivate init(
-    socketAddresses: [any SocketAddress],
+    addressState: Ocp1DeviceAddressState,
     options: Ocp1ConnectionOptions,
     ring: IORing
   ) throws {
-    guard socketAddresses.allSatisfy({ $0.family == AF_LOCAL })
+    guard addressState.addresses.allSatisfy({ $0.family == AF_LOCAL })
     else { throw Errno.addressFamilyNotSupported }
     _boundAddress = try sockaddr_un.ephemeralDatagramDomainSocketName
-    try super.init(socketAddresses: socketAddresses, options: options, ring: ring)
+    try super.init(addressState: addressState, options: options, ring: ring)
   }
 
   override fileprivate func _cleanupConnection() {

--- a/Sources/SwiftOCA/OCP.1/Backend/Ocp1NWConnection.swift
+++ b/Sources/SwiftOCA/OCP.1/Backend/Ocp1NWConnection.swift
@@ -67,8 +67,7 @@ private extension SocketAddress {
 }
 
 open class Ocp1NWConnection: Ocp1Connection, Ocp1MutableSocketAddressConnection {
-  package let _deviceAddresses: Mutex<[AnySocketAddress]>
-  package let _connectedDeviceAddress = Mutex<AnySocketAddress?>(nil)
+  package let _deviceAddressState: Mutex<Ocp1DeviceAddressState>
   package var _queue: DispatchQueue!
   package var _nwConnection: NWConnection!
 
@@ -86,10 +85,10 @@ open class Ocp1NWConnection: Ocp1Connection, Ocp1MutableSocketAddressConnection 
   }
 
   package init(
-    deviceAddresses: [AnySocketAddress],
+    addressState: Ocp1DeviceAddressState,
     options: Ocp1ConnectionOptions = Ocp1ConnectionOptions()
   ) throws {
-    _deviceAddresses = Mutex(deviceAddresses)
+    _deviceAddressState = Mutex(addressState)
     super.init(options: options)
     _nwConnection = try NWConnection(to: nwEndpoint, using: parameters)
     Self._installPostReadyStateHandler(_nwConnection) { [weak self] in
@@ -116,8 +115,10 @@ open class Ocp1NWConnection: Ocp1Connection, Ocp1MutableSocketAddressConnection 
     deviceAddress: Data,
     options: Ocp1ConnectionOptions = Ocp1ConnectionOptions()
   ) throws {
-    let deviceAddress = try AnySocketAddress(bytes: Array(deviceAddress))
-    try self.init(deviceAddresses: [deviceAddress], options: options)
+    try self.init(
+      addressState: Ocp1DeviceAddressState(addresses: [AnySocketAddress(bytes: Array(deviceAddress))]),
+      options: options
+    )
   }
 
   public convenience init(
@@ -125,7 +126,23 @@ open class Ocp1NWConnection: Ocp1Connection, Ocp1MutableSocketAddressConnection 
     options: Ocp1ConnectionOptions = Ocp1ConnectionOptions()
   ) throws {
     try self.init(
-      deviceAddresses: deviceAddresses.compactMap { try? AnySocketAddress(bytes: Array($0)) },
+      addressState: Ocp1DeviceAddressState(
+        addresses: deviceAddresses.compactMap { try? AnySocketAddress(bytes: Array($0)) }
+      ),
+      options: options
+    )
+  }
+
+  /// Connect to `host`:`port`, resolved natively by Network.framework (which
+  /// applies Happy Eyeballs across the A/AAAA records itself). The name is not
+  /// pre-resolved, so an absent device is retried by the reconnect machinery.
+  public convenience init(
+    host: String,
+    port: UInt16,
+    options: Ocp1ConnectionOptions = Ocp1ConnectionOptions()
+  ) throws {
+    try self.init(
+      addressState: Ocp1DeviceAddressState(networkAddress: Ocp1NetworkAddress(address: host, port: port)),
       options: options
     )
   }
@@ -134,11 +151,13 @@ open class Ocp1NWConnection: Ocp1Connection, Ocp1MutableSocketAddressConnection 
     path: String,
     options: Ocp1ConnectionOptions = Ocp1ConnectionOptions()
   ) throws {
-    let deviceAddress = try AnySocketAddress(
-      family: sa_family_t(AF_LOCAL),
-      presentationAddress: path
+    try self.init(
+      addressState: Ocp1DeviceAddressState(addresses: [AnySocketAddress(
+        family: sa_family_t(AF_LOCAL),
+        presentationAddress: path
+      )]),
+      options: options
     )
-    try self.init(deviceAddresses: [deviceAddress], options: options)
   }
 
   private func _cleanupConnection() throws {
@@ -154,14 +173,31 @@ open class Ocp1NWConnection: Ocp1Connection, Ocp1MutableSocketAddressConnection 
     if _nwConnection.state != .setup {
       try _cleanupConnection()
     }
-    try await _connectFirstReachableDeviceAddress()
+    if let networkAddress = _deviceNetworkAddress {
+      // Native path: hand NW the hostname and let it resolve and apply Happy
+      // Eyeballs across the A/AAAA records, rather than pre-resolving ourselves.
+      try await _connectDevice(to: Self._nwEndpoint(for: networkAddress))
+    } else {
+      try await _connectFirstReachableDeviceAddress()
+    }
     try await super.connectDevice()
   }
 
   package func _connectDevice(to deviceAddress: AnySocketAddress) async throws {
     // Rebuild the connection for this specific candidate; NW is given a resolved
     // endpoint, so each candidate needs its own `NWConnection`.
-    let endpoint = try deviceAddress.asNWEndpoint()
+    try await _connectDevice(to: deviceAddress.asNWEndpoint())
+  }
+
+  /// The host:port endpoint for native (NW-resolved) connections.
+  fileprivate nonisolated static func _nwEndpoint(for networkAddress: Ocp1NetworkAddress) -> NWEndpoint {
+    NWEndpoint.hostPort(
+      host: .name(networkAddress.address, nil),
+      port: NWEndpoint.Port(integerLiteral: networkAddress.port)
+    )
+  }
+
+  private func _connectDevice(to endpoint: NWEndpoint) async throws {
     _nwConnection = try NWConnection(to: endpoint, using: parameters)
     let connection = _nwConnection!
     do {
@@ -280,7 +316,11 @@ open class Ocp1NWConnection: Ocp1Connection, Ocp1MutableSocketAddressConnection 
   /// `_connectDevice(to:)` builds an endpoint per candidate.
   open nonisolated var nwEndpoint: NWEndpoint {
     get throws {
-      guard let first = _deviceAddresses.criticalValue.first else {
+      let state = _deviceAddressState.criticalValue
+      if let networkAddress = state.networkAddress {
+        return Self._nwEndpoint(for: networkAddress)
+      }
+      guard let first = state.connectedAddress ?? state.addresses.first else {
         throw Ocp1Error.notConnected
       }
       return try first.asNWEndpoint()

--- a/Sources/SwiftOCA/OCP.1/Ocp1Connection.swift
+++ b/Sources/SwiftOCA/OCP.1/Ocp1Connection.swift
@@ -491,26 +491,48 @@ extension Ocp1Connection: Hashable {
   }
 }
 
+/// The mutable address state of a socket connection — the candidate addresses,
+/// the candidate actually connected to, and an optional host:port to re-resolve —
+/// bundled into one value so a backend declares a single `Mutex`-protected cell
+/// and the presentation accessors observe a consistent snapshot under one lock.
+/// A `struct` (not a class) so the `Mutex` owns and protects the value.
+package struct Ocp1DeviceAddressState: Sendable {
+  /// Candidate addresses, in preference order.
+  package var addresses: [AnySocketAddress]
+  /// The candidate the current session connected to (`nil` while disconnected),
+  /// which may differ from `addresses.first` if the preferred address failed.
+  package var connectedAddress: AnySocketAddress?
+  /// When set, the connection resolves this host:port on each connect attempt
+  /// instead of using `addresses` directly (NW resolves it natively and leaves
+  /// `addresses` empty). `Ocp1NetworkAddress.address` may be a hostname or a
+  /// numeric address.
+  package let networkAddress: Ocp1NetworkAddress?
+
+  package init(
+    addresses: [AnySocketAddress] = [],
+    connectedAddress: AnySocketAddress? = nil,
+    networkAddress: Ocp1NetworkAddress? = nil
+  ) {
+    self.addresses = addresses
+    self.connectedAddress = connectedAddress
+    self.networkAddress = networkAddress
+  }
+}
+
 /// A mutable connection that targets one or more resolved socket addresses (as
 /// opposed to, say, a Mach port or a WebSocket URL). Conformers declare only the
-/// two storage cells plus the per-candidate connect; this extension derives
-/// ``deviceAddresses``, tracks the candidate actually connected to, and drives
-/// first-reachable connect — so the address-handling lives here, with the
-/// backends, rather than on the base `Ocp1Connection`.
+/// single `Mutex`-protected ``Ocp1DeviceAddressState`` cell plus the per-candidate
+/// connect; this extension derives ``deviceAddresses``, tracks the candidate
+/// actually connected to, resolves an optional hostname, and drives first-reachable
+/// connect — so the address-handling lives here, not on the base `Ocp1Connection`.
 ///
 /// `package` for now: an internal mechanism shared by the package's socket
 /// backends, not yet public API.
 package protocol Ocp1MutableSocketAddressConnection: Ocp1Connection {
-  /// Backing store for the candidate addresses, parsed, in preference order. A
-  /// `Mutex` (not actor isolation) because `deviceAddresses` is read and written
-  /// `nonisolated`, off the `@OcaConnection` actor.
-  nonisolated var _deviceAddresses: Mutex<[AnySocketAddress]> { get }
-
-  /// Backing store for the candidate actually connected to (`nil` while
-  /// disconnected). A `Mutex` because it is written from the connect path (the
-  /// chosen candidate can change across reconnects) and read `nonisolated` by the
-  /// presentation accessors.
-  nonisolated var _connectedDeviceAddress: Mutex<AnySocketAddress?> { get }
+  /// Single store for the candidate addresses, the connected candidate, and an
+  /// optional hostname. A `Mutex` (not actor isolation) because the accessors are
+  /// read and written `nonisolated`, off the `@OcaConnection` actor.
+  nonisolated var _deviceAddressState: Mutex<Ocp1DeviceAddressState> { get }
 
   /// Establish the underlying transport to a single resolved candidate. Called
   /// by ``_connectFirstReachableDeviceAddress()`` for each address in turn;
@@ -527,11 +549,11 @@ package extension Ocp1MutableSocketAddressConnection {
   /// re-resolves the live connection (`deviceAddressesDidChange()`), an unchanged
   /// set is a no-op.
   nonisolated var deviceAddresses: [AnySocketAddress] {
-    get { _deviceAddresses.criticalValue }
+    get { _deviceAddressState.criticalValue.addresses }
     set {
-      let changed = _deviceAddresses.withLock { stored -> Bool in
-        guard stored != newValue else { return false }
-        stored = newValue
+      let changed = _deviceAddressState.withLock { state -> Bool in
+        guard state.addresses != newValue else { return false }
+        state.addresses = newValue
         return true
       }
       if changed { deviceAddressesDidChange() }
@@ -541,7 +563,7 @@ package extension Ocp1MutableSocketAddressConnection {
   /// Single-address convenience over ``deviceAddresses``: reads the preferred
   /// (first) candidate; writing replaces the whole set with the one address.
   nonisolated var deviceAddress: AnySocketAddress? {
-    get { _deviceAddresses.criticalValue.first }
+    get { _deviceAddressState.criticalValue.addresses.first }
     set { deviceAddresses = newValue.map { [$0] } ?? [] }
   }
 
@@ -549,7 +571,12 @@ package extension Ocp1MutableSocketAddressConnection {
   /// `deviceAddresses.first` if the preferred address was unreachable. `nil`
   /// while disconnected.
   nonisolated var connectedDeviceAddress: AnySocketAddress? {
-    _connectedDeviceAddress.criticalValue
+    _deviceAddressState.criticalValue.connectedAddress
+  }
+
+  /// The host:port this connection resolves, if any.
+  nonisolated var _deviceNetworkAddress: Ocp1NetworkAddress? {
+    _deviceAddressState.criticalValue.networkAddress
   }
 
   // MARK: `Data`-valued convenience for compatibility with callers that work in
@@ -565,37 +592,56 @@ package extension Ocp1MutableSocketAddressConnection {
 
 package extension Ocp1MutableSocketAddressConnection {
   /// The address currently in use: the connected candidate while connected,
-  /// otherwise the preferred (first) candidate. Use this — not
-  /// `deviceAddresses.first` — for any accessor that describes the live
+  /// otherwise the preferred (first) candidate, read under one lock. Use this —
+  /// not `deviceAddresses.first` — for any accessor that describes the live
   /// connection, so a connect that failed over to a non-preferred address is
   /// reported accurately.
   nonisolated var _currentSocketAddress: AnySocketAddress? {
-    _connectedDeviceAddress.criticalValue ?? _deviceAddresses.criticalValue.first
+    _deviceAddressState.withLock { $0.connectedAddress ?? $0.addresses.first }
   }
 
-  /// Numeric presentation ("host:port"/"[v6]:port") of the address currently in
-  /// use, for `connectionPrefix` and logging.
+  /// Numeric presentation of the address currently in use, for `connectionPrefix`
+  /// and logging. A hostname connection reports its (stable) `host:port` so its
+  /// identity doesn't churn as resolution changes the underlying address.
   nonisolated var _currentPresentationAddress: String {
-    _currentSocketAddress?._presentationAddress ?? "<unknown>"
+    _deviceAddressState.withLock { state in
+      if let networkAddress = state.networkAddress {
+        return "\(networkAddress.address):\(networkAddress.port)"
+      }
+      return (state.connectedAddress ?? state.addresses.first)?._presentationAddress ?? "<unknown>"
+    }
   }
 
   nonisolated func _clearConnectedDeviceAddress() {
-    _connectedDeviceAddress.withLock { $0 = nil }
+    _deviceAddressState.withLock { $0.connectedAddress = nil }
   }
 
-  /// Connect to the first candidate in ``deviceAddresses`` for which
-  /// ``_connectDevice(to:)`` succeeds, trying each in preference order, and
-  /// record it as ``connectedDeviceAddress``. The overall connect budget
-  /// (`_connectionTimeout`, applied by `_connectDeviceWithTimeout`) is divided
-  /// across the candidates, so a black-holed early address (SYN dropped, no RST)
-  /// cannot consume the whole budget before the next candidate is tried. The
+  /// Connect to the first reachable candidate, trying each in preference order
+  /// and recording it as ``connectedDeviceAddress``. If a hostname is set it is
+  /// re-resolved (off-actor) first, so a device absent at launch or one that
+  /// moved is picked up on a later attempt. The overall connect budget
+  /// (`_connectionTimeout`) is divided across the candidates, so a black-holed
+  /// early address can't consume the whole budget before the next is tried. The
   /// real connect *is* the reachability test — there is no separate probe.
   @OcaConnection
   func _connectFirstReachableDeviceAddress() async throws {
-    let candidates = _deviceAddresses.criticalValue
-    guard !candidates.isEmpty else { throw Ocp1Error.notConnected }
+    if let networkAddress = _deviceNetworkAddress {
+      // Re-resolve off the actor on each attempt. Set directly (not via the
+      // `deviceAddresses` setter) so it doesn't fire `deviceAddressesDidChange()`
+      // mid-connect.
+      let resolved = await _resolveDeviceAddresses(
+        host: networkAddress.address,
+        port: networkAddress.port,
+        isDatagram: isDatagram
+      )
+      _deviceAddressState.withLock { $0.addresses = resolved }
+    }
 
-    _connectedDeviceAddress.withLock { $0 = nil }
+    let candidates = _deviceAddressState.withLock { state -> [AnySocketAddress] in
+      state.connectedAddress = nil
+      return state.addresses
+    }
+    guard !candidates.isEmpty else { throw Ocp1Error.notConnected }
 
     // Single candidate: rely on the outer `_connectDeviceWithTimeout`. Multiple:
     // give each an equal slice so their sum fits the outer budget (which would
@@ -614,7 +660,7 @@ package extension Ocp1MutableSocketAddressConnection {
         } else {
           try await _connectDevice(to: deviceAddress)
         }
-        _connectedDeviceAddress.withLock { $0 = deviceAddress }
+        _deviceAddressState.withLock { $0.connectedAddress = deviceAddress }
         if candidates.count > 1 {
           logger.debug("connectDevice: connected to \(deviceAddress._presentationAddress)")
         }

--- a/Sources/SwiftOCASecure/OCP.1/Backend/Ocp1NWSecureConnection.swift
+++ b/Sources/SwiftOCASecure/OCP.1/Backend/Ocp1NWSecureConnection.swift
@@ -269,7 +269,7 @@ public final class Ocp1NWSecureTCPConnection: Ocp1NWConnection {
     self.trustRoots = trustRoots
     preloadedAnchors = preloaded
     self.revocation = revocation
-    try super.init(deviceAddresses: deviceAddresses, options: options)
+    try super.init(addressState: Ocp1DeviceAddressState(addresses: deviceAddresses), options: options)
   }
 
   public convenience init(
@@ -383,7 +383,7 @@ public final class Ocp1NWSecureUDPConnection: Ocp1NWConnection {
     self.trustRoots = trustRoots
     preloadedAnchors = preloaded
     self.revocation = revocation
-    try super.init(deviceAddresses: deviceAddresses, options: options)
+    try super.init(addressState: Ocp1DeviceAddressState(addresses: deviceAddresses), options: options)
   }
 
   public convenience init(

--- a/Sources/SwiftOCASecure/OCP.1/Backend/Ocp1OpenSSLConnection.swift
+++ b/Sources/SwiftOCASecure/OCP.1/Backend/Ocp1OpenSSLConnection.swift
@@ -48,8 +48,7 @@ fileprivate extension Errno {
 /// `Ocp1OpenSSLEngine` only sees the memory BIO pair we pump.
 public final class Ocp1OpenSSLConnection: Ocp1Connection, Ocp1MutableSocketAddressConnection {
   private let _ring: IORing
-  package let _deviceAddresses: Mutex<[AnySocketAddress]>
-  package let _connectedDeviceAddress = Mutex<AnySocketAddress?>(nil)
+  package let _deviceAddressState: Mutex<Ocp1DeviceAddressState>
   private let _socket: Mutex<Socket?> = .init(nil)
   private let _credential: Ocp1TLSCredential
   private let _engine: Ocp1OpenSSLEngine
@@ -62,7 +61,7 @@ public final class Ocp1OpenSSLConnection: Ocp1Connection, Ocp1MutableSocketAddre
   override public var hasTransportLayerSecurity: Bool { true }
 
   private init(
-    socketAddresses: [any SocketAddress],
+    addressState: Ocp1DeviceAddressState,
     credential: Ocp1TLSCredential,
     hostname: String?,
     trustRoots: Ocp1TLSTrustRoots?,
@@ -70,7 +69,7 @@ public final class Ocp1OpenSSLConnection: Ocp1Connection, Ocp1MutableSocketAddre
     options: Ocp1ConnectionOptions,
     ring: IORing
   ) throws {
-    _deviceAddresses = Mutex(socketAddresses.map { AnySocketAddress($0) })
+    _deviceAddressState = Mutex(addressState)
     _ring = ring
     _credential = credential
     let verifyPeer = !options.flags.contains(.disableCertificateVerification)
@@ -95,7 +94,7 @@ public final class Ocp1OpenSSLConnection: Ocp1Connection, Ocp1MutableSocketAddre
     ring: IORing = .shared
   ) throws {
     try self.init(
-      socketAddresses: [deviceAddress.socketAddress],
+      addressState: Ocp1DeviceAddressState(addresses: [AnySocketAddress(deviceAddress.socketAddress)]),
       credential: credential,
       hostname: hostname,
       trustRoots: trustRoots,
@@ -115,9 +114,33 @@ public final class Ocp1OpenSSLConnection: Ocp1Connection, Ocp1MutableSocketAddre
     ring: IORing = .shared
   ) throws {
     try self.init(
-      socketAddresses: deviceAddresses.compactMap { try? $0.socketAddress },
+      addressState: Ocp1DeviceAddressState(
+        addresses: deviceAddresses.compactMap { try? $0.socketAddress }.map { AnySocketAddress($0) }
+      ),
       credential: credential,
       hostname: hostname,
+      trustRoots: trustRoots,
+      revocation: revocation,
+      options: options,
+      ring: ring
+    )
+  }
+
+  /// Connect to `host`:`port`, resolved to candidate addresses on each connect
+  /// attempt. `host` is also the TLS server name (SNI / certificate verification).
+  public convenience init(
+    host: String,
+    port: UInt16,
+    credential: Ocp1TLSCredential,
+    trustRoots: Ocp1TLSTrustRoots? = nil,
+    revocation: Ocp1TLSRevocationOptions = .disabled,
+    options: Ocp1ConnectionOptions = Ocp1ConnectionOptions(),
+    ring: IORing = .shared
+  ) throws {
+    try self.init(
+      addressState: Ocp1DeviceAddressState(networkAddress: Ocp1NetworkAddress(address: host, port: port)),
+      credential: credential,
+      hostname: host,
       trustRoots: trustRoots,
       revocation: revocation,
       options: options,
@@ -132,10 +155,10 @@ public final class Ocp1OpenSSLConnection: Ocp1Connection, Ocp1MutableSocketAddre
     ring: IORing = .shared
   ) throws {
     try self.init(
-      socketAddresses: [sockaddr_un(
+      addressState: Ocp1DeviceAddressState(addresses: [AnySocketAddress(sockaddr_un(
         family: sa_family_t(AF_LOCAL),
         presentationAddress: path
-      )],
+      ))]),
       credential: credential,
       hostname: nil,
       trustRoots: nil,

--- a/Sources/SwiftOCASecure/OCP.1/Backend/Ocp1OpenSSLDTLSConnection.swift
+++ b/Sources/SwiftOCASecure/OCP.1/Backend/Ocp1OpenSSLDTLSConnection.swift
@@ -49,8 +49,7 @@ fileprivate extension Errno {
 /// rbio for SSL_read to drain one DTLS record at a time.
 public final class Ocp1OpenSSLDTLSConnection: Ocp1Connection, Ocp1MutableSocketAddressConnection {
   private let _ring: IORing
-  package let _deviceAddresses: Mutex<[AnySocketAddress]>
-  package let _connectedDeviceAddress = Mutex<AnySocketAddress?>(nil)
+  package let _deviceAddressState: Mutex<Ocp1DeviceAddressState>
   private let _socket: Mutex<Socket?> = .init(nil)
   private let _credential: Ocp1TLSCredential
   private let _engine: Ocp1OpenSSLEngine
@@ -65,7 +64,7 @@ public final class Ocp1OpenSSLDTLSConnection: Ocp1Connection, Ocp1MutableSocketA
   override public var heartbeatTime: Duration { .seconds(1) }
 
   private init(
-    socketAddresses: [any SocketAddress],
+    addressState: Ocp1DeviceAddressState,
     credential: Ocp1TLSCredential,
     hostname: String?,
     trustRoots: Ocp1TLSTrustRoots?,
@@ -73,7 +72,7 @@ public final class Ocp1OpenSSLDTLSConnection: Ocp1Connection, Ocp1MutableSocketA
     options: Ocp1ConnectionOptions,
     ring: IORing
   ) throws {
-    _deviceAddresses = Mutex(socketAddresses.map { AnySocketAddress($0) })
+    _deviceAddressState = Mutex(addressState)
     _ring = ring
     _credential = credential
     let verifyPeer = !options.flags.contains(.disableCertificateVerification)
@@ -99,7 +98,7 @@ public final class Ocp1OpenSSLDTLSConnection: Ocp1Connection, Ocp1MutableSocketA
     ring: IORing = .shared
   ) throws {
     try self.init(
-      socketAddresses: [deviceAddress.socketAddress],
+      addressState: Ocp1DeviceAddressState(addresses: [AnySocketAddress(deviceAddress.socketAddress)]),
       credential: credential,
       hostname: hostname,
       trustRoots: trustRoots,
@@ -119,7 +118,9 @@ public final class Ocp1OpenSSLDTLSConnection: Ocp1Connection, Ocp1MutableSocketA
     ring: IORing = .shared
   ) throws {
     try self.init(
-      socketAddresses: deviceAddresses.compactMap { try? $0.socketAddress },
+      addressState: Ocp1DeviceAddressState(
+        addresses: deviceAddresses.compactMap { try? $0.socketAddress }.map { AnySocketAddress($0) }
+      ),
       credential: credential,
       hostname: hostname,
       trustRoots: trustRoots,


### PR DESCRIPTION
## Summary

Adds support for connections that are constructed with a **host:port** and resolve it themselves on each connect attempt, and consolidates the multi-address state each socket backend carries into a single `Mutex`-protected value.

### Device address state
The two separate `Mutex` cells (`_deviceAddresses`, `_connectedDeviceAddress`) every socket backend declared are replaced by one `Mutex<Ocp1DeviceAddressState>` bundling the candidate addresses, the connected candidate, and an optional `Ocp1NetworkAddress` (host:port). The presentation accessors (`_currentSocketAddress`, `_currentPresentationAddress`) now read a consistent snapshot under a single lock.

### Hostname resolution
A connection built with `init(host:port:)` carries an `Ocp1NetworkAddress` and resolves it on **each** connect attempt:
- **getaddrinfo** off the `OcaConnection` actor (on a dedicated queue) for the socket backends — `Helpers/HostnameResolution.swift`.
- **natively** by Network.framework for the NW backend (`NWEndpoint.host(.name…)`), so it applies Happy Eyeballs across the A/AAAA records and we don't double-resolve.

An unresolved name yields an **empty candidate set**, treated as "not reachable yet" and retried by the reconnect machinery — there is no `0.0.0.0` placeholder.

### Backends
`init(host:port:)` added to IORing, FlyingSocks, NW and OpenSSL (for OpenSSL the host doubles as the TLS server name for SNI / certificate verification). CFSocket (legacy) and the secure/DTLS datagram paths are moved to the single-cell storage without gaining host:port support.

The connection broker is unchanged (it still pushes resolved mDNS addresses via `deviceAddressData`); delegating its re-resolution to the connection is a possible follow-up.

## Test plan
- `swift build` + `swift test` on Linux (IORing/OpenSSL/DTLS); pre-existing DTLS full-suite flake only.
- Darwin CI green (NW / FlyingSocks / CFSocket / secure NW).