### PR TITLE
Add the remaining property-oriented AES70 control classes

### DIFF
--- a/Sources/SwiftOCA/OCA/ClassRegistry.swift
+++ b/Sources/SwiftOCA/OCA/ClassRegistry.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 PADL Software Pty Ltd
+// Copyright (c) 2023-2026 PADL Software Pty Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.
@@ -91,6 +91,7 @@ public class OcaClassRegistry {
     try register(OcaGroup.self)
     try register(OcaCounterNotifier.self)
     try register(OcaCounterSetAgent.self)
+    try register(OcaPowerSupply.self)
 
     // managers
     try register(OcaManager.self)
@@ -140,6 +141,19 @@ public class OcaClassRegistry {
     try register(OcaPanBalance.self)
     try register(OcaPolarity.self)
     try register(OcaSwitch.self)
+    try register(OcaDelay.self)
+    try register(OcaDelayExtended.self)
+    try register(OcaTemperatureActuator.self)
+    try register(OcaSamplingRateConverter.self)
+    try register(OcaSignalGenerator.self)
+    try register(OcaFilterClassical.self)
+    try register(OcaFilterParametric.self)
+    try register(OcaFilterPolynomial.self)
+    try register(OcaFilterFIR.self)
+    try register(OcaFilterArbitraryCurve.self)
+    try register(OcaDynamics.self)
+    try register(OcaDynamicsDetector.self)
+    try register(OcaDynamicsCurve.self)
 
     // sensors
     try register(OcaSensor.self)
@@ -159,6 +173,14 @@ public class OcaClassRegistry {
     try register(OcaLevelSensor.self)
     try register(OcaIdentificationSensor.self)
     try register(OcaTemperatureSensor.self)
+    try register(OcaTimeIntervalSensor.self)
+    try register(OcaFrequencySensor.self)
+    try register(OcaVoltageSensor.self)
+    try register(OcaCurrentSensor.self)
+    try register(OcaImpedanceSensor.self)
+    try register(OcaGainSensor.self)
+    try register(OcaPowerSensor.self)
+    try register(OcaStateSensor.self)
 
     // application networks
     try register(OcaControlNetwork.self)

--- a/Sources/SwiftOCA/OCC/ControlClasses/Agents/PowerSupply.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Agents/PowerSupply.swift
@@ -1,0 +1,68 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+open class OcaPowerSupply: OcaAgent, @unchecked Sendable {
+  override open class var classID: OcaClassID { OcaClassID("1.2.7") }
+
+  @OcaProperty(
+    propertyID: OcaPropertyID("3.1"),
+    getMethodID: OcaMethodID("3.1")
+  )
+  public var type: OcaProperty<OcaPowerSupplyType>.PropertyValue
+
+  /// implementation-dependent model information
+  @OcaProperty(
+    propertyID: OcaPropertyID("3.2"),
+    getMethodID: OcaMethodID("3.2")
+  )
+  public var modelInfo: OcaProperty<OcaString>.PropertyValue
+
+  @OcaProperty(
+    propertyID: OcaPropertyID("3.3"),
+    getMethodID: OcaMethodID("3.3"),
+    setMethodID: OcaMethodID("3.4")
+  )
+  public var state: OcaProperty<OcaPowerSupplyState>.PropertyValue
+
+  /// whether a rechargeable supply is currently charging
+  @OcaProperty(
+    propertyID: OcaPropertyID("3.4"),
+    getMethodID: OcaMethodID("3.5")
+  )
+  public var charging: OcaProperty<OcaBoolean>.PropertyValue
+
+  /// fraction of the supply's load capacity that is currently unused, normally in the
+  /// range zero to one; a negative value indicates the data is unavailable
+  @OcaProperty(
+    propertyID: OcaPropertyID("3.5"),
+    getMethodID: OcaMethodID("3.6")
+  )
+  public var loadFractionAvailable: OcaProperty<OcaFloat32>.PropertyValue
+
+  /// fraction of the supply's energy storage that remains available, normally in the
+  /// range zero to one; a negative value indicates the data is unavailable
+  @OcaProperty(
+    propertyID: OcaPropertyID("3.6"),
+    getMethodID: OcaMethodID("3.7")
+  )
+  public var storageFractionAvailable: OcaProperty<OcaFloat32>.PropertyValue
+
+  @OcaProperty(
+    propertyID: OcaPropertyID("3.7"),
+    getMethodID: OcaMethodID("3.8")
+  )
+  public var location: OcaProperty<OcaPowerSupplyLocation>.PropertyValue
+}

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/Delay.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/Delay.swift
@@ -1,0 +1,50 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+open class OcaDelay: OcaActuator, @unchecked Sendable {
+  override open class var classID: OcaClassID { OcaClassID("1.1.1.7") }
+  override open class var classVersion: OcaClassVersionNumber { 3 }
+
+  /// delay in seconds
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1"),
+    setMethodID: OcaMethodID("4.2")
+  )
+  public var delayTime: OcaBoundedProperty<OcaTimeInterval>.PropertyValue
+}
+
+open class OcaDelayExtended: OcaDelay, @unchecked Sendable {
+  override open class var classID: OcaClassID { OcaClassID("1.1.1.7.1") }
+
+  /// delay expressed in an arbitrary unit of measure; the inherited ``delayTime``
+  /// property reflects the same delay in seconds
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("5.1"),
+    getMethodID: OcaMethodID("5.1"),
+    setMethodID: OcaMethodID("5.2")
+  )
+  public var delayValue: OcaBoundedProperty<OcaDelayValue>.PropertyValue
+
+  public func getDelayValue(convertedTo unitOfMeasure: OcaDelayUnit) async throws
+    -> OcaDelayValue
+  {
+    try await sendCommandRrq(
+      methodID: OcaMethodID("5.3"),
+      parameters: unitOfMeasure
+    )
+  }
+}

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/Dynamics.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/Dynamics.swift
@@ -1,0 +1,444 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+open class OcaDynamics: OcaActuator, @unchecked Sendable {
+  override open class var classID: OcaClassID { OcaClassID("1.1.1.14") }
+  override open class var classVersion: OcaClassVersionNumber { 3 }
+
+  /// whether the signal level is currently outside the threshold
+  @OcaProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1")
+  )
+  public var triggered: OcaProperty<OcaBoolean>.PropertyValue
+
+  /// the instantaneous gain of the dynamics element
+  @OcaProperty(
+    propertyID: OcaPropertyID("4.2"),
+    getMethodID: OcaMethodID("4.2")
+  )
+  public var dynamicGain: OcaProperty<OcaDB>.PropertyValue
+
+  @OcaProperty(
+    propertyID: OcaPropertyID("4.3"),
+    getMethodID: OcaMethodID("4.3"),
+    setMethodID: OcaMethodID("4.4")
+  )
+  public var function: OcaProperty<OcaDynamicsFunction>.PropertyValue
+
+  @available(*, deprecated, message: "deprecated by AES70, use slope instead")
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.4"),
+    getMethodID: OcaMethodID("4.5"),
+    setMethodID: OcaMethodID("4.6")
+  )
+  public var ratio: OcaBoundedProperty<OcaFloat32>.PropertyValue
+
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.5"),
+    getMethodID: OcaMethodID("4.7"),
+    setMethodID: OcaMethodID("4.8")
+  )
+  public var threshold: OcaBoundedProperty<OcaDBr>.PropertyValue
+
+  @OcaProperty(
+    propertyID: OcaPropertyID("4.6"),
+    getMethodID: OcaMethodID("4.9"),
+    setMethodID: OcaMethodID("4.10")
+  )
+  public var thresholdPresentationUnits: OcaProperty<OcaPresentationUnit>.PropertyValue
+
+  @OcaProperty(
+    propertyID: OcaPropertyID("4.7"),
+    getMethodID: OcaMethodID("4.11"),
+    setMethodID: OcaMethodID("4.12")
+  )
+  public var detectorLaw: OcaProperty<OcaLevelDetectionLaw>.PropertyValue
+
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.8"),
+    getMethodID: OcaMethodID("4.13"),
+    setMethodID: OcaMethodID("4.14")
+  )
+  public var attackTime: OcaBoundedProperty<OcaTimeInterval>.PropertyValue
+
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.9"),
+    getMethodID: OcaMethodID("4.15"),
+    setMethodID: OcaMethodID("4.16")
+  )
+  public var releaseTime: OcaBoundedProperty<OcaTimeInterval>.PropertyValue
+
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.10"),
+    getMethodID: OcaMethodID("4.17"),
+    setMethodID: OcaMethodID("4.18")
+  )
+  public var holdTime: OcaBoundedProperty<OcaTimeInterval>.PropertyValue
+
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.11"),
+    getMethodID: OcaMethodID("4.21"),
+    setMethodID: OcaMethodID("4.22")
+  )
+  public var dynamicGainCeiling: OcaBoundedProperty<OcaDB>.PropertyValue
+
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.12"),
+    getMethodID: OcaMethodID("4.19"),
+    setMethodID: OcaMethodID("4.20")
+  )
+  public var dynamicGainFloor: OcaBoundedProperty<OcaDB>.PropertyValue
+
+  /// soft knee parameter, interpreted in a device-dependent manner
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.13"),
+    getMethodID: OcaMethodID("4.23"),
+    setMethodID: OcaMethodID("4.24")
+  )
+  public var kneeParameter: OcaBoundedProperty<OcaFloat32>.PropertyValue
+
+  /// d(output amplitude) / d(input amplitude), independently of ``function``
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.14"),
+    getMethodID: OcaMethodID("4.25"),
+    setMethodID: OcaMethodID("4.26")
+  )
+  public var slope: OcaBoundedProperty<OcaFloat32>.PropertyValue
+
+  @_spi(SwiftOCAPrivate)
+  public struct SetMultipleParameters: Ocp1ParametersReflectable {
+    public let mask: OcaParameterMask
+    public let function: OcaDynamicsFunction
+    public let threshold: OcaDBr
+    public let thresholdPresentationUnits: OcaPresentationUnit
+    public let detectorLaw: OcaLevelDetectionLaw
+    public let attackTime: OcaTimeInterval
+    public let releaseTime: OcaTimeInterval
+    public let holdTime: OcaTimeInterval
+    public let dynamicGainCeiling: OcaDB
+    public let dynamicGainFloor: OcaDB
+    public let kneeParameter: OcaFloat32
+    public let slope: OcaFloat32
+
+    public init(
+      mask: OcaParameterMask,
+      function: OcaDynamicsFunction,
+      threshold: OcaDBr,
+      thresholdPresentationUnits: OcaPresentationUnit,
+      detectorLaw: OcaLevelDetectionLaw,
+      attackTime: OcaTimeInterval,
+      releaseTime: OcaTimeInterval,
+      holdTime: OcaTimeInterval,
+      dynamicGainCeiling: OcaDB,
+      dynamicGainFloor: OcaDB,
+      kneeParameter: OcaFloat32,
+      slope: OcaFloat32
+    ) {
+      self.mask = mask
+      self.function = function
+      self.threshold = threshold
+      self.thresholdPresentationUnits = thresholdPresentationUnits
+      self.detectorLaw = detectorLaw
+      self.attackTime = attackTime
+      self.releaseTime = releaseTime
+      self.holdTime = holdTime
+      self.dynamicGainCeiling = dynamicGainCeiling
+      self.dynamicGainFloor = dynamicGainFloor
+      self.kneeParameter = kneeParameter
+      self.slope = slope
+    }
+  }
+
+  /// atomically sets the dynamics parameters selected by `mask`
+  public func setMultiple(
+    mask: OcaParameterMask,
+    function: OcaDynamicsFunction,
+    threshold: OcaDBr,
+    thresholdPresentationUnits: OcaPresentationUnit,
+    detectorLaw: OcaLevelDetectionLaw,
+    attackTime: OcaTimeInterval,
+    releaseTime: OcaTimeInterval,
+    holdTime: OcaTimeInterval,
+    dynamicGainCeiling: OcaDB,
+    dynamicGainFloor: OcaDB,
+    kneeParameter: OcaFloat32,
+    slope: OcaFloat32
+  ) async throws {
+    try await sendCommandRrq(
+      methodID: OcaMethodID("4.27"),
+      parameters: SetMultipleParameters(
+        mask: mask,
+        function: function,
+        threshold: threshold,
+        thresholdPresentationUnits: thresholdPresentationUnits,
+        detectorLaw: detectorLaw,
+        attackTime: attackTime,
+        releaseTime: releaseTime,
+        holdTime: holdTime,
+        dynamicGainCeiling: dynamicGainCeiling,
+        dynamicGainFloor: dynamicGainFloor,
+        kneeParameter: kneeParameter,
+        slope: slope
+      )
+    )
+  }
+}
+
+open class OcaDynamicsDetector: OcaActuator, @unchecked Sendable {
+  override open class var classID: OcaClassID { OcaClassID("1.1.1.15") }
+  override open class var classVersion: OcaClassVersionNumber { 3 }
+
+  @OcaProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1"),
+    setMethodID: OcaMethodID("4.2")
+  )
+  public var law: OcaProperty<OcaLevelDetectionLaw>.PropertyValue
+
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.2"),
+    getMethodID: OcaMethodID("4.3"),
+    setMethodID: OcaMethodID("4.4")
+  )
+  public var attackTime: OcaBoundedProperty<OcaTimeInterval>.PropertyValue
+
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.3"),
+    getMethodID: OcaMethodID("4.5"),
+    setMethodID: OcaMethodID("4.6")
+  )
+  public var releaseTime: OcaBoundedProperty<OcaTimeInterval>.PropertyValue
+
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.4"),
+    getMethodID: OcaMethodID("4.7"),
+    setMethodID: OcaMethodID("4.8")
+  )
+  public var holdTime: OcaBoundedProperty<OcaTimeInterval>.PropertyValue
+
+  @_spi(SwiftOCAPrivate)
+  public struct SetMultipleParameters: Ocp1ParametersReflectable {
+    public let mask: OcaParameterMask
+    public let law: OcaLevelDetectionLaw
+    public let attackTime: OcaTimeInterval
+    public let releaseTime: OcaTimeInterval
+    public let holdTime: OcaTimeInterval
+
+    public init(
+      mask: OcaParameterMask,
+      law: OcaLevelDetectionLaw,
+      attackTime: OcaTimeInterval,
+      releaseTime: OcaTimeInterval,
+      holdTime: OcaTimeInterval
+    ) {
+      self.mask = mask
+      self.law = law
+      self.attackTime = attackTime
+      self.releaseTime = releaseTime
+      self.holdTime = holdTime
+    }
+  }
+
+  /// atomically sets the detector parameters selected by `mask`
+  public func setMultiple(
+    mask: OcaParameterMask,
+    law: OcaLevelDetectionLaw,
+    attackTime: OcaTimeInterval,
+    releaseTime: OcaTimeInterval,
+    holdTime: OcaTimeInterval
+  ) async throws {
+    try await sendCommandRrq(
+      methodID: OcaMethodID("4.9"),
+      parameters: SetMultipleParameters(
+        mask: mask,
+        law: law,
+        attackTime: attackTime,
+        releaseTime: releaseTime,
+        holdTime: holdTime
+      )
+    )
+  }
+}
+
+open class OcaDynamicsCurve: OcaActuator, @unchecked Sendable {
+  override open class var classID: OcaClassID { OcaClassID("1.1.1.16") }
+  override open class var classVersion: OcaClassVersionNumber { 3 }
+
+  /// the curve is composed of (n + 1) straight line segments joined by (n) knees
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1"),
+    setMethodID: OcaMethodID("4.2")
+  )
+  public var nSegments: OcaBoundedProperty<OcaUint8>.PropertyValue
+
+  /// segment thresholds; the limits are scalar rather than per-element, so the value is
+  /// retrieved with ``getThresholds()`` rather than by property accessor
+  @OcaProperty(
+    propertyID: OcaPropertyID("4.2"),
+    setMethodID: OcaMethodID("4.4")
+  )
+  public var thresholds: OcaProperty<OcaList<OcaDBr>>.PropertyValue
+
+  /// segment slopes; retrieved with ``getSlopes()``, which returns per-element limits
+  @OcaProperty(
+    propertyID: OcaPropertyID("4.3"),
+    setMethodID: OcaMethodID("4.6")
+  )
+  public var slopes: OcaProperty<OcaList<OcaFloat32>>.PropertyValue
+
+  /// knee parameters; retrieved with ``getKneeParameters()``, which returns per-element
+  /// limits
+  @OcaProperty(
+    propertyID: OcaPropertyID("4.4"),
+    setMethodID: OcaMethodID("4.8")
+  )
+  public var kneeParameters: OcaProperty<OcaList<OcaFloat32>>.PropertyValue
+
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.5"),
+    getMethodID: OcaMethodID("4.11"),
+    setMethodID: OcaMethodID("4.12")
+  )
+  public var dynamicGainFloor: OcaBoundedProperty<OcaDB>.PropertyValue
+
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.6"),
+    getMethodID: OcaMethodID("4.9"),
+    setMethodID: OcaMethodID("4.10")
+  )
+  public var dynamicGainCeiling: OcaBoundedProperty<OcaDB>.PropertyValue
+
+  @_spi(SwiftOCAPrivate)
+  public struct GetThresholdsParameters: Ocp1ParametersReflectable {
+    public let thresholds: OcaList<OcaDBr>
+    public let minThreshold: OcaDBz
+    public let maxThreshold: OcaDBz
+
+    public init(
+      thresholds: OcaList<OcaDBr>,
+      minThreshold: OcaDBz,
+      maxThreshold: OcaDBz
+    ) {
+      self.thresholds = thresholds
+      self.minThreshold = minThreshold
+      self.maxThreshold = maxThreshold
+    }
+  }
+
+  @_spi(SwiftOCAPrivate)
+  public struct GetFloat32ListParameters: Ocp1ParametersReflectable {
+    public let values: OcaList<OcaFloat32>
+    public let minValues: OcaList<OcaFloat32>
+    public let maxValues: OcaList<OcaFloat32>
+
+    public init(
+      values: OcaList<OcaFloat32>,
+      minValues: OcaList<OcaFloat32>,
+      maxValues: OcaList<OcaFloat32>
+    ) {
+      self.values = values
+      self.minValues = minValues
+      self.maxValues = maxValues
+    }
+  }
+
+  public func getThresholds() async throws
+    -> (thresholds: OcaList<OcaDBr>, minThreshold: OcaDBz, maxThreshold: OcaDBz)
+  {
+    let parameters: GetThresholdsParameters =
+      try await sendCommandRrq(methodID: OcaMethodID("4.14"))
+    return (parameters.thresholds, parameters.minThreshold, parameters.maxThreshold)
+  }
+
+  public func getSlopes() async throws
+    -> (
+      slopes: OcaList<OcaFloat32>,
+      minSlopes: OcaList<OcaFloat32>,
+      maxSlopes: OcaList<OcaFloat32>
+    )
+  {
+    let parameters: GetFloat32ListParameters =
+      try await sendCommandRrq(methodID: OcaMethodID("4.5"))
+    return (parameters.values, parameters.minValues, parameters.maxValues)
+  }
+
+  public func getKneeParameters() async throws
+    -> (
+      kneeParameters: OcaList<OcaFloat32>,
+      minKneeParameters: OcaList<OcaFloat32>,
+      maxKneeParameters: OcaList<OcaFloat32>
+    )
+  {
+    let parameters: GetFloat32ListParameters =
+      try await sendCommandRrq(methodID: OcaMethodID("4.7"))
+    return (parameters.values, parameters.minValues, parameters.maxValues)
+  }
+
+  @_spi(SwiftOCAPrivate)
+  public struct SetMultipleParameters: Ocp1ParametersReflectable {
+    public let mask: OcaParameterMask
+    public let nSegments: OcaUint8
+    public let thresholds: OcaList<OcaDBr>
+    public let slopes: OcaList<OcaFloat32>
+    public let kneeParameters: OcaList<OcaFloat32>
+    public let dynamicGainFloor: OcaDB
+    public let dynamicGainCeiling: OcaDB
+
+    public init(
+      mask: OcaParameterMask,
+      nSegments: OcaUint8,
+      thresholds: OcaList<OcaDBr>,
+      slopes: OcaList<OcaFloat32>,
+      kneeParameters: OcaList<OcaFloat32>,
+      dynamicGainFloor: OcaDB,
+      dynamicGainCeiling: OcaDB
+    ) {
+      self.mask = mask
+      self.nSegments = nSegments
+      self.thresholds = thresholds
+      self.slopes = slopes
+      self.kneeParameters = kneeParameters
+      self.dynamicGainFloor = dynamicGainFloor
+      self.dynamicGainCeiling = dynamicGainCeiling
+    }
+  }
+
+  /// atomically sets the curve parameters selected by `mask`
+  public func setMultiple(
+    mask: OcaParameterMask,
+    nSegments: OcaUint8,
+    thresholds: OcaList<OcaDBr>,
+    slopes: OcaList<OcaFloat32>,
+    kneeParameters: OcaList<OcaFloat32>,
+    dynamicGainFloor: OcaDB,
+    dynamicGainCeiling: OcaDB
+  ) async throws {
+    try await sendCommandRrq(
+      methodID: OcaMethodID("4.13"),
+      parameters: SetMultipleParameters(
+        mask: mask,
+        nSegments: nSegments,
+        thresholds: thresholds,
+        slopes: slopes,
+        kneeParameters: kneeParameters,
+        dynamicGainFloor: dynamicGainFloor,
+        dynamicGainCeiling: dynamicGainCeiling
+      )
+    )
+  }
+}

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/Filters.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/Filters.swift
@@ -1,0 +1,313 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+open class OcaFilterClassical: OcaActuator, @unchecked Sendable {
+  override open class var classID: OcaClassID { OcaClassID("1.1.1.9") }
+  override open class var classVersion: OcaClassVersionNumber { 3 }
+
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1"),
+    setMethodID: OcaMethodID("4.2")
+  )
+  public var frequency: OcaBoundedProperty<OcaFrequency>.PropertyValue
+
+  @OcaProperty(
+    propertyID: OcaPropertyID("4.2"),
+    getMethodID: OcaMethodID("4.3"),
+    setMethodID: OcaMethodID("4.4")
+  )
+  public var passband: OcaProperty<OcaFilterPassband>.PropertyValue
+
+  @OcaProperty(
+    propertyID: OcaPropertyID("4.3"),
+    getMethodID: OcaMethodID("4.5"),
+    setMethodID: OcaMethodID("4.6")
+  )
+  public var shape: OcaProperty<OcaClassicalFilterShape>.PropertyValue
+
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.4"),
+    getMethodID: OcaMethodID("4.7"),
+    setMethodID: OcaMethodID("4.8")
+  )
+  public var order: OcaBoundedProperty<OcaUint16>.PropertyValue
+
+  /// ripple or other shape-dependent parameter; unused by some shapes
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.5"),
+    getMethodID: OcaMethodID("4.9"),
+    setMethodID: OcaMethodID("4.10")
+  )
+  public var parameter: OcaBoundedProperty<OcaFloat32>.PropertyValue
+
+  @_spi(SwiftOCAPrivate)
+  public struct SetMultipleParameters: Ocp1ParametersReflectable {
+    public let mask: OcaParameterMask
+    public let frequency: OcaFrequency
+    public let passband: OcaFilterPassband
+    public let shape: OcaClassicalFilterShape
+    public let order: OcaUint16
+    public let parameter: OcaFloat32
+
+    public init(
+      mask: OcaParameterMask,
+      frequency: OcaFrequency,
+      passband: OcaFilterPassband,
+      shape: OcaClassicalFilterShape,
+      order: OcaUint16,
+      parameter: OcaFloat32
+    ) {
+      self.mask = mask
+      self.frequency = frequency
+      self.passband = passband
+      self.shape = shape
+      self.order = order
+      self.parameter = parameter
+    }
+  }
+
+  /// atomically sets the filter parameters selected by `mask`
+  public func setMultiple(
+    mask: OcaParameterMask,
+    frequency: OcaFrequency,
+    passband: OcaFilterPassband,
+    shape: OcaClassicalFilterShape,
+    order: OcaUint16,
+    parameter: OcaFloat32
+  ) async throws {
+    try await sendCommandRrq(
+      methodID: OcaMethodID("4.11"),
+      parameters: SetMultipleParameters(
+        mask: mask,
+        frequency: frequency,
+        passband: passband,
+        shape: shape,
+        order: order,
+        parameter: parameter
+      )
+    )
+  }
+}
+
+open class OcaFilterParametric: OcaActuator, @unchecked Sendable {
+  override open class var classID: OcaClassID { OcaClassID("1.1.1.10") }
+  override open class var classVersion: OcaClassVersionNumber { 3 }
+
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1"),
+    setMethodID: OcaMethodID("4.2")
+  )
+  public var frequency: OcaBoundedProperty<OcaFrequency>.PropertyValue
+
+  @OcaProperty(
+    propertyID: OcaPropertyID("4.2"),
+    getMethodID: OcaMethodID("4.3"),
+    setMethodID: OcaMethodID("4.4")
+  )
+  public var shape: OcaProperty<OcaParametricEQShape>.PropertyValue
+
+  /// the Q of the filter, for conventional parametric implementations
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.3"),
+    getMethodID: OcaMethodID("4.5"),
+    setMethodID: OcaMethodID("4.6")
+  )
+  public var widthParameter: OcaBoundedProperty<OcaFloat32>.PropertyValue
+
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.4"),
+    getMethodID: OcaMethodID("4.7"),
+    setMethodID: OcaMethodID("4.8")
+  )
+  public var inBandGain: OcaBoundedProperty<OcaDB>.PropertyValue
+
+  /// extra shape information, for filter types that require it
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.5"),
+    getMethodID: OcaMethodID("4.9"),
+    setMethodID: OcaMethodID("4.10")
+  )
+  public var shapeParameter: OcaBoundedProperty<OcaFloat32>.PropertyValue
+
+  @_spi(SwiftOCAPrivate)
+  public struct SetMultipleParameters: Ocp1ParametersReflectable {
+    public let mask: OcaParameterMask
+    public let frequency: OcaFrequency
+    public let shape: OcaParametricEQShape
+    public let widthParameter: OcaFloat32
+    public let inBandGain: OcaDB
+    public let shapeParameter: OcaFloat32
+
+    public init(
+      mask: OcaParameterMask,
+      frequency: OcaFrequency,
+      shape: OcaParametricEQShape,
+      widthParameter: OcaFloat32,
+      inBandGain: OcaDB,
+      shapeParameter: OcaFloat32
+    ) {
+      self.mask = mask
+      self.frequency = frequency
+      self.shape = shape
+      self.widthParameter = widthParameter
+      self.inBandGain = inBandGain
+      self.shapeParameter = shapeParameter
+    }
+  }
+
+  /// atomically sets the filter parameters selected by `mask`
+  public func setMultiple(
+    mask: OcaParameterMask,
+    frequency: OcaFrequency,
+    shape: OcaParametricEQShape,
+    widthParameter: OcaFloat32,
+    inBandGain: OcaDB,
+    shapeParameter: OcaFloat32
+  ) async throws {
+    try await sendCommandRrq(
+      methodID: OcaMethodID("4.11"),
+      parameters: SetMultipleParameters(
+        mask: mask,
+        frequency: frequency,
+        shape: shape,
+        widthParameter: widthParameter,
+        inBandGain: inBandGain,
+        shapeParameter: shapeParameter
+      )
+    )
+  }
+}
+
+open class OcaFilterPolynomial: OcaActuator, @unchecked Sendable {
+  override open class var classID: OcaClassID { OcaClassID("1.1.1.11") }
+  override open class var classVersion: OcaClassVersionNumber { 3 }
+
+  /// numerator coefficients; retrieved together with ``b`` by ``getCoefficients()``
+  @OcaProperty(
+    propertyID: OcaPropertyID("4.1")
+  )
+  public var a: OcaProperty<OcaList<OcaFloat32>>.PropertyValue
+
+  /// denominator coefficients; retrieved together with ``a`` by ``getCoefficients()``
+  @OcaProperty(
+    propertyID: OcaPropertyID("4.2")
+  )
+  public var b: OcaProperty<OcaList<OcaFloat32>>.PropertyValue
+
+  /// the sampling rate inside the filter, which need not be the device sampling rate
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.3"),
+    getMethodID: OcaMethodID("4.3"),
+    setMethodID: OcaMethodID("4.4")
+  )
+  public var sampleRate: OcaBoundedProperty<OcaFrequency>.PropertyValue
+
+  /// the maximum number of elements of ``a`` and ``b``
+  @OcaProperty(
+    propertyID: OcaPropertyID("4.4"),
+    getMethodID: OcaMethodID("4.5")
+  )
+  public var maxOrder: OcaProperty<OcaUint8>.PropertyValue
+
+  @_spi(SwiftOCAPrivate)
+  public struct CoefficientsParameters: Ocp1ParametersReflectable {
+    public let a: OcaList<OcaFloat32>
+    public let b: OcaList<OcaFloat32>
+
+    public init(a: OcaList<OcaFloat32>, b: OcaList<OcaFloat32>) {
+      self.a = a
+      self.b = b
+    }
+  }
+
+  public func getCoefficients() async throws
+    -> (a: OcaList<OcaFloat32>, b: OcaList<OcaFloat32>)
+  {
+    let parameters: CoefficientsParameters =
+      try await sendCommandRrq(methodID: OcaMethodID("4.1"))
+    return (parameters.a, parameters.b)
+  }
+
+  public func setCoefficients(a: OcaList<OcaFloat32>, b: OcaList<OcaFloat32>) async throws {
+    try await sendCommandRrq(
+      methodID: OcaMethodID("4.2"),
+      parameters: CoefficientsParameters(a: a, b: b)
+    )
+  }
+}
+
+open class OcaFilterFIR: OcaActuator, @unchecked Sendable {
+  override open class var classID: OcaClassID { OcaClassID("1.1.1.12") }
+  override open class var classVersion: OcaClassVersionNumber { 3 }
+
+  /// length of the filter in samples
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1")
+  )
+  public var length: OcaBoundedProperty<OcaUint32>.PropertyValue
+
+  @OcaProperty(
+    propertyID: OcaPropertyID("4.2"),
+    getMethodID: OcaMethodID("4.2"),
+    setMethodID: OcaMethodID("4.3")
+  )
+  public var coefficients: OcaProperty<OcaList<OcaFloat32>>.PropertyValue
+
+  /// the sampling rate inside the filter, which need not be the device sampling rate
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.3"),
+    getMethodID: OcaMethodID("4.4"),
+    setMethodID: OcaMethodID("4.5")
+  )
+  public var sampleRate: OcaBoundedProperty<OcaFrequency>.PropertyValue
+}
+
+open class OcaFilterArbitraryCurve: OcaActuator, @unchecked Sendable {
+  override open class var classID: OcaClassID { OcaClassID("1.1.1.13") }
+  override open class var classVersion: OcaClassVersionNumber { 3 }
+
+  @OcaProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1"),
+    setMethodID: OcaMethodID("4.2")
+  )
+  public var transferFunction: OcaProperty<OcaTransferFunction>.PropertyValue
+
+  /// the sampling rate inside the filter, which need not be the device sampling rate
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.2"),
+    getMethodID: OcaMethodID("4.3"),
+    setMethodID: OcaMethodID("4.4")
+  )
+  public var sampleRate: OcaBoundedProperty<OcaFrequency>.PropertyValue
+
+  /// minimum number of points the transfer function must specify
+  @OcaProperty(
+    propertyID: OcaPropertyID("4.3"),
+    getMethodID: OcaMethodID("4.5")
+  )
+  public var tfMinLength: OcaProperty<OcaUint16>.PropertyValue
+
+  /// maximum number of points the transfer function may specify
+  @OcaProperty(
+    propertyID: OcaPropertyID("4.4"),
+    getMethodID: OcaMethodID("4.6")
+  )
+  public var tfMaxLength: OcaProperty<OcaUint16>.PropertyValue
+}

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/SamplingRateConverter.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/SamplingRateConverter.swift
@@ -1,0 +1,26 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+open class OcaSamplingRateConverter: OcaActuator, @unchecked Sendable {
+  override open class var classID: OcaClassID { OcaClassID("1.1.1.23") }
+  override open class var classVersion: OcaClassVersionNumber { 1 }
+
+  @OcaProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1")
+  )
+  public var type: OcaProperty<OcaSamplingRateConverterType>.PropertyValue
+}

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/SignalGenerator.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/SignalGenerator.swift
@@ -1,0 +1,146 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+open class OcaSignalGenerator: OcaActuator, @unchecked Sendable {
+  override open class var classID: OcaClassID { OcaClassID("1.1.1.17") }
+  override open class var classVersion: OcaClassVersionNumber { 3 }
+
+  /// centre frequency, or sweep start frequency
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1"),
+    setMethodID: OcaMethodID("4.2")
+  )
+  public var frequency1: OcaBoundedProperty<OcaFrequency>.PropertyValue
+
+  /// sweep end frequency
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.2"),
+    getMethodID: OcaMethodID("4.3"),
+    setMethodID: OcaMethodID("4.4")
+  )
+  public var frequency2: OcaBoundedProperty<OcaFrequency>.PropertyValue
+
+  /// output level relative to the device-defined zero level
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.3"),
+    getMethodID: OcaMethodID("4.5"),
+    setMethodID: OcaMethodID("4.6")
+  )
+  public var level: OcaBoundedProperty<OcaDBz>.PropertyValue
+
+  @OcaProperty(
+    propertyID: OcaPropertyID("4.4"),
+    getMethodID: OcaMethodID("4.7"),
+    setMethodID: OcaMethodID("4.8")
+  )
+  public var waveform: OcaProperty<OcaWaveformType>.PropertyValue
+
+  @OcaProperty(
+    propertyID: OcaPropertyID("4.5"),
+    getMethodID: OcaMethodID("4.9"),
+    setMethodID: OcaMethodID("4.10")
+  )
+  public var sweepType: OcaProperty<OcaSweepType>.PropertyValue
+
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.6"),
+    getMethodID: OcaMethodID("4.11"),
+    setMethodID: OcaMethodID("4.12")
+  )
+  public var sweepTime: OcaBoundedProperty<OcaTimeInterval>.PropertyValue
+
+  /// whether the sweep repeats, or is one-shot
+  @OcaProperty(
+    propertyID: OcaPropertyID("4.7"),
+    getMethodID: OcaMethodID("4.13"),
+    setMethodID: OcaMethodID("4.14")
+  )
+  public var sweepRepeat: OcaProperty<OcaBoolean>.PropertyValue
+
+  /// whether the generator is currently producing output
+  @OcaProperty(
+    propertyID: OcaPropertyID("4.8"),
+    getMethodID: OcaMethodID("4.15")
+  )
+  public var generating: OcaProperty<OcaBoolean>.PropertyValue
+
+  public func start() async throws {
+    try await sendCommandRrq(methodID: OcaMethodID("4.16"))
+  }
+
+  public func stop() async throws {
+    try await sendCommandRrq(methodID: OcaMethodID("4.17"))
+  }
+
+  @_spi(SwiftOCAPrivate)
+  public struct SetMultipleParameters: Ocp1ParametersReflectable {
+    public let mask: OcaParameterMask
+    public let frequency1: OcaFrequency
+    public let frequency2: OcaFrequency
+    public let level: OcaDBz
+    public let waveform: OcaWaveformType
+    public let sweepType: OcaSweepType
+    public let sweepTime: OcaTimeInterval
+    public let sweepRepeat: OcaBoolean
+
+    public init(
+      mask: OcaParameterMask,
+      frequency1: OcaFrequency,
+      frequency2: OcaFrequency,
+      level: OcaDBz,
+      waveform: OcaWaveformType,
+      sweepType: OcaSweepType,
+      sweepTime: OcaTimeInterval,
+      sweepRepeat: OcaBoolean
+    ) {
+      self.mask = mask
+      self.frequency1 = frequency1
+      self.frequency2 = frequency2
+      self.level = level
+      self.waveform = waveform
+      self.sweepType = sweepType
+      self.sweepTime = sweepTime
+      self.sweepRepeat = sweepRepeat
+    }
+  }
+
+  /// atomically sets the generation parameters selected by `mask`
+  public func setMultiple(
+    mask: OcaParameterMask,
+    frequency1: OcaFrequency,
+    frequency2: OcaFrequency,
+    level: OcaDBz,
+    waveform: OcaWaveformType,
+    sweepType: OcaSweepType,
+    sweepTime: OcaTimeInterval,
+    sweepRepeat: OcaBoolean
+  ) async throws {
+    try await sendCommandRrq(
+      methodID: OcaMethodID("4.18"),
+      parameters: SetMultipleParameters(
+        mask: mask,
+        frequency1: frequency1,
+        frequency2: frequency2,
+        level: level,
+        waveform: waveform,
+        sweepType: sweepType,
+        sweepTime: sweepTime,
+        sweepRepeat: sweepRepeat
+      )
+    )
+  }
+}

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/TemperatureActuator.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/TemperatureActuator.swift
@@ -1,0 +1,27 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+open class OcaTemperatureActuator: OcaActuator, @unchecked Sendable {
+  override open class var classID: OcaClassID { OcaClassID("1.1.1.20") }
+  override open class var classVersion: OcaClassVersionNumber { 3 }
+
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1"),
+    setMethodID: OcaMethodID("4.2")
+  )
+  public var temperature: OcaBoundedProperty<OcaTemperature>.PropertyValue
+}

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Sensors/CurrentSensor.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Sensors/CurrentSensor.swift
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+open class OcaCurrentSensor: OcaSensor, @unchecked Sendable {
+  override open class var classID: OcaClassID { OcaClassID("1.1.2.8") }
+
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1")
+  )
+  public var reading: OcaBoundedProperty<OcaCurrent>.PropertyValue
+}

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Sensors/FrequencySensor.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Sensors/FrequencySensor.swift
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+open class OcaFrequencySensor: OcaSensor, @unchecked Sendable {
+  override open class var classID: OcaClassID { OcaClassID("1.1.2.4") }
+
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1")
+  )
+  public var reading: OcaBoundedProperty<OcaFrequency>.PropertyValue
+}

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Sensors/GainSensor.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Sensors/GainSensor.swift
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+open class OcaGainSensor: OcaSensor, @unchecked Sendable {
+  override open class var classID: OcaClassID { OcaClassID("1.1.2.10") }
+
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1")
+  )
+  public var reading: OcaBoundedProperty<OcaDB>.PropertyValue
+}

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Sensors/ImpedanceSensor.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Sensors/ImpedanceSensor.swift
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+open class OcaImpedanceSensor: OcaSensor, @unchecked Sendable {
+  override open class var classID: OcaClassID { OcaClassID("1.1.2.9") }
+
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1")
+  )
+  public var reading: OcaBoundedProperty<OcaImpedance>.PropertyValue
+}

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Sensors/PowerSensor.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Sensors/PowerSensor.swift
@@ -1,0 +1,66 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+open class OcaPowerSensor: OcaSensor, @unchecked Sendable {
+  override open class var classID: OcaClassID { OcaClassID("1.1.2.11") }
+  override open class var classVersion: OcaClassVersionNumber { 1 }
+
+  /// power in watts; retrieved together with ``powerFactor`` by ``getReading()``
+  @OcaProperty(
+    propertyID: OcaPropertyID("4.1")
+  )
+  public var power: OcaProperty<OcaFloat32>.PropertyValue
+
+  /// ranges from one (a purely resistive circuit) to zero
+  @OcaProperty(
+    propertyID: OcaPropertyID("4.2")
+  )
+  public var powerFactor: OcaProperty<OcaFloat32>.PropertyValue
+
+  @_spi(SwiftOCAPrivate)
+  public struct GetReadingParameters: Ocp1ParametersReflectable {
+    public let power: OcaFloat32
+    public let powerFactor: OcaFloat32
+    public let minPower: OcaFloat32
+    public let maxPower: OcaFloat32
+
+    public init(
+      power: OcaFloat32,
+      powerFactor: OcaFloat32,
+      minPower: OcaFloat32,
+      maxPower: OcaFloat32
+    ) {
+      self.power = power
+      self.powerFactor = powerFactor
+      self.minPower = minPower
+      self.maxPower = maxPower
+    }
+  }
+
+  public func getReading() async throws
+    -> (power: OcaBoundedPropertyValue<OcaFloat32>, powerFactor: OcaFloat32)
+  {
+    let parameters: GetReadingParameters =
+      try await sendCommandRrq(methodID: OcaMethodID("4.1"))
+    return (
+      OcaBoundedPropertyValue(
+        value: parameters.power,
+        in: parameters.minPower...parameters.maxPower
+      ),
+      parameters.powerFactor
+    )
+  }
+}

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Sensors/StateSensor.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Sensors/StateSensor.swift
@@ -1,0 +1,38 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+open class OcaStateSensor: OcaSensor, @unchecked Sendable {
+  override open class var classID: OcaClassID { OcaClassID("1.1.2.12") }
+  override open class var classVersion: OcaClassVersionNumber { 1 }
+
+  /// the current state, named `State` by AES70 and renamed here to avoid colliding with
+  /// the inherited reading state; states are numbered from the minimum to the maximum
+  /// value of this property inclusive
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1")
+  )
+  public var reading: OcaBoundedProperty<OcaUint16>.PropertyValue
+
+  /// the first element corresponds to the minimum value of ``reading``; the setter is
+  /// optional and may not be implemented by all devices
+  @OcaProperty(
+    propertyID: OcaPropertyID("4.2"),
+    getMethodID: OcaMethodID("4.2"),
+    setMethodID: OcaMethodID("4.3")
+  )
+  public var stateNames: OcaProperty<OcaList<OcaString>>.PropertyValue
+}

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Sensors/TimeIntervalSensor.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Sensors/TimeIntervalSensor.swift
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+open class OcaTimeIntervalSensor: OcaSensor, @unchecked Sendable {
+  override open class var classID: OcaClassID { OcaClassID("1.1.2.3") }
+
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1")
+  )
+  public var reading: OcaBoundedProperty<OcaTimeInterval>.PropertyValue
+}

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Sensors/VoltageSensor.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Sensors/VoltageSensor.swift
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+open class OcaVoltageSensor: OcaSensor, @unchecked Sendable {
+  override open class var classID: OcaClassID { OcaClassID("1.1.2.7") }
+
+  @OcaBoundedProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1")
+  )
+  public var reading: OcaBoundedProperty<OcaVoltage>.PropertyValue
+}

--- a/Sources/SwiftOCA/OCC/ControlDataTypes/PowerManagerDataTypes.swift
+++ b/Sources/SwiftOCA/OCC/ControlDataTypes/PowerManagerDataTypes.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024 PADL Software Pty Ltd
+// Copyright (c) 2024-2026 PADL Software Pty Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.
@@ -19,4 +19,28 @@ public enum OcaPowerState: OcaUint8, Codable, Sendable, CaseIterable {
   case working = 1
   case standby = 2
   case off = 3
+}
+
+public enum OcaPowerSupplyType: OcaUint8, Codable, Sendable, CaseIterable {
+  case none = 0
+  case mains = 1
+  case battery = 2
+  /// includes Power-over-Ethernet supplies
+  case phantom = 3
+  case solar = 4
+}
+
+public enum OcaPowerSupplyState: OcaUint8, Codable, Sendable, CaseIterable {
+  case off = 0
+  /// turned on, but not available for activation
+  case unavailable = 1
+  case available = 2
+  /// currently supplying power to the device
+  case active = 3
+}
+
+public enum OcaPowerSupplyLocation: OcaUint8, Codable, Sendable, CaseIterable {
+  case unspecified = 1
+  case `internal` = 2
+  case external = 3
 }

--- a/Sources/SwiftOCA/OCC/ControlDataTypes/WorkerDataTypes.swift
+++ b/Sources/SwiftOCA/OCC/ControlDataTypes/WorkerDataTypes.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 PADL Software Pty Ltd
+// Copyright (c) 2023-2026 PADL Software Pty Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.
@@ -23,9 +23,18 @@ public typealias OcaDBz = OcaDB
 public typealias OcaVoltage = OcaFloat32
 public typealias OcaCurrent = OcaFloat32
 
-public struct OcaImpedance: Codable, Sendable {
-  let magnitude: OcaFloat32
-  let phase: OcaFloat32
+public struct OcaImpedance: Codable, Comparable, Equatable, Sendable {
+  public let magnitude: OcaFloat32
+  public let phase: OcaFloat32
+
+  public init(magnitude: OcaFloat32, phase: OcaFloat32) {
+    self.magnitude = magnitude
+    self.phase = phase
+  }
+
+  public static func < (lhs: Self, rhs: Self) -> Bool {
+    (lhs.magnitude, lhs.phase) < (rhs.magnitude, rhs.phase)
+  }
 }
 
 public enum OcaDelayUnit: OcaUint8, Codable, Sendable, CaseIterable {
@@ -39,22 +48,47 @@ public enum OcaDelayUnit: OcaUint8, Codable, Sendable, CaseIterable {
   case feet = 8
 }
 
-public struct OcaDelayValue: Codable, Sendable {
-  let delayValue: OcaFloat32
-  let delayUnit: OcaDelayUnit
+public struct OcaDelayValue: Codable, Comparable, Equatable, Sendable {
+  public let delayValue: OcaFloat32
+  public let delayUnit: OcaDelayUnit
+
+  public init(delayValue: OcaFloat32, delayUnit: OcaDelayUnit) {
+    self.delayValue = delayValue
+    self.delayUnit = delayUnit
+  }
+
+  /// Note that ordering is only meaningful for values sharing the same unit of measure;
+  /// the AES70 bounds returned by `OcaDelayExtended.GetDelayValue()` always do.
+  public static func < (lhs: Self, rhs: Self) -> Bool {
+    (lhs.delayUnit.rawValue, lhs.delayValue) < (rhs.delayUnit.rawValue, rhs.delayValue)
+  }
 }
 
 public typealias OcaFrequency = OcaFloat32
 
 public typealias OcaFrequencyResponse = OcaMap<OcaFrequency, OcaDB>
 
-public struct OcaTransferFunction: Codable, Sendable {
-  var frequency: OcaList<OcaFrequency>
-  var amplitude: OcaList<OcaFloat32>
-  var phase: OcaList<OcaFloat32>
+public struct OcaTransferFunction: Codable, Equatable, Sendable {
+  public var frequency: OcaList<OcaFrequency>
+  public var amplitude: OcaList<OcaFloat32>
+  public var phase: OcaList<OcaFloat32>
+
+  public init(
+    frequency: OcaList<OcaFrequency> = [],
+    amplitude: OcaList<OcaFloat32> = [],
+    phase: OcaList<OcaFloat32> = []
+  ) {
+    self.frequency = frequency
+    self.amplitude = amplitude
+    self.phase = phase
+  }
 }
 
 public typealias OcaPeriod = OcaUint32 // ms
+
+/// Bitmask selecting which parameters a `SetMultiple()` method applies. Bit numbering is
+/// defined by AES70 on a per-class basis; refer to the class definition.
+public typealias OcaParameterMask = OcaBitSet16
 
 public enum OcaClassicalFilterShape: OcaUint8, Codable, Sendable, CaseIterable {
   case butterworth = 1

--- a/Sources/SwiftOCADevice/OCA/ClassRegistry.swift
+++ b/Sources/SwiftOCADevice/OCA/ClassRegistry.swift
@@ -95,6 +95,7 @@ public class OcaDeviceClassRegistry {
     try register(OcaCounterNotifier.self)
     try register(OcaCounterSetAgent.self)
     try register(OcaTimeSource.self)
+    try register(OcaPowerSupply.self)
 
     // managers
     try register(OcaManager.self)
@@ -139,6 +140,19 @@ public class OcaDeviceClassRegistry {
     try register(OcaSignalInput.self)
     try register(OcaSignalOutput.self)
     try register(OcaSummingPoint.self)
+    try register(OcaDelay.self)
+    try register(OcaDelayExtended.self)
+    try register(OcaTemperatureActuator.self)
+    try register(OcaSamplingRateConverter.self)
+    try register(OcaSignalGenerator.self)
+    try register(OcaFilterClassical.self)
+    try register(OcaFilterParametric.self)
+    try register(OcaFilterPolynomial.self)
+    try register(OcaFilterFIR.self)
+    try register(OcaFilterArbitraryCurve.self)
+    try register(OcaDynamics.self)
+    try register(OcaDynamicsDetector.self)
+    try register(OcaDynamicsCurve.self)
 
     // sensors
     try register(OcaSensor.self)
@@ -159,6 +173,14 @@ public class OcaDeviceClassRegistry {
     try register(OcaAudioLevelSensor.self)
     try register(OcaIdentificationSensor.self)
     try register(OcaTemperatureSensor.self)
+    try register(OcaTimeIntervalSensor.self)
+    try register(OcaFrequencySensor.self)
+    try register(OcaVoltageSensor.self)
+    try register(OcaCurrentSensor.self)
+    try register(OcaImpedanceSensor.self)
+    try register(OcaGainSensor.self)
+    try register(OcaPowerSensor.self)
+    try register(OcaStateSensor.self)
 
     // application networks
     try register(OcaApplicationNetwork.self)

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Agents/PowerSupply.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Agents/PowerSupply.swift
@@ -1,0 +1,70 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import SwiftOCA
+
+open class OcaPowerSupply: OcaAgent {
+  override open class var classID: OcaClassID { OcaClassID("1.2.7") }
+
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("3.1"),
+    getMethodID: OcaMethodID("3.1")
+  )
+  public var type: OcaPowerSupplyType = .none
+
+  /// implementation-dependent model information
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("3.2"),
+    getMethodID: OcaMethodID("3.2")
+  )
+  public var modelInfo: OcaString = ""
+
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("3.3"),
+    getMethodID: OcaMethodID("3.3"),
+    setMethodID: OcaMethodID("3.4")
+  )
+  public var state: OcaPowerSupplyState = .off
+
+  /// whether a rechargeable supply is currently charging
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("3.4"),
+    getMethodID: OcaMethodID("3.5")
+  )
+  public var charging: OcaBoolean = false
+
+  /// fraction of the supply's load capacity that is currently unused, normally in the
+  /// range zero to one; a negative value indicates the data is unavailable
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("3.5"),
+    getMethodID: OcaMethodID("3.6")
+  )
+  public var loadFractionAvailable: OcaFloat32 = -1
+
+  /// fraction of the supply's energy storage that remains available, normally in the
+  /// range zero to one; a negative value indicates the data is unavailable
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("3.6"),
+    getMethodID: OcaMethodID("3.7")
+  )
+  public var storageFractionAvailable: OcaFloat32 = -1
+
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("3.7"),
+    getMethodID: OcaMethodID("3.8")
+  )
+  public var location: OcaPowerSupplyLocation = .unspecified
+}

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Root.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Root.swift
@@ -29,7 +29,7 @@ extension OcaController {
 @OcaDevice
 open class OcaRoot: CustomStringConvertible, Codable, Sendable, _OcaObjectKeyPathRepresentable {
   open nonisolated class var classID: OcaClassID { OcaClassID("1") }
-  open nonisolated class var classVersion: OcaClassVersionNumber { 2 }
+  open nonisolated class var classVersion: OcaClassVersionNumber { 3 }
 
   public nonisolated let objectNumber: OcaONo
   public nonisolated let lockable: OcaBoolean

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/Delay.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/Delay.swift
@@ -1,0 +1,70 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import SwiftOCA
+
+open class OcaDelay: OcaActuator {
+  override open class var classID: OcaClassID { OcaClassID("1.1.1.7") }
+  override open class var classVersion: OcaClassVersionNumber { 3 }
+
+  /// delay in seconds
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1"),
+    setMethodID: OcaMethodID("4.2")
+  )
+  public var delayTime = OcaBoundedPropertyValue<OcaTimeInterval>(value: 0, in: 0...1)
+}
+
+open class OcaDelayExtended: OcaDelay {
+  override open class var classID: OcaClassID { OcaClassID("1.1.1.7.1") }
+
+  /// delay expressed in an arbitrary unit of measure; the inherited ``delayTime``
+  /// property reflects the same delay in seconds
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("5.1"),
+    getMethodID: OcaMethodID("5.1"),
+    setMethodID: OcaMethodID("5.2")
+  )
+  public var delayValue = OcaBoundedPropertyValue<OcaDelayValue>(
+    value: OcaDelayValue(delayValue: 0, delayUnit: .time),
+    in: OcaDelayValue(delayValue: 0, delayUnit: .time)...OcaDelayValue(
+      delayValue: 1,
+      delayUnit: .time
+    )
+  )
+
+  /// unit conversion is device specific; the default implementation is unimplemented
+  open func getDelayValue(convertedTo unitOfMeasure: OcaDelayUnit) async throws
+    -> OcaDelayValue
+  {
+    throw Ocp1Error.status(.notImplemented)
+  }
+
+  override open func handleCommand(
+    _ command: Ocp1Command,
+    from controller: OcaController
+  ) async throws -> Ocp1Response {
+    switch command.methodID {
+    case OcaMethodID("5.3"):
+      let unitOfMeasure: OcaDelayUnit = try decodeCommand(command)
+      try await ensureReadable(by: controller, command: command)
+      return try await encodeResponse(getDelayValue(convertedTo: unitOfMeasure))
+    default:
+      return try await super.handleCommand(command, from: controller)
+    }
+  }
+}

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/Dynamics.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/Dynamics.swift
@@ -1,0 +1,380 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+@_spi(SwiftOCAPrivate)
+import SwiftOCA
+
+open class OcaDynamics: OcaActuator {
+  override open class var classID: OcaClassID { OcaClassID("1.1.1.14") }
+  override open class var classVersion: OcaClassVersionNumber { 3 }
+
+  /// whether the signal level is currently outside the threshold
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1")
+  )
+  public var triggered: OcaBoolean = false
+
+  /// the instantaneous gain of the dynamics element
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("4.2"),
+    getMethodID: OcaMethodID("4.2")
+  )
+  public var dynamicGain: OcaDB = 0.0
+
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("4.3"),
+    getMethodID: OcaMethodID("4.3"),
+    setMethodID: OcaMethodID("4.4")
+  )
+  public var function: OcaDynamicsFunction = .none
+
+  @available(*, deprecated, message: "deprecated by AES70, use slope instead")
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.4"),
+    getMethodID: OcaMethodID("4.5"),
+    setMethodID: OcaMethodID("4.6")
+  )
+  public var ratio = OcaBoundedPropertyValue<OcaFloat32>(value: 1, in: 1...100)
+
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.5"),
+    getMethodID: OcaMethodID("4.7"),
+    setMethodID: OcaMethodID("4.8")
+  )
+  public var threshold = OcaBoundedPropertyValue<OcaDBr>(value: 0.0, in: -144.0...20.0)
+
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("4.6"),
+    getMethodID: OcaMethodID("4.9"),
+    setMethodID: OcaMethodID("4.10")
+  )
+  public var thresholdPresentationUnits: OcaPresentationUnit = .dBu
+
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("4.7"),
+    getMethodID: OcaMethodID("4.11"),
+    setMethodID: OcaMethodID("4.12")
+  )
+  public var detectorLaw: OcaLevelDetectionLaw = .none
+
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.8"),
+    getMethodID: OcaMethodID("4.13"),
+    setMethodID: OcaMethodID("4.14")
+  )
+  public var attackTime = OcaBoundedPropertyValue<OcaTimeInterval>(value: 0, in: 0...1)
+
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.9"),
+    getMethodID: OcaMethodID("4.15"),
+    setMethodID: OcaMethodID("4.16")
+  )
+  public var releaseTime = OcaBoundedPropertyValue<OcaTimeInterval>(value: 0, in: 0...1)
+
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.10"),
+    getMethodID: OcaMethodID("4.17"),
+    setMethodID: OcaMethodID("4.18")
+  )
+  public var holdTime = OcaBoundedPropertyValue<OcaTimeInterval>(value: 0, in: 0...1)
+
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.11"),
+    getMethodID: OcaMethodID("4.21"),
+    setMethodID: OcaMethodID("4.22")
+  )
+  public var dynamicGainCeiling = OcaBoundedPropertyValue<OcaDB>(
+    value: 0.0,
+    in: -144.0...20.0
+  )
+
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.12"),
+    getMethodID: OcaMethodID("4.19"),
+    setMethodID: OcaMethodID("4.20")
+  )
+  public var dynamicGainFloor = OcaBoundedPropertyValue<OcaDB>(
+    value: -144.0,
+    in: -144.0...20.0
+  )
+
+  /// soft knee parameter, interpreted in a device-dependent manner
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.13"),
+    getMethodID: OcaMethodID("4.23"),
+    setMethodID: OcaMethodID("4.24")
+  )
+  public var kneeParameter = OcaBoundedPropertyValue<OcaFloat32>(value: 0, in: 0...1)
+
+  /// d(output amplitude) / d(input amplitude), independently of ``function``
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.14"),
+    getMethodID: OcaMethodID("4.25"),
+    setMethodID: OcaMethodID("4.26")
+  )
+  public var slope = OcaBoundedPropertyValue<OcaFloat32>(value: 1, in: 0...100)
+
+  /// atomic multiple-parameter assignment is device specific; the default implementation
+  /// is unimplemented
+  open func setMultiple(
+    mask: OcaParameterMask,
+    function: OcaDynamicsFunction,
+    threshold: OcaDBr,
+    thresholdPresentationUnits: OcaPresentationUnit,
+    detectorLaw: OcaLevelDetectionLaw,
+    attackTime: OcaTimeInterval,
+    releaseTime: OcaTimeInterval,
+    holdTime: OcaTimeInterval,
+    dynamicGainCeiling: OcaDB,
+    dynamicGainFloor: OcaDB,
+    kneeParameter: OcaFloat32,
+    slope: OcaFloat32
+  ) async throws {
+    throw Ocp1Error.status(.notImplemented)
+  }
+
+  override open func handleCommand(
+    _ command: Ocp1Command,
+    from controller: OcaController
+  ) async throws -> Ocp1Response {
+    switch command.methodID {
+    case OcaMethodID("4.27"):
+      let parameters: SwiftOCA.OcaDynamics.SetMultipleParameters = try decodeCommand(command)
+      try await ensureWritable(by: controller, command: command)
+      try await setMultiple(
+        mask: parameters.mask,
+        function: parameters.function,
+        threshold: parameters.threshold,
+        thresholdPresentationUnits: parameters.thresholdPresentationUnits,
+        detectorLaw: parameters.detectorLaw,
+        attackTime: parameters.attackTime,
+        releaseTime: parameters.releaseTime,
+        holdTime: parameters.holdTime,
+        dynamicGainCeiling: parameters.dynamicGainCeiling,
+        dynamicGainFloor: parameters.dynamicGainFloor,
+        kneeParameter: parameters.kneeParameter,
+        slope: parameters.slope
+      )
+      return Ocp1Response()
+    default:
+      return try await super.handleCommand(command, from: controller)
+    }
+  }
+}
+
+open class OcaDynamicsDetector: OcaActuator {
+  override open class var classID: OcaClassID { OcaClassID("1.1.1.15") }
+  override open class var classVersion: OcaClassVersionNumber { 3 }
+
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1"),
+    setMethodID: OcaMethodID("4.2")
+  )
+  public var law: OcaLevelDetectionLaw = .none
+
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.2"),
+    getMethodID: OcaMethodID("4.3"),
+    setMethodID: OcaMethodID("4.4")
+  )
+  public var attackTime = OcaBoundedPropertyValue<OcaTimeInterval>(value: 0, in: 0...1)
+
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.3"),
+    getMethodID: OcaMethodID("4.5"),
+    setMethodID: OcaMethodID("4.6")
+  )
+  public var releaseTime = OcaBoundedPropertyValue<OcaTimeInterval>(value: 0, in: 0...1)
+
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.4"),
+    getMethodID: OcaMethodID("4.7"),
+    setMethodID: OcaMethodID("4.8")
+  )
+  public var holdTime = OcaBoundedPropertyValue<OcaTimeInterval>(value: 0, in: 0...1)
+
+  /// atomic multiple-parameter assignment is device specific; the default implementation
+  /// is unimplemented
+  open func setMultiple(
+    mask: OcaParameterMask,
+    law: OcaLevelDetectionLaw,
+    attackTime: OcaTimeInterval,
+    releaseTime: OcaTimeInterval,
+    holdTime: OcaTimeInterval
+  ) async throws {
+    throw Ocp1Error.status(.notImplemented)
+  }
+
+  override open func handleCommand(
+    _ command: Ocp1Command,
+    from controller: OcaController
+  ) async throws -> Ocp1Response {
+    switch command.methodID {
+    case OcaMethodID("4.9"):
+      let parameters: SwiftOCA.OcaDynamicsDetector.SetMultipleParameters =
+        try decodeCommand(command)
+      try await ensureWritable(by: controller, command: command)
+      try await setMultiple(
+        mask: parameters.mask,
+        law: parameters.law,
+        attackTime: parameters.attackTime,
+        releaseTime: parameters.releaseTime,
+        holdTime: parameters.holdTime
+      )
+      return Ocp1Response()
+    default:
+      return try await super.handleCommand(command, from: controller)
+    }
+  }
+}
+
+open class OcaDynamicsCurve: OcaActuator {
+  override open class var classID: OcaClassID { OcaClassID("1.1.1.16") }
+  override open class var classVersion: OcaClassVersionNumber { 3 }
+
+  /// the curve is composed of (n + 1) straight line segments joined by (n) knees
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1"),
+    setMethodID: OcaMethodID("4.2")
+  )
+  public var nSegments = OcaBoundedPropertyValue<OcaUint8>(value: 1, in: 1...8)
+
+  /// segment thresholds; there is no property getter because the limits AES70 returns
+  /// from GetThresholds() are scalar rather than per-element
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("4.2"),
+    setMethodID: OcaMethodID("4.4")
+  )
+  public var thresholds: OcaList<OcaDBr> = []
+
+  /// segment slopes; there is no property getter because GetSlopes() returns per-element
+  /// limits alongside the value
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("4.3"),
+    setMethodID: OcaMethodID("4.6")
+  )
+  public var slopes: OcaList<OcaFloat32> = []
+
+  /// knee parameters; there is no property getter because GetKneeParameters() returns
+  /// per-element limits alongside the value
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("4.4"),
+    setMethodID: OcaMethodID("4.8")
+  )
+  public var kneeParameters: OcaList<OcaFloat32> = []
+
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.5"),
+    getMethodID: OcaMethodID("4.11"),
+    setMethodID: OcaMethodID("4.12")
+  )
+  public var dynamicGainFloor = OcaBoundedPropertyValue<OcaDB>(
+    value: -144.0,
+    in: -144.0...20.0
+  )
+
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.6"),
+    getMethodID: OcaMethodID("4.9"),
+    setMethodID: OcaMethodID("4.10")
+  )
+  public var dynamicGainCeiling = OcaBoundedPropertyValue<OcaDB>(
+    value: 0.0,
+    in: -144.0...20.0
+  )
+
+  /// the limits reported by GetThresholds(); not itself an AES70 property
+  open var thresholdRange: ClosedRange<OcaDBz> = -144.0...20.0
+
+  /// the limits reported by GetSlopes(), applied uniformly to every segment; not itself
+  /// an AES70 property
+  open var slopeRange: ClosedRange<OcaFloat32> = 0...100
+
+  /// the limits reported by GetKneeParameters(), applied uniformly to every segment; not
+  /// itself an AES70 property
+  open var kneeParameterRange: ClosedRange<OcaFloat32> = 0...1
+
+  /// atomic multiple-parameter assignment is device specific; the default implementation
+  /// is unimplemented
+  open func setMultiple(
+    mask: OcaParameterMask,
+    nSegments: OcaUint8,
+    thresholds: OcaList<OcaDBr>,
+    slopes: OcaList<OcaFloat32>,
+    kneeParameters: OcaList<OcaFloat32>,
+    dynamicGainFloor: OcaDB,
+    dynamicGainCeiling: OcaDB
+  ) async throws {
+    throw Ocp1Error.status(.notImplemented)
+  }
+
+  private func _float32ListParameters(
+    _ values: OcaList<OcaFloat32>,
+    in range: ClosedRange<OcaFloat32>
+  ) -> SwiftOCA.OcaDynamicsCurve.GetFloat32ListParameters {
+    SwiftOCA.OcaDynamicsCurve.GetFloat32ListParameters(
+      values: values,
+      minValues: OcaList(repeating: range.lowerBound, count: values.count),
+      maxValues: OcaList(repeating: range.upperBound, count: values.count)
+    )
+  }
+
+  override open func handleCommand(
+    _ command: Ocp1Command,
+    from controller: OcaController
+  ) async throws -> Ocp1Response {
+    switch command.methodID {
+    case OcaMethodID("4.5"):
+      try decodeNullCommand(command)
+      try await ensureReadable(by: controller, command: command)
+      return try encodeResponse(_float32ListParameters(slopes, in: slopeRange))
+    case OcaMethodID("4.7"):
+      try decodeNullCommand(command)
+      try await ensureReadable(by: controller, command: command)
+      return try encodeResponse(
+        _float32ListParameters(kneeParameters, in: kneeParameterRange)
+      )
+    case OcaMethodID("4.13"):
+      let parameters: SwiftOCA.OcaDynamicsCurve.SetMultipleParameters =
+        try decodeCommand(command)
+      try await ensureWritable(by: controller, command: command)
+      try await setMultiple(
+        mask: parameters.mask,
+        nSegments: parameters.nSegments,
+        thresholds: parameters.thresholds,
+        slopes: parameters.slopes,
+        kneeParameters: parameters.kneeParameters,
+        dynamicGainFloor: parameters.dynamicGainFloor,
+        dynamicGainCeiling: parameters.dynamicGainCeiling
+      )
+      return Ocp1Response()
+    case OcaMethodID("4.14"):
+      try decodeNullCommand(command)
+      try await ensureReadable(by: controller, command: command)
+      let parameters = SwiftOCA.OcaDynamicsCurve.GetThresholdsParameters(
+        thresholds: thresholds,
+        minThreshold: thresholdRange.lowerBound,
+        maxThreshold: thresholdRange.upperBound
+      )
+      return try encodeResponse(parameters)
+    default:
+      return try await super.handleCommand(command, from: controller)
+    }
+  }
+}

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/Filters.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/Filters.swift
@@ -1,0 +1,306 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+@_spi(SwiftOCAPrivate)
+import SwiftOCA
+
+open class OcaFilterClassical: OcaActuator {
+  override open class var classID: OcaClassID { OcaClassID("1.1.1.9") }
+  override open class var classVersion: OcaClassVersionNumber { 3 }
+
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1"),
+    setMethodID: OcaMethodID("4.2")
+  )
+  public var frequency = OcaBoundedPropertyValue<OcaFrequency>(value: 1000, in: 10...20000)
+
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("4.2"),
+    getMethodID: OcaMethodID("4.3"),
+    setMethodID: OcaMethodID("4.4")
+  )
+  public var passband: OcaFilterPassband = .lowPass
+
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("4.3"),
+    getMethodID: OcaMethodID("4.5"),
+    setMethodID: OcaMethodID("4.6")
+  )
+  public var shape: OcaClassicalFilterShape = .butterworth
+
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.4"),
+    getMethodID: OcaMethodID("4.7"),
+    setMethodID: OcaMethodID("4.8")
+  )
+  public var order = OcaBoundedPropertyValue<OcaUint16>(value: 1, in: 1...8)
+
+  /// ripple or other shape-dependent parameter; unused by some shapes
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.5"),
+    getMethodID: OcaMethodID("4.9"),
+    setMethodID: OcaMethodID("4.10")
+  )
+  public var parameter = OcaBoundedPropertyValue<OcaFloat32>(value: 0, in: 0...1)
+
+  /// atomic multiple-parameter assignment is device specific; the default implementation
+  /// is unimplemented
+  open func setMultiple(
+    mask: OcaParameterMask,
+    frequency: OcaFrequency,
+    passband: OcaFilterPassband,
+    shape: OcaClassicalFilterShape,
+    order: OcaUint16,
+    parameter: OcaFloat32
+  ) async throws {
+    throw Ocp1Error.status(.notImplemented)
+  }
+
+  override open func handleCommand(
+    _ command: Ocp1Command,
+    from controller: OcaController
+  ) async throws -> Ocp1Response {
+    switch command.methodID {
+    case OcaMethodID("4.11"):
+      let parameters: SwiftOCA.OcaFilterClassical.SetMultipleParameters =
+        try decodeCommand(command)
+      try await ensureWritable(by: controller, command: command)
+      try await setMultiple(
+        mask: parameters.mask,
+        frequency: parameters.frequency,
+        passband: parameters.passband,
+        shape: parameters.shape,
+        order: parameters.order,
+        parameter: parameters.parameter
+      )
+      return Ocp1Response()
+    default:
+      return try await super.handleCommand(command, from: controller)
+    }
+  }
+}
+
+open class OcaFilterParametric: OcaActuator {
+  override open class var classID: OcaClassID { OcaClassID("1.1.1.10") }
+  override open class var classVersion: OcaClassVersionNumber { 3 }
+
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1"),
+    setMethodID: OcaMethodID("4.2")
+  )
+  public var frequency = OcaBoundedPropertyValue<OcaFrequency>(value: 1000, in: 10...20000)
+
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("4.2"),
+    getMethodID: OcaMethodID("4.3"),
+    setMethodID: OcaMethodID("4.4")
+  )
+  public var shape: OcaParametricEQShape = .none
+
+  /// the Q of the filter, for conventional parametric implementations
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.3"),
+    getMethodID: OcaMethodID("4.5"),
+    setMethodID: OcaMethodID("4.6")
+  )
+  public var widthParameter = OcaBoundedPropertyValue<OcaFloat32>(value: 1, in: 0.1...100)
+
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.4"),
+    getMethodID: OcaMethodID("4.7"),
+    setMethodID: OcaMethodID("4.8")
+  )
+  public var inBandGain = OcaBoundedPropertyValue<OcaDB>(value: 0.0, in: -144.0...20.0)
+
+  /// extra shape information, for filter types that require it
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.5"),
+    getMethodID: OcaMethodID("4.9"),
+    setMethodID: OcaMethodID("4.10")
+  )
+  public var shapeParameter = OcaBoundedPropertyValue<OcaFloat32>(value: 0, in: 0...1)
+
+  /// atomic multiple-parameter assignment is device specific; the default implementation
+  /// is unimplemented
+  open func setMultiple(
+    mask: OcaParameterMask,
+    frequency: OcaFrequency,
+    shape: OcaParametricEQShape,
+    widthParameter: OcaFloat32,
+    inBandGain: OcaDB,
+    shapeParameter: OcaFloat32
+  ) async throws {
+    throw Ocp1Error.status(.notImplemented)
+  }
+
+  override open func handleCommand(
+    _ command: Ocp1Command,
+    from controller: OcaController
+  ) async throws -> Ocp1Response {
+    switch command.methodID {
+    case OcaMethodID("4.11"):
+      let parameters: SwiftOCA.OcaFilterParametric.SetMultipleParameters =
+        try decodeCommand(command)
+      try await ensureWritable(by: controller, command: command)
+      try await setMultiple(
+        mask: parameters.mask,
+        frequency: parameters.frequency,
+        shape: parameters.shape,
+        widthParameter: parameters.widthParameter,
+        inBandGain: parameters.inBandGain,
+        shapeParameter: parameters.shapeParameter
+      )
+      return Ocp1Response()
+    default:
+      return try await super.handleCommand(command, from: controller)
+    }
+  }
+}
+
+open class OcaFilterPolynomial: OcaActuator {
+  override open class var classID: OcaClassID { OcaClassID("1.1.1.11") }
+  override open class var classVersion: OcaClassVersionNumber { 3 }
+
+  /// numerator coefficients; there is no property accessor because AES70 returns this
+  /// together with ``b`` from GetCoefficients()
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("4.1")
+  )
+  public var a: OcaList<OcaFloat32> = []
+
+  /// denominator coefficients; there is no property accessor because AES70 returns this
+  /// together with ``a`` from GetCoefficients()
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("4.2")
+  )
+  public var b: OcaList<OcaFloat32> = []
+
+  /// the sampling rate inside the filter, which need not be the device sampling rate
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.3"),
+    getMethodID: OcaMethodID("4.3"),
+    setMethodID: OcaMethodID("4.4")
+  )
+  public var sampleRate = OcaBoundedPropertyValue<OcaFrequency>(
+    value: 48000,
+    in: 8000...192_000
+  )
+
+  /// the maximum number of elements of ``a`` and ``b``
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("4.4"),
+    getMethodID: OcaMethodID("4.5")
+  )
+  public var maxOrder: OcaUint8 = 0
+
+  open func set(a: OcaList<OcaFloat32>, b: OcaList<OcaFloat32>) async throws {
+    guard a.count <= Int(maxOrder), b.count <= Int(maxOrder) else {
+      throw Ocp1Error.status(.parameterOutOfRange)
+    }
+    self.a = a
+    self.b = b
+  }
+
+  override open func handleCommand(
+    _ command: Ocp1Command,
+    from controller: OcaController
+  ) async throws -> Ocp1Response {
+    switch command.methodID {
+    case OcaMethodID("4.1"):
+      try decodeNullCommand(command)
+      try await ensureReadable(by: controller, command: command)
+      let parameters = SwiftOCA.OcaFilterPolynomial.CoefficientsParameters(a: a, b: b)
+      return try encodeResponse(parameters)
+    case OcaMethodID("4.2"):
+      let parameters: SwiftOCA.OcaFilterPolynomial.CoefficientsParameters =
+        try decodeCommand(command)
+      try await ensureWritable(by: controller, command: command)
+      try await set(a: parameters.a, b: parameters.b)
+      return Ocp1Response()
+    default:
+      return try await super.handleCommand(command, from: controller)
+    }
+  }
+}
+
+open class OcaFilterFIR: OcaActuator {
+  override open class var classID: OcaClassID { OcaClassID("1.1.1.12") }
+  override open class var classVersion: OcaClassVersionNumber { 3 }
+
+  /// length of the filter in samples
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1")
+  )
+  public var length = OcaBoundedPropertyValue<OcaUint32>(value: 0, in: 0...0)
+
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("4.2"),
+    getMethodID: OcaMethodID("4.2"),
+    setMethodID: OcaMethodID("4.3")
+  )
+  public var coefficients: OcaList<OcaFloat32> = []
+
+  /// the sampling rate inside the filter, which need not be the device sampling rate
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.3"),
+    getMethodID: OcaMethodID("4.4"),
+    setMethodID: OcaMethodID("4.5")
+  )
+  public var sampleRate = OcaBoundedPropertyValue<OcaFrequency>(
+    value: 48000,
+    in: 8000...192_000
+  )
+}
+
+open class OcaFilterArbitraryCurve: OcaActuator {
+  override open class var classID: OcaClassID { OcaClassID("1.1.1.13") }
+  override open class var classVersion: OcaClassVersionNumber { 3 }
+
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1"),
+    setMethodID: OcaMethodID("4.2")
+  )
+  public var transferFunction = OcaTransferFunction()
+
+  /// the sampling rate inside the filter, which need not be the device sampling rate
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.2"),
+    getMethodID: OcaMethodID("4.3"),
+    setMethodID: OcaMethodID("4.4")
+  )
+  public var sampleRate = OcaBoundedPropertyValue<OcaFrequency>(
+    value: 48000,
+    in: 8000...192_000
+  )
+
+  /// minimum number of points the transfer function must specify
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("4.3"),
+    getMethodID: OcaMethodID("4.5")
+  )
+  public var tfMinLength: OcaUint16 = 0
+
+  /// maximum number of points the transfer function may specify
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("4.4"),
+    getMethodID: OcaMethodID("4.6")
+  )
+  public var tfMaxLength: OcaUint16 = 0
+}

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/SamplingRateConverter.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/SamplingRateConverter.swift
@@ -1,0 +1,28 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import SwiftOCA
+
+open class OcaSamplingRateConverter: OcaActuator {
+  override open class var classID: OcaClassID { OcaClassID("1.1.1.23") }
+  override open class var classVersion: OcaClassVersionNumber { 1 }
+
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1")
+  )
+  public var type: OcaSamplingRateConverterType = .none
+}

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/SignalGenerator.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/SignalGenerator.swift
@@ -1,0 +1,143 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+@_spi(SwiftOCAPrivate)
+import SwiftOCA
+
+open class OcaSignalGenerator: OcaActuator {
+  override open class var classID: OcaClassID { OcaClassID("1.1.1.17") }
+  override open class var classVersion: OcaClassVersionNumber { 3 }
+
+  /// centre frequency, or sweep start frequency
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1"),
+    setMethodID: OcaMethodID("4.2")
+  )
+  public var frequency1 = OcaBoundedPropertyValue<OcaFrequency>(value: 1000, in: 10...20000)
+
+  /// sweep end frequency
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.2"),
+    getMethodID: OcaMethodID("4.3"),
+    setMethodID: OcaMethodID("4.4")
+  )
+  public var frequency2 = OcaBoundedPropertyValue<OcaFrequency>(value: 20000, in: 10...20000)
+
+  /// output level relative to the device-defined zero level
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.3"),
+    getMethodID: OcaMethodID("4.5"),
+    setMethodID: OcaMethodID("4.6")
+  )
+  public var level = OcaBoundedPropertyValue<OcaDBz>(value: -144.0, in: -144.0...20.0)
+
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("4.4"),
+    getMethodID: OcaMethodID("4.7"),
+    setMethodID: OcaMethodID("4.8")
+  )
+  public var waveform: OcaWaveformType = .none
+
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("4.5"),
+    getMethodID: OcaMethodID("4.9"),
+    setMethodID: OcaMethodID("4.10")
+  )
+  public var sweepType: OcaSweepType = .none
+
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.6"),
+    getMethodID: OcaMethodID("4.11"),
+    setMethodID: OcaMethodID("4.12")
+  )
+  public var sweepTime = OcaBoundedPropertyValue<OcaTimeInterval>(value: 0, in: 0...60)
+
+  /// whether the sweep repeats, or is one-shot
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("4.7"),
+    getMethodID: OcaMethodID("4.13"),
+    setMethodID: OcaMethodID("4.14")
+  )
+  public var sweepRepeat: OcaBoolean = false
+
+  /// whether the generator is currently producing output
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("4.8"),
+    getMethodID: OcaMethodID("4.15")
+  )
+  public var generating: OcaBoolean = false
+
+  /// signal generation is device specific; the default implementation is unimplemented
+  open func start() async throws {
+    throw Ocp1Error.status(.notImplemented)
+  }
+
+  /// signal generation is device specific; the default implementation is unimplemented
+  open func stop() async throws {
+    throw Ocp1Error.status(.notImplemented)
+  }
+
+  /// atomic multiple-parameter assignment is device specific; the default implementation
+  /// is unimplemented
+  open func setMultiple(
+    mask: OcaParameterMask,
+    frequency1: OcaFrequency,
+    frequency2: OcaFrequency,
+    level: OcaDBz,
+    waveform: OcaWaveformType,
+    sweepType: OcaSweepType,
+    sweepTime: OcaTimeInterval,
+    sweepRepeat: OcaBoolean
+  ) async throws {
+    throw Ocp1Error.status(.notImplemented)
+  }
+
+  override open func handleCommand(
+    _ command: Ocp1Command,
+    from controller: OcaController
+  ) async throws -> Ocp1Response {
+    switch command.methodID {
+    case OcaMethodID("4.16"):
+      try decodeNullCommand(command)
+      try await ensureWritable(by: controller, command: command)
+      try await start()
+      return Ocp1Response()
+    case OcaMethodID("4.17"):
+      try decodeNullCommand(command)
+      try await ensureWritable(by: controller, command: command)
+      try await stop()
+      return Ocp1Response()
+    case OcaMethodID("4.18"):
+      let parameters: SwiftOCA.OcaSignalGenerator.SetMultipleParameters =
+        try decodeCommand(command)
+      try await ensureWritable(by: controller, command: command)
+      try await setMultiple(
+        mask: parameters.mask,
+        frequency1: parameters.frequency1,
+        frequency2: parameters.frequency2,
+        level: parameters.level,
+        waveform: parameters.waveform,
+        sweepType: parameters.sweepType,
+        sweepTime: parameters.sweepTime,
+        sweepRepeat: parameters.sweepRepeat
+      )
+      return Ocp1Response()
+    default:
+      return try await super.handleCommand(command, from: controller)
+    }
+  }
+}

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/TemperatureActuator.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/TemperatureActuator.swift
@@ -1,0 +1,32 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import SwiftOCA
+
+open class OcaTemperatureActuator: OcaActuator {
+  override open class var classID: OcaClassID { OcaClassID("1.1.1.20") }
+  override open class var classVersion: OcaClassVersionNumber { 3 }
+
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1"),
+    setMethodID: OcaMethodID("4.2")
+  )
+  public var temperature = OcaBoundedPropertyValue<OcaTemperature>(
+    value: 0.0,
+    in: -273.15...1000.0
+  )
+}

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Sensors/CurrentSensor.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Sensors/CurrentSensor.swift
@@ -1,0 +1,32 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import SwiftOCA
+
+open class OcaCurrentSensor: OcaSensor {
+  override open class var classID: OcaClassID { OcaClassID("1.1.2.8") }
+
+  /// current in amperes; subclasses are expected to narrow the range to that of the
+  /// physical sensor
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1")
+  )
+  public var reading = OcaBoundedPropertyValue<OcaCurrent>(
+    value: 0,
+    in: -OcaCurrent.greatestFiniteMagnitude...OcaCurrent.greatestFiniteMagnitude
+  )
+}

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Sensors/FrequencySensor.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Sensors/FrequencySensor.swift
@@ -1,0 +1,27 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import SwiftOCA
+
+open class OcaFrequencySensor: OcaSensor {
+  override open class var classID: OcaClassID { OcaClassID("1.1.2.4") }
+
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1")
+  )
+  public var reading = OcaBoundedPropertyValue<OcaFrequency>(value: 0, in: 0...20000)
+}

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Sensors/GainSensor.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Sensors/GainSensor.swift
@@ -1,0 +1,27 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import SwiftOCA
+
+open class OcaGainSensor: OcaSensor {
+  override open class var classID: OcaClassID { OcaClassID("1.1.2.10") }
+
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1")
+  )
+  public var reading = OcaBoundedPropertyValue<OcaDB>(value: 0.0, in: -144.0...20.0)
+}

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Sensors/ImpedanceSensor.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Sensors/ImpedanceSensor.swift
@@ -1,0 +1,35 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import SwiftOCA
+
+open class OcaImpedanceSensor: OcaSensor {
+  override open class var classID: OcaClassID { OcaClassID("1.1.2.9") }
+
+  /// impedance magnitude and phase; subclasses are expected to narrow the range to that
+  /// of the physical sensor
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1")
+  )
+  public var reading = OcaBoundedPropertyValue<OcaImpedance>(
+    value: OcaImpedance(magnitude: 0, phase: 0),
+    in: OcaImpedance(magnitude: 0, phase: -.pi)...OcaImpedance(
+      magnitude: .greatestFiniteMagnitude,
+      phase: .pi
+    )
+  )
+}

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Sensors/PowerSensor.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Sensors/PowerSensor.swift
@@ -1,0 +1,59 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+@_spi(SwiftOCAPrivate)
+import SwiftOCA
+
+open class OcaPowerSensor: OcaSensor {
+  override open class var classID: OcaClassID { OcaClassID("1.1.2.11") }
+  override open class var classVersion: OcaClassVersionNumber { 1 }
+
+  /// power in watts; there is no property accessor because AES70 returns this together
+  /// with ``powerFactor`` from GetReading()
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.1")
+  )
+  public var power = OcaBoundedPropertyValue<OcaFloat32>(
+    value: 0,
+    in: 0...OcaFloat32.greatestFiniteMagnitude
+  )
+
+  /// ranges from one (a purely resistive circuit) to zero
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("4.2")
+  )
+  public var powerFactor: OcaFloat32 = 1
+
+  override open func handleCommand(
+    _ command: Ocp1Command,
+    from controller: OcaController
+  ) async throws -> Ocp1Response {
+    switch command.methodID {
+    case OcaMethodID("4.1"):
+      try decodeNullCommand(command)
+      try await ensureReadable(by: controller, command: command)
+      let parameters = SwiftOCA.OcaPowerSensor.GetReadingParameters(
+        power: power.value,
+        powerFactor: powerFactor,
+        minPower: power.minValue,
+        maxPower: power.maxValue
+      )
+      return try encodeResponse(parameters)
+    default:
+      return try await super.handleCommand(command, from: controller)
+    }
+  }
+}

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Sensors/StateSensor.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Sensors/StateSensor.swift
@@ -1,0 +1,39 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import SwiftOCA
+
+open class OcaStateSensor: OcaSensor {
+  override open class var classID: OcaClassID { OcaClassID("1.1.2.12") }
+  override open class var classVersion: OcaClassVersionNumber { 1 }
+
+  /// the current state, named `State` by AES70 and renamed here to avoid colliding with
+  /// the inherited reading state; states are numbered from the minimum to the maximum
+  /// value of this property inclusive
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1")
+  )
+  public var reading = OcaBoundedPropertyValue<OcaUint16>(value: 0, in: 0...0)
+
+  /// the first element corresponds to the minimum value of ``reading``
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("4.2"),
+    getMethodID: OcaMethodID("4.2"),
+    setMethodID: OcaMethodID("4.3")
+  )
+  public var stateNames: OcaList<OcaString> = []
+}

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Sensors/TimeIntervalSensor.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Sensors/TimeIntervalSensor.swift
@@ -1,0 +1,27 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import SwiftOCA
+
+open class OcaTimeIntervalSensor: OcaSensor {
+  override open class var classID: OcaClassID { OcaClassID("1.1.2.3") }
+
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1")
+  )
+  public var reading = OcaBoundedPropertyValue<OcaTimeInterval>(value: 0, in: 0...1)
+}

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Sensors/VoltageSensor.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Sensors/VoltageSensor.swift
@@ -1,0 +1,32 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import SwiftOCA
+
+open class OcaVoltageSensor: OcaSensor {
+  override open class var classID: OcaClassID { OcaClassID("1.1.2.7") }
+
+  /// voltage in volts; subclasses are expected to narrow the range to that of the
+  /// physical sensor
+  @OcaBoundedDeviceProperty(
+    propertyID: OcaPropertyID("4.1"),
+    getMethodID: OcaMethodID("4.1")
+  )
+  public var reading = OcaBoundedPropertyValue<OcaVoltage>(
+    value: 0,
+    in: -OcaVoltage.greatestFiniteMagnitude...OcaVoltage.greatestFiniteMagnitude
+  )
+}

--- a/SwiftOCA.xcodeproj/project.pbxproj
+++ b/SwiftOCA.xcodeproj/project.pbxproj
@@ -109,8 +109,6 @@
 		D3527EC72F00DA0100000044 /* AsyncAlgorithms in Frameworks */ = {isa = PBXBuildFile; productRef = D3E6E1ED2A3ACB0700BF7095 /* AsyncAlgorithms */; };
 		D3527EC72F00DA0100000045 /* AsyncExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = D3E6E25A2A3D28DD00BF7095 /* AsyncExtensions */; };
 		D3527EC72F00DA0100000062 /* Crypto in Frameworks */ = {isa = PBXBuildFile; productRef = D3527EC72F00DA0100000061 /* Crypto */; };
-		D3527EC72F00DA01000000B2 /* BinaryParsing in Frameworks */ = {isa = PBXBuildFile; productRef = D3527EC72F00DA01000000B1 /* BinaryParsing */; };
-		D3527EC72F00DA01000000B3 /* BinaryParsing in Frameworks */ = {isa = PBXBuildFile; productRef = D3527EC72F00DA01000000B1 /* BinaryParsing */; };
 		D3527EC72F00DA0100000071 /* BackendConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3527EC72F00DA0100000070 /* BackendConnectionTests.swift */; };
 		D3527EC72F00DA0100000073 /* FileDatasetStorageProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3527EC72F00DA0100000072 /* FileDatasetStorageProviderTests.swift */; };
 		D3527EC72F00DA0100000075 /* KeepAliveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3527EC72F00DA0100000074 /* KeepAliveTests.swift */; };
@@ -126,6 +124,8 @@
 		D3527EC72F00DA0100000090 /* FlyingSocks in Frameworks */ = {isa = PBXBuildFile; productRef = D33B52D32A706FD7001A1BA7 /* FlyingSocks */; };
 		D3527EC72F00DA0100000091 /* FlyingFox in Frameworks */ = {isa = PBXBuildFile; productRef = D3B325042B4F677700C8335F /* FlyingFox */; };
 		D3527EC72F00DA01000000A1 /* Ocp1NWDatagramDeviceEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3527EC72F00DA01000000A0 /* Ocp1NWDatagramDeviceEndpoint.swift */; };
+		D3527EC72F00DA01000000B2 /* BinaryParsing in Frameworks */ = {isa = PBXBuildFile; productRef = D3527EC72F00DA01000000B1 /* BinaryParsing */; };
+		D3527EC72F00DA01000000B3 /* BinaryParsing in Frameworks */ = {isa = PBXBuildFile; productRef = D3527EC72F00DA01000000B1 /* BinaryParsing */; };
 		D355925D2B51E5FF000F633B /* DatagramProxyDeviceEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35592592B51E5DB000F633B /* DatagramProxyDeviceEndpoint.swift */; };
 		D355925E2B51E604000F633B /* DatagramProxyController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D355925B2B51E5DF000F633B /* DatagramProxyController.swift */; };
 		D35592602B520DFC000F633B /* ControllerDefaultSubscribing.swift in Sources */ = {isa = PBXBuildFile; fileRef = D355925F2B520DFC000F633B /* ControllerDefaultSubscribing.swift */; };
@@ -317,6 +317,36 @@
 		D3E741482D56331F0044CCBB /* TemperatureSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E741472D56331F0044CCBB /* TemperatureSensor.swift */; };
 		D3E7414A2D5633740044CCBB /* TemperatureSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E741492D5633740044CCBB /* TemperatureSensor.swift */; };
 		D3E820E62DFBEF0C001C9DC8 /* Ocp1NWConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E820E52DFBEF0C001C9DC8 /* Ocp1NWConnection.swift */; };
+		D3EC0562301975FF0042AE48 /* Dynamics.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3EC055D301975FE0042AE48 /* Dynamics.swift */; };
+		D3EC0563301975FF0042AE48 /* Filters.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3EC055E301975FE0042AE48 /* Filters.swift */; };
+		D3EC0564301975FF0042AE48 /* Delay.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3EC055C301975FE0042AE48 /* Delay.swift */; };
+		D3EC0565301975FF0042AE48 /* SignalGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3EC0560301975FE0042AE48 /* SignalGenerator.swift */; };
+		D3EC0566301975FF0042AE48 /* TemperatureActuator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3EC0561301975FE0042AE48 /* TemperatureActuator.swift */; };
+		D3EC0567301975FF0042AE48 /* SamplingRateConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3EC055F301975FE0042AE48 /* SamplingRateConverter.swift */; };
+		D3EC056E3019762B0042AE48 /* SamplingRateConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3EC056B3019762B0042AE48 /* SamplingRateConverter.swift */; };
+		D3EC056F3019762B0042AE48 /* Delay.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3EC05683019762B0042AE48 /* Delay.swift */; };
+		D3EC05703019762B0042AE48 /* Dynamics.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3EC05693019762B0042AE48 /* Dynamics.swift */; };
+		D3EC05713019762B0042AE48 /* Filters.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3EC056A3019762B0042AE48 /* Filters.swift */; };
+		D3EC05723019762B0042AE48 /* TemperatureActuator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3EC056D3019762B0042AE48 /* TemperatureActuator.swift */; };
+		D3EC05733019762B0042AE48 /* SignalGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3EC056C3019762B0042AE48 /* SignalGenerator.swift */; };
+		D3EC057C3019764B0042AE48 /* FrequencySensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3EC05753019764B0042AE48 /* FrequencySensor.swift */; };
+		D3EC057D3019764B0042AE48 /* StateSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3EC05793019764B0042AE48 /* StateSensor.swift */; };
+		D3EC057E3019764B0042AE48 /* ImpedanceSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3EC05773019764B0042AE48 /* ImpedanceSensor.swift */; };
+		D3EC057F3019764B0042AE48 /* PowerSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3EC05783019764B0042AE48 /* PowerSensor.swift */; };
+		D3EC05803019764B0042AE48 /* CurrentSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3EC05743019764B0042AE48 /* CurrentSensor.swift */; };
+		D3EC05813019764B0042AE48 /* VoltageSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3EC057B3019764B0042AE48 /* VoltageSensor.swift */; };
+		D3EC05823019764B0042AE48 /* GainSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3EC05763019764B0042AE48 /* GainSensor.swift */; };
+		D3EC05833019764B0042AE48 /* TimeIntervalSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3EC057A3019764B0042AE48 /* TimeIntervalSensor.swift */; };
+		D3EC058C3019765A0042AE48 /* TimeIntervalSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3EC058A3019765A0042AE48 /* TimeIntervalSensor.swift */; };
+		D3EC058D3019765A0042AE48 /* StateSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3EC05893019765A0042AE48 /* StateSensor.swift */; };
+		D3EC058E3019765A0042AE48 /* GainSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3EC05863019765A0042AE48 /* GainSensor.swift */; };
+		D3EC058F3019765A0042AE48 /* VoltageSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3EC058B3019765A0042AE48 /* VoltageSensor.swift */; };
+		D3EC05903019765A0042AE48 /* ImpedanceSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3EC05873019765A0042AE48 /* ImpedanceSensor.swift */; };
+		D3EC05913019765A0042AE48 /* CurrentSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3EC05843019765A0042AE48 /* CurrentSensor.swift */; };
+		D3EC05923019765A0042AE48 /* FrequencySensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3EC05853019765A0042AE48 /* FrequencySensor.swift */; };
+		D3EC05933019765A0042AE48 /* PowerSensor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3EC05883019765A0042AE48 /* PowerSensor.swift */; };
+		D3EC0595301976740042AE48 /* PowerSupply.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3EC0594301976740042AE48 /* PowerSupply.swift */; };
+		D3EC05973019767F0042AE48 /* PowerSupply.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3EC05963019767F0042AE48 /* PowerSupply.swift */; };
 		D3F2942C2A95D55F00D7F0CD /* Sequence+AsyncMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3F2942B2A95D55F00D7F0CD /* Sequence+AsyncMap.swift */; };
 		D3F368D92F713C56008419DC /* ClassRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3F368D82F713C56008419DC /* ClassRegistry.swift */; };
 		D3F369442F78BF99008419DC /* Ocp1FlyingFoxConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3F369432F78BF99008419DC /* Ocp1FlyingFoxConnection.swift */; };
@@ -709,6 +739,36 @@
 		D3E741472D56331F0044CCBB /* TemperatureSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemperatureSensor.swift; sourceTree = "<group>"; };
 		D3E741492D5633740044CCBB /* TemperatureSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemperatureSensor.swift; sourceTree = "<group>"; };
 		D3E820E52DFBEF0C001C9DC8 /* Ocp1NWConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Ocp1NWConnection.swift; sourceTree = "<group>"; };
+		D3EC055C301975FE0042AE48 /* Delay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Delay.swift; sourceTree = "<group>"; };
+		D3EC055D301975FE0042AE48 /* Dynamics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dynamics.swift; sourceTree = "<group>"; };
+		D3EC055E301975FE0042AE48 /* Filters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Filters.swift; sourceTree = "<group>"; };
+		D3EC055F301975FE0042AE48 /* SamplingRateConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SamplingRateConverter.swift; sourceTree = "<group>"; };
+		D3EC0560301975FE0042AE48 /* SignalGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignalGenerator.swift; sourceTree = "<group>"; };
+		D3EC0561301975FE0042AE48 /* TemperatureActuator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemperatureActuator.swift; sourceTree = "<group>"; };
+		D3EC05683019762B0042AE48 /* Delay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Delay.swift; sourceTree = "<group>"; };
+		D3EC05693019762B0042AE48 /* Dynamics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dynamics.swift; sourceTree = "<group>"; };
+		D3EC056A3019762B0042AE48 /* Filters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Filters.swift; sourceTree = "<group>"; };
+		D3EC056B3019762B0042AE48 /* SamplingRateConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SamplingRateConverter.swift; sourceTree = "<group>"; };
+		D3EC056C3019762B0042AE48 /* SignalGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignalGenerator.swift; sourceTree = "<group>"; };
+		D3EC056D3019762B0042AE48 /* TemperatureActuator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemperatureActuator.swift; sourceTree = "<group>"; };
+		D3EC05743019764B0042AE48 /* CurrentSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentSensor.swift; sourceTree = "<group>"; };
+		D3EC05753019764B0042AE48 /* FrequencySensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrequencySensor.swift; sourceTree = "<group>"; };
+		D3EC05763019764B0042AE48 /* GainSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GainSensor.swift; sourceTree = "<group>"; };
+		D3EC05773019764B0042AE48 /* ImpedanceSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImpedanceSensor.swift; sourceTree = "<group>"; };
+		D3EC05783019764B0042AE48 /* PowerSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerSensor.swift; sourceTree = "<group>"; };
+		D3EC05793019764B0042AE48 /* StateSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateSensor.swift; sourceTree = "<group>"; };
+		D3EC057A3019764B0042AE48 /* TimeIntervalSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeIntervalSensor.swift; sourceTree = "<group>"; };
+		D3EC057B3019764B0042AE48 /* VoltageSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoltageSensor.swift; sourceTree = "<group>"; };
+		D3EC05843019765A0042AE48 /* CurrentSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentSensor.swift; sourceTree = "<group>"; };
+		D3EC05853019765A0042AE48 /* FrequencySensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrequencySensor.swift; sourceTree = "<group>"; };
+		D3EC05863019765A0042AE48 /* GainSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GainSensor.swift; sourceTree = "<group>"; };
+		D3EC05873019765A0042AE48 /* ImpedanceSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImpedanceSensor.swift; sourceTree = "<group>"; };
+		D3EC05883019765A0042AE48 /* PowerSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerSensor.swift; sourceTree = "<group>"; };
+		D3EC05893019765A0042AE48 /* StateSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateSensor.swift; sourceTree = "<group>"; };
+		D3EC058A3019765A0042AE48 /* TimeIntervalSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeIntervalSensor.swift; sourceTree = "<group>"; };
+		D3EC058B3019765A0042AE48 /* VoltageSensor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoltageSensor.swift; sourceTree = "<group>"; };
+		D3EC0594301976740042AE48 /* PowerSupply.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerSupply.swift; sourceTree = "<group>"; };
+		D3EC05963019767F0042AE48 /* PowerSupply.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerSupply.swift; sourceTree = "<group>"; };
 		D3F2942B2A95D55F00D7F0CD /* Sequence+AsyncMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Sequence+AsyncMap.swift"; sourceTree = "<group>"; };
 		D3F368D82F713C56008419DC /* ClassRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClassRegistry.swift; sourceTree = "<group>"; };
 		D3F369432F78BF99008419DC /* Ocp1FlyingFoxConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Ocp1FlyingFoxConnection.swift; sourceTree = "<group>"; };
@@ -1071,6 +1131,14 @@
 		D33B52B12A7060B4001A1BA7 /* Sensors */ = {
 			isa = PBXGroup;
 			children = (
+				D3EC05843019765A0042AE48 /* CurrentSensor.swift */,
+				D3EC05853019765A0042AE48 /* FrequencySensor.swift */,
+				D3EC05863019765A0042AE48 /* GainSensor.swift */,
+				D3EC05873019765A0042AE48 /* ImpedanceSensor.swift */,
+				D3EC05883019765A0042AE48 /* PowerSensor.swift */,
+				D3EC05893019765A0042AE48 /* StateSensor.swift */,
+				D3EC058A3019765A0042AE48 /* TimeIntervalSensor.swift */,
+				D3EC058B3019765A0042AE48 /* VoltageSensor.swift */,
 				D351F20B2A729AB3008C5513 /* Sensor.swift */,
 				D351F20D2A729AF2008C5513 /* BasicSensors.swift */,
 				D351F20F2A729C36008C5513 /* LevelSensor.swift */,
@@ -1084,6 +1152,12 @@
 		D33B52B22A7060B6001A1BA7 /* Actuators */ = {
 			isa = PBXGroup;
 			children = (
+				D3EC055C301975FE0042AE48 /* Delay.swift */,
+				D3EC055D301975FE0042AE48 /* Dynamics.swift */,
+				D3EC055E301975FE0042AE48 /* Filters.swift */,
+				D3EC055F301975FE0042AE48 /* SamplingRateConverter.swift */,
+				D3EC0560301975FE0042AE48 /* SignalGenerator.swift */,
+				D3EC0561301975FE0042AE48 /* TemperatureActuator.swift */,
 				D33B52B32A7060BC001A1BA7 /* Actuator.swift */,
 				D33B52B52A7060E0001A1BA7 /* BasicActuators.swift */,
 				D36851272EEA2700000129F3 /* IdentificationActuator.swift */,
@@ -1112,6 +1186,7 @@
 		D351F2062A72999D008C5513 /* Agents */ = {
 			isa = PBXGroup;
 			children = (
+				D3EC0594301976740042AE48 /* PowerSupply.swift */,
 				D351F2072A7299B0008C5513 /* Agent.swift */,
 				D30349E12BC803280080FF09 /* CounterNotifier.swift */,
 				D30349DB2BC67AD20080FF09 /* CounterSetAgent.swift */,
@@ -1489,6 +1564,7 @@
 		D3E6E18A2A3ACA6C00BF7095 /* Agents */ = {
 			isa = PBXGroup;
 			children = (
+				D3EC05963019767F0042AE48 /* PowerSupply.swift */,
 				D3E6E18B2A3ACA6C00BF7095 /* Agent.swift */,
 				D3A0BE7D2B71921900A5AA05 /* Group.swift */,
 				D3E6E18C2A3ACA6C00BF7095 /* EventHandler.swift */,
@@ -1526,6 +1602,14 @@
 		D3E6E18F2A3ACA6C00BF7095 /* Sensors */ = {
 			isa = PBXGroup;
 			children = (
+				D3EC05743019764B0042AE48 /* CurrentSensor.swift */,
+				D3EC05753019764B0042AE48 /* FrequencySensor.swift */,
+				D3EC05763019764B0042AE48 /* GainSensor.swift */,
+				D3EC05773019764B0042AE48 /* ImpedanceSensor.swift */,
+				D3EC05783019764B0042AE48 /* PowerSensor.swift */,
+				D3EC05793019764B0042AE48 /* StateSensor.swift */,
+				D3EC057A3019764B0042AE48 /* TimeIntervalSensor.swift */,
+				D3EC057B3019764B0042AE48 /* VoltageSensor.swift */,
 				D3E6E1902A3ACA6C00BF7095 /* Sensor.swift */,
 				D3E6E1912A3ACA6C00BF7095 /* BasicSensors.swift */,
 				D3E6E1922A3ACA6C00BF7095 /* LevelSensor.swift */,
@@ -1539,6 +1623,12 @@
 		D3E6E1962A3ACA6C00BF7095 /* Actuators */ = {
 			isa = PBXGroup;
 			children = (
+				D3EC05683019762B0042AE48 /* Delay.swift */,
+				D3EC05693019762B0042AE48 /* Dynamics.swift */,
+				D3EC056A3019762B0042AE48 /* Filters.swift */,
+				D3EC056B3019762B0042AE48 /* SamplingRateConverter.swift */,
+				D3EC056C3019762B0042AE48 /* SignalGenerator.swift */,
+				D3EC056D3019762B0042AE48 /* TemperatureActuator.swift */,
 				D36851252EEA26A6000129F3 /* IdentificationActuator.swift */,
 				D3E6E1972A3ACA6C00BF7095 /* PanBalance.swift */,
 				D3E6E1982A3ACA6C00BF7095 /* Mute.swift */,
@@ -2144,6 +2234,7 @@
 				D32229D32ABC270900B56B6B /* Ocp1IORingDeviceEndpoint.swift in Sources */,
 				D351F2082A7299B0008C5513 /* Agent.swift in Sources */,
 				D35592602B520DFC000F633B /* ControllerDefaultSubscribing.swift in Sources */,
+				D3EC0595301976740042AE48 /* PowerSupply.swift in Sources */,
 				D30349E22BC803280080FF09 /* CounterNotifier.swift in Sources */,
 				D33B52A52A702D04001A1BA7 /* Worker.swift in Sources */,
 				D3FAC8EE2B5CFE3A009E2775 /* FirmwareManager.swift in Sources */,
@@ -2153,6 +2244,12 @@
 				D3AFD35C2B30EC0600A72E9A /* CodingManager.swift in Sources */,
 				D3E7414A2D5633740044CCBB /* TemperatureSensor.swift in Sources */,
 				D351F2122A729CB0008C5513 /* TimeSource.swift in Sources */,
+				D3EC0562301975FF0042AE48 /* Dynamics.swift in Sources */,
+				D3EC0563301975FF0042AE48 /* Filters.swift in Sources */,
+				D3EC0564301975FF0042AE48 /* Delay.swift in Sources */,
+				D3EC0565301975FF0042AE48 /* SignalGenerator.swift in Sources */,
+				D3EC0566301975FF0042AE48 /* TemperatureActuator.swift in Sources */,
+				D3EC0567301975FF0042AE48 /* SamplingRateConverter.swift in Sources */,
 				D33B52AC2A702D4D001A1BA7 /* DeviceManager.swift in Sources */,
 				D355925D2B51E5FF000F633B /* DatagramProxyDeviceEndpoint.swift in Sources */,
 				D32229D62ABD26E100B56B6B /* DeviceEndpointRegistrar.swift in Sources */,
@@ -2181,6 +2278,14 @@
 				D3527EC52F00DA0100000004 /* Ocp1NWStreamController.swift in Sources */,
 				D3527EC52F00DA0100000006 /* Ocp1NWStreamDeviceEndpoint.swift in Sources */,
 				D3527EC72F00DA0100000019 /* Ocp1NWDatagramController.swift in Sources */,
+				D3EC058C3019765A0042AE48 /* TimeIntervalSensor.swift in Sources */,
+				D3EC058D3019765A0042AE48 /* StateSensor.swift in Sources */,
+				D3EC058E3019765A0042AE48 /* GainSensor.swift in Sources */,
+				D3EC058F3019765A0042AE48 /* VoltageSensor.swift in Sources */,
+				D3EC05903019765A0042AE48 /* ImpedanceSensor.swift in Sources */,
+				D3EC05913019765A0042AE48 /* CurrentSensor.swift in Sources */,
+				D3EC05923019765A0042AE48 /* FrequencySensor.swift in Sources */,
+				D3EC05933019765A0042AE48 /* PowerSensor.swift in Sources */,
 				D3527EC72F00DA01000000A1 /* Ocp1NWDatagramDeviceEndpoint.swift in Sources */,
 				D351F21C2A72A26E008C5513 /* Matrix.swift in Sources */,
 				D351F2162A729DFC008C5513 /* PolarityState.swift in Sources */,
@@ -2282,12 +2387,19 @@
 				D3E6E1C42A3ACA8C00BF7095 /* Worker.swift in Sources */,
 				D3BA711B2DE991B700A35C50 /* LengthTaggedData32.swift in Sources */,
 				D3AFD3342B2A505D00A72E9A /* AudioProcessingManager.swift in Sources */,
+				D3EC05973019767F0042AE48 /* PowerSupply.swift in Sources */,
 				D34B5FAA2B688A9A000C8DD1 /* MapProperty.swift in Sources */,
 				D3E6E1C52A3ACA8C00BF7095 /* Block.swift in Sources */,
 				D3E6E1E82A3ACAAD00BF7095 /* Data+Hex.swift in Sources */,
 				D3AFD3362B2A516C00A72E9A /* DeviceTimeManager.swift in Sources */,
 				D306556F2A5254D70083F093 /* TimeSource.swift in Sources */,
 				D301C6772BF0576200488B99 /* UnsafeMutablePointer+PropertyBasePointer.swift in Sources */,
+				D3EC056E3019762B0042AE48 /* SamplingRateConverter.swift in Sources */,
+				D3EC056F3019762B0042AE48 /* Delay.swift in Sources */,
+				D3EC05703019762B0042AE48 /* Dynamics.swift in Sources */,
+				D3EC05713019762B0042AE48 /* Filters.swift in Sources */,
+				D3EC05723019762B0042AE48 /* TemperatureActuator.swift in Sources */,
+				D3EC05733019762B0042AE48 /* SignalGenerator.swift in Sources */,
 				D3AFD3442B2CEA3800A72E9A /* LockManager.swift in Sources */,
 				D3AFD3922B41513300A72E9A /* SummingPoint.swift in Sources */,
 				D3E6E1BF2A3ACA8200BF7095 /* Header.swift in Sources */,
@@ -2363,6 +2475,14 @@
 				D3AFD37C2B32A06700A72E9A /* UnkeyedOcp1EncodingContainer.swift in Sources */,
 				D30349E02BC67E530080FF09 /* CounterNotifier.swift in Sources */,
 				D3E6E1DD2A3ACAA900BF7095 /* Array2D.swift in Sources */,
+				D3EC057C3019764B0042AE48 /* FrequencySensor.swift in Sources */,
+				D3EC057D3019764B0042AE48 /* StateSensor.swift in Sources */,
+				D3EC057E3019764B0042AE48 /* ImpedanceSensor.swift in Sources */,
+				D3EC057F3019764B0042AE48 /* PowerSensor.swift in Sources */,
+				D3EC05803019764B0042AE48 /* CurrentSensor.swift in Sources */,
+				D3EC05813019764B0042AE48 /* VoltageSensor.swift in Sources */,
+				D3EC05823019764B0042AE48 /* GainSensor.swift in Sources */,
+				D3EC05833019764B0042AE48 /* TimeIntervalSensor.swift in Sources */,
 				D36ECA212A5AEB9B0015174A /* Ocp1FlyingSocksConnection.swift in Sources */,
 				D3AFD3422B2CE91B00A72E9A /* MediaClockManager.swift in Sources */,
 				D3E6E1BB2A3ACA7B00BF7095 /* Ocp1Connection.swift in Sources */,
@@ -3193,20 +3313,20 @@
 				minimumVersion = 0.6.7;
 			};
 		};
-		D3527EC72F00DA01000000B0 /* XCRemoteSwiftPackageReference "swift-binary-parsing" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/apple/swift-binary-parsing";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.0.2;
-			};
-		};
 		D3527EC72F00DA0100000060 /* XCRemoteSwiftPackageReference "swift-crypto" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/apple/swift-crypto";
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 3.10.0;
+			};
+		};
+		D3527EC72F00DA01000000B0 /* XCRemoteSwiftPackageReference "swift-binary-parsing" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-binary-parsing";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.0.2;
 			};
 		};
 		D35C9D9E2BF76E5100D680F2 /* XCRemoteSwiftPackageReference "SocketAddress" */ = {

--- a/Tests/SwiftOCADeviceTests/ClassRegistryTests.swift
+++ b/Tests/SwiftOCADeviceTests/ClassRegistryTests.swift
@@ -38,6 +38,28 @@ struct ClassRegistryTests {
       == SwiftOCADevice.OcaMediaClock3.self)
     #expect(try registry.match(classID: OcaClassID("1.2.16"))
       == SwiftOCADevice.OcaTimeSource.self)
+    #expect(try registry.match(classID: OcaClassID("1.1.1.14"))
+      == SwiftOCADevice.OcaDynamics.self)
+    #expect(try registry.match(classID: OcaClassID("1.1.1.7.1"))
+      == SwiftOCADevice.OcaDelayExtended.self)
+  }
+
+  @Test @OcaDevice
+  func resolvesNewlyAddedClasses() throws {
+    let registry = OcaDeviceClassRegistry.shared
+
+    #expect(try registry.match(classID: OcaClassID("1.1.2.7"))
+      == SwiftOCADevice.OcaVoltageSensor.self)
+    #expect(try registry.match(classID: OcaClassID("1.1.2.11"))
+      == SwiftOCADevice.OcaPowerSensor.self)
+    #expect(try registry.match(classID: OcaClassID("1.1.2.12"))
+      == SwiftOCADevice.OcaStateSensor.self)
+    #expect(try registry.match(classID: OcaClassID("1.1.1.16"))
+      == SwiftOCADevice.OcaDynamicsCurve.self)
+    #expect(try registry.match(classID: OcaClassID("1.1.1.23"))
+      == SwiftOCADevice.OcaSamplingRateConverter.self)
+    #expect(try registry.match(classID: OcaClassID("1.2.7"))
+      == SwiftOCADevice.OcaPowerSupply.self)
   }
 
   /// an unknown subclass still resolves to the nearest registered superclass

--- a/Tests/SwiftOCADeviceTests/ClassRegistryTests.swift
+++ b/Tests/SwiftOCADeviceTests/ClassRegistryTests.swift
@@ -1,0 +1,56 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import SwiftOCA
+import SwiftOCADevice
+import Testing
+
+@Suite
+struct ClassRegistryTests {
+  /// `_match()` searches downwards from `OcaRoot.classVersion`, so a device class
+  /// registered at a later version than `OcaRoot` is unreachable; keep the two
+  /// frameworks' idea of the root class version in step
+  @Test
+  func deviceAndControllerRootClassVersionsAgree() {
+    #expect(SwiftOCADevice.OcaRoot.classVersion == SwiftOCA.OcaRoot.classVersion)
+  }
+
+  @Test @OcaDevice
+  func resolvesClassVersion3Classes() throws {
+    let registry = OcaDeviceClassRegistry.shared
+
+    #expect(try registry.match(classID: OcaClassID("1.1.1.8"))
+      == SwiftOCADevice.OcaFrequencyActuator.self)
+    #expect(try registry.match(classID: OcaClassID("1.2.15"))
+      == SwiftOCADevice.OcaMediaClock3.self)
+    #expect(try registry.match(classID: OcaClassID("1.2.16"))
+      == SwiftOCADevice.OcaTimeSource.self)
+  }
+
+  /// an unknown subclass still resolves to the nearest registered superclass
+  @Test @OcaDevice
+  func fallsBackToSuperclass() throws {
+    let registry = OcaDeviceClassRegistry.shared
+
+    #expect(try registry.match(classID: OcaClassID("1.1.1.9999"))
+      == SwiftOCADevice.OcaActuator.self)
+  }
+
+  @Test @OcaConnection
+  func controllerRegistryConstructs() {
+    _ = OcaClassRegistry.shared
+  }
+}


### PR DESCRIPTION
Audits the AES70 class tree against what SwiftOCA implements and fills in every
missing class that the existing property wrappers can express, on both the
controller and device sides.

## Classes added

| | |
|---|---|
| **sensors** | `OcaTimeIntervalSensor`, `OcaFrequencySensor`, `OcaVoltageSensor`, `OcaCurrentSensor`, `OcaImpedanceSensor`, `OcaGainSensor`, `OcaPowerSensor`, `OcaStateSensor` |
| **actuators** | `OcaDelay`, `OcaDelayExtended`, `OcaTemperatureActuator`, `OcaSamplingRateConverter`, `OcaSignalGenerator`, `OcaFilterClassical`, `OcaFilterParametric`, `OcaFilterPolynomial`, `OcaFilterFIR`, `OcaFilterArbitraryCurve`, `OcaDynamics`, `OcaDynamicsDetector`, `OcaDynamicsCurve` |
| **agents** | `OcaPowerSupply` |

All are registered in both class registries.

## Notes

Where AES70 returns several properties from a single method the value cannot be
carried by a property accessor, so the property is declared without one and the
method is spelled out instead: `OcaPowerSensor.getReading()`,
`OcaFilterPolynomial.getCoefficients()` and the `OcaDynamicsCurve` list getters.
The device side answers these directly, taking the bounds that
`GetThresholds()`, `GetSlopes()` and `GetKneeParameters()` report from
overridable range properties.

Non-accessor methods — every `SetMultiple()`, `OcaSignalGenerator.start()` and
`stop()`, and `OcaDelayExtended.GetDelayValueConverted()` — are `open func`s
that throw `notImplemented`, for subclasses to implement where the behaviour is
device specific.

`OcaStateSensor`'s `State` property is named `reading`, because `OcaSensor`
already uses `state` for AES70's `ReadingState`.

`OcaImpedance` and `OcaDelayValue` gain `Comparable` conformances and public
memberwise initialisers so they can be used as bounded property values, and
`OcaTransferFunction`'s members are made public for the same reason.

## Device-side OcaRoot class version

`SwiftOCADevice.OcaRoot` declared class version 2 while `SwiftOCA.OcaRoot`
declares 3, which AES70 agrees with. The registry's `_match()` searches
downwards from `OcaRoot.classVersion`, so any device class registered at version
3 was unreachable and fell back to its superclass — `OcaFrequencyActuator`,
`OcaMediaClock3` and `OcaTimeSource` resolved to `OcaActuator` and `OcaAgent`.
Bumping the root version fixes those alongside the new classes, and
`ClassRegistryTests` covers it.

## Not included

Classes needing datatypes or machinery that don't exist yet, and so not "easy":
the bitstring and JSON basic actuators/sensors; the remaining agents
(`OcaRamper`, `OcaGrouper`, `OcaTaskAgent`, `OcaTaskScheduler`,
`OcaNumericObserver`, `OcaNumericObserverList`, `OcaBlockFactoryAgent`,
`OcaCommandSetAgent`, `OcaMediaTransportSessionAgent`); the datasets
`OcaProgram` and `OcaCommandSet`; and the deprecated `OcaNetworkSignalChannel`,
`OcaNetwork`, `OcaStreamNetwork`, `OcaStreamConnector` and `OcaMediaClock`.
Eleven classes that exist only on the controller side (`OcaDatasetWorker`,
`OcaMediaRecorderPlayer`, `OcaPhysicalPosition`, `OcaPowerManager`,
`OcaLibraryManager`, `OcaTaskManager`, `OcaLog`, `OcaNetworkInterface`,
`OcaNetworkApplication`, `OcaMediaTransportApplication`, `OcaBitstringActuator`)
still have no device implementation; that's untouched here.

## Testing

`swift build` and `swift test` pass. The test run exits non-zero from a SIGPIPE
in the TLS/dataset suite — that reproduces identically on unmodified `main`, so
it is pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SbSPUSoq5Pirbz3unXFzuq