### PR TITLE
Tune SQLite dataset storage for frequent writes to flash

### DIFF
--- a/Sources/SwiftOCADevice/OCA/DatasetStorageProviders/SQLiteDatasetStorageProvider.swift
+++ b/Sources/SwiftOCADevice/OCA/DatasetStorageProviders/SQLiteDatasetStorageProvider.swift
@@ -42,7 +42,21 @@ public actor OcaSQLiteDatasetStorageProvider: OcaDatasetStorageProvider {
     deviceDelegate: OcaDevice?
   ) throws {
     let db = try Connection(path)
-    try db.run("PRAGMA auto_vacuum = INCREMENTAL")
+    // Tuned for frequent writes to flash storage with limited write cycles.
+    // auto_vacuum must be set before any table is created; it only takes effect
+    // on newly created databases (existing databases keep the mode they were
+    // created with), so NONE avoids pointer-map maintenance on every write for
+    // new databases without requiring a migration VACUUM of deployed ones.
+    try db.run("PRAGMA auto_vacuum = NONE")
+    // WAL batches main-database writes into checkpoints, roughly halving write
+    // amplification versus the rollback journal, while synchronous = FULL keeps
+    // every committed write durable across a power cut (the WAL is fsynced on
+    // each commit and replayed on recovery).
+    try db.run("PRAGMA journal_mode = WAL")
+    try db.run("PRAGMA synchronous = FULL")
+    // Wait rather than fail immediately if an external tool (e.g. the sqlite3
+    // CLI) briefly holds a lock.
+    try db.run("PRAGMA busy_timeout = 5000")
     _db = SendableConnectionBox(db)
     self.validDatasetONos = validDatasetONos
     self.validBlockONos = validBlockONos
@@ -266,8 +280,9 @@ public actor OcaSQLiteDatasetStorageProvider: OcaDatasetStorageProvider {
       throw Ocp1Error.unknownDataset
     }
 
-    try db.run("PRAGMA incremental_vacuum")
-
+    // Deliberately not reclaiming freed pages here: incremental_vacuum on every
+    // delete moves pages and truncates the file, costing extra flash writes. The
+    // dataset ONo space is small and bounded, so freed pages are simply reused.
     try? await deviceDelegate?.deregister(objectNumber: datasetONo)
   }
 }


### PR DESCRIPTION
## Summary

The SQLite dataset storage provider runs on devices that write **frequently** to flash storage with **limited write cycles**, and must keep committed writes durable across a **power cut**. This tunes the connection PRAGMAs and vacuum policy to cut write amplification without giving up durability.

Changes (all in `SQLiteDatasetStorageProvider.swift`):

- **`journal_mode = WAL`** — batches main-database writes into checkpoints, roughly halving write amplification and fsync count versus the default rollback journal. `synchronous = FULL` is kept, so the WAL is fsynced on every commit and every committed write survives a power cut (replayed on recovery).
- **`auto_vacuum = NONE`** — avoids pointer-map maintenance on every write. This only affects **newly created** databases; existing databases keep the mode they were created with, so no migration `VACUUM` is forced on deployed devices.
- **Removed per-delete `incremental_vacuum`** — it moved pages and truncated the file on every delete, costing extra flash writes. The dataset ONo space is small and bounded, so freed pages are simply reused.
- **`busy_timeout = 5000`** — wait rather than fail immediately if an external tool (e.g. the `sqlite3` CLI) briefly holds a lock.

## Compatibility

Safe for already-deployed databases: WAL converts existing rollback-journal databases in place on first open, and `synchronous`/`busy_timeout` are connection-level settings. The `auto_vacuum` change is silently a no-op on existing databases (they stay `INCREMENTAL`) and only applies to newly created ones — no forced migration.

## Testing

- `swift build --target SwiftOCADevice` succeeds (only pre-existing, unrelated deprecation warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151e1C1MGhZbER9hehChZCQ