### PR TITLE
enrol requests before sending so responses and timeouts are never lost

### DIFF
--- a/Sources/SwiftOCA/OCC/ControlClasses/Root+Commands.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Root+Commands.swift
@@ -27,9 +27,8 @@ private extension OcaRoot {
     parameterData: Data
   ) async throws {
     guard let connectionDelegate else { throw Ocp1Error.noConnectionDelegate }
-    let command = await Ocp1Command(
+    let command = Ocp1Command(
       commandSize: 0,
-      handle: connectionDelegate.getNextCommandHandle(),
       targetONo: objectNumber,
       methodID: methodID,
       parameters: Ocp1Parameters(
@@ -163,9 +162,8 @@ public extension OcaRoot {
   ) async throws -> Ocp1Response {
     guard let connectionDelegate else { throw Ocp1Error.noConnectionDelegate }
 
-    let command = await Ocp1Command(
+    let command = Ocp1Command(
       commandSize: 0,
-      handle: connectionDelegate.getNextCommandHandle(),
       targetONo: objectNumber,
       methodID: methodID,
       parameters: Ocp1Parameters(

--- a/Sources/SwiftOCA/OCF/Messages/Command.swift
+++ b/Sources/SwiftOCA/OCF/Messages/Command.swift
@@ -37,7 +37,8 @@ public struct Ocp1Parameters: Codable, Sendable {
 
 public struct Ocp1Command: _Ocp1MessageCodable, Sendable {
   public let commandSize: OcaUint32
-  public let handle: OcaUint32
+  /// assigned by the connection when the command is sent
+  public var handle: OcaUint32
   public let targetONo: OcaONo
   public let methodID: OcaMethodID
   public let parameters: Ocp1Parameters
@@ -46,7 +47,7 @@ public struct Ocp1Command: _Ocp1MessageCodable, Sendable {
 
   public init(
     commandSize: OcaUint32 = 0,
-    handle: OcaUint32,
+    handle: OcaUint32 = 0,
     targetONo: OcaONo,
     methodID: OcaMethodID,
     parameters: Ocp1Parameters = .init()

--- a/Sources/SwiftOCA/OCF/Messages/KeepAlive.swift
+++ b/Sources/SwiftOCA/OCF/Messages/KeepAlive.swift
@@ -59,8 +59,10 @@ public struct Ocp1KeepAlive2: _Ocp1MessageCodable, Sendable {
 
 public typealias Ocp1KeepAlive = Ocp1KeepAlive1
 
-package extension Ocp1KeepAlive {
-  static func keepAlive(interval heartbeatTime: Duration) -> Ocp1Message {
+extension Ocp1KeepAlive {
+  /// Seconds if the interval is at least one, milliseconds otherwise: two
+  /// distinct message types, so the choice can only be made at runtime.
+  static func message(interval heartbeatTime: Duration) -> any _Ocp1MessageCodable {
     let seconds = heartbeatTime.seconds
     if seconds >= 1 {
       return Ocp1KeepAlive1(heartBeatTime: OcaUint16(seconds))
@@ -68,5 +70,13 @@ package extension Ocp1KeepAlive {
       let milliseconds = heartbeatTime.milliseconds
       return Ocp1KeepAlive2(heartBeatTime: OcaUint32(max(milliseconds, 1)))
     }
+  }
+}
+
+package extension Ocp1KeepAlive {
+  /// `_Ocp1MessageCodable` is internal, so callers in other modules — which
+  /// batch messages heterogeneously anyway — get the wider erasure.
+  static func keepAlive(interval heartbeatTime: Duration) -> Ocp1Message {
+    message(interval: heartbeatTime)
   }
 }

--- a/Sources/SwiftOCA/OCP.1/Ocp1Connection+Messages.swift
+++ b/Sources/SwiftOCA/OCP.1/Ocp1Connection+Messages.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 PADL Software Pty Ltd
+// Copyright (c) 2023-2026 PADL Software Pty Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.
@@ -22,42 +22,50 @@ import Foundation
 
 extension Ocp1Connection {
   private func sendMessage(
-    _ message: Ocp1Message,
+    _ message: some _Ocp1MessageCodable,
     type messageType: OcaMessageType
   ) async throws {
     try await batcher.enqueue(message, type: messageType)
   }
 
-  public func sendCommand(_ command: Ocp1Command) async throws {
-    try await sendMessage(command, type: .ocaCmd)
-  }
-
-  private func response(for handle: OcaUint32) async throws -> Ocp1Response {
+  /// `command.handle` is assigned here, replacing whatever the caller set:
+  /// only the connection knows which handles it has issued.
+  public func sendCommand(_ command: consuming Ocp1Command) async throws {
     guard let monitor else {
       throw Ocp1Error.notConnected
     }
 
-    return try await withUnsafeThrowingContinuation { continuation in
-      monitor.register(handle: handle, continuation: continuation)
-    }
+    monitor.allocateCommandHandle(&command, responseRequired: false)
+    try await sendMessage(command, type: .ocaCmd)
   }
 
-  public func sendCommandRrq(_ command: Ocp1Command) async throws -> Ocp1Response {
-    try await withThrowingTimeout(
+  /// `command.handle` is assigned here, replacing whatever the caller set:
+  /// only the connection knows which handles are in flight.
+  public func sendCommandRrq(_ command: consuming Ocp1Command) async throws -> Ocp1Response {
+    guard let monitor else {
+      throw Ocp1Error.notConnected
+    }
+
+    let handle = monitor.allocateCommandHandle(&command, responseRequired: true)
+    defer { monitor.releaseCommandHandle(handle) }
+
+    let request = consume command
+
+    return try await withThrowingTimeout(
       of: responseTimeout,
       clock: .continuous,
       operation: { [self] in
-        try await sendMessage(command, type: .ocaCmdRrq)
-        return try await response(for: command.handle)
-      }, onTimeout: { [self] in
-        try await monitor?.resumeTimedOut(handle: command.handle)
+        try await sendMessage(request, type: .ocaCmdRrq)
+        return try await monitor.response(for: handle)
+      }, onTimeout: {
+        monitor.resumeTimedOut(handle: handle)
       }
     )
   }
 
   func sendKeepAlive() async throws {
     try await sendMessage(
-      Ocp1KeepAlive.keepAlive(interval: heartbeatTime),
+      Ocp1KeepAlive.message(interval: heartbeatTime),
       type: .ocaKeepAlive
     )
   }

--- a/Sources/SwiftOCA/OCP.1/Ocp1Connection.swift
+++ b/Sources/SwiftOCA/OCP.1/Ocp1Connection.swift
@@ -284,8 +284,6 @@ open class Ocp1Connection: CustomStringConvertible {
   nonisolated(unsafe) var logger = Logger(label: "com.padl.SwiftOCA")
   var connectionID = 0
 
-  /// internal rather than private so tests can wind it to the wrap boundary
-  var nextCommandHandle = UInt64(0)
   private var continuousClockReference = ContinuousClockReference()
 
   var lastMessageSentTime = ContinuousClock.recentPast
@@ -300,7 +298,7 @@ open class Ocp1Connection: CustomStringConvertible {
     Ocp1ConnectionStatistics(
       connectionState: currentConnectionState,
       connectionID: connectionID,
-      requestCount: nextCommandHandle,
+      requestCount: monitor?.requestCount ?? 0,
       outstandingRequests: monitor?.outstandingRequests ?? [],
       cachedObjectCount: objects.count,
       subscribedEvents: Array(subscriptions.keys),
@@ -318,95 +316,6 @@ open class Ocp1Connection: CustomStringConvertible {
       return heartbeatTime * 2
     } else {
       return timeout
-    }
-  }
-
-  /// Monitor for matching requests and responses.
-  /// Deliberately not isolated to `@OcaConnection` so that the
-  /// receiveMessages/keepAlive loops run on the default executor and
-  /// are not starved by work on other connections sharing the global actor.
-  final class Monitor: Sendable, CustomStringConvertible {
-    typealias Continuation = UnsafeContinuation<Ocp1Response, Error>
-
-    private let _connection: Weak<Ocp1Connection>
-    let _connectionID: Int
-    private let _continuations = Mutex<[OcaUint32: Continuation]>([:])
-    private let _lastMessageReceivedTime = Mutex<ContinuousClock.Instant>(.now)
-
-    init(_ connection: Ocp1Connection, id: Int) {
-      _connection = Weak(connection)
-      _connectionID = id
-      updateLastMessageReceivedTime()
-    }
-
-    var connection: Ocp1Connection? {
-      _connection.object
-    }
-
-    func run() async throws {
-      guard let connection else { throw Ocp1Error.notConnected }
-      do {
-        try await receiveMessages(connection)
-      } catch Ocp1Error.notConnected {
-        _resumeAllNotConnected()
-      }
-    }
-
-    func stop() {
-      _resumeAllNotConnected()
-    }
-
-    func register(handle: OcaUint32, continuation: Continuation) {
-      _continuations.withLock { $0[handle] = continuation }
-    }
-
-    private func _resumeAllNotConnected() {
-      let continuations = _continuations.withLock { continuations in
-        let values = Array(continuations.values)
-        continuations.removeAll()
-        return values
-      }
-      for continuation in continuations {
-        continuation.resume(throwing: Ocp1Error.notConnected)
-      }
-    }
-
-    func resumeTimedOut(handle: OcaUint32) throws {
-      let continuation = try _findAndRemoveContinuation(for: handle)
-      continuation.resume(with: Result<Ocp1Response, Ocp1Error>.failure(Ocp1Error.responseTimeout))
-    }
-
-    func resume(with response: Ocp1Response) throws {
-      let continuation = try _findAndRemoveContinuation(for: response.handle)
-      continuation.resume(with: Result<Ocp1Response, Ocp1Error>.success(response))
-    }
-
-    private func _findAndRemoveContinuation(
-      for handle: OcaUint32
-    ) throws -> Continuation {
-      try _continuations.withLock { continuations in
-        guard let continuation = continuations[handle] else {
-          throw Ocp1Error.invalidHandle
-        }
-        continuations.removeValue(forKey: handle)
-        return continuation
-      }
-    }
-
-    func updateLastMessageReceivedTime() {
-      _lastMessageReceivedTime.withLock { $0 = .now }
-    }
-
-    fileprivate var outstandingRequests: [OcaUint32] {
-      _continuations.withLock { Array($0.keys) }
-    }
-
-    var lastMessageReceivedTime: ContinuousClock.Instant {
-      _lastMessageReceivedTime.withLock { $0 }
-    }
-
-    var description: String {
-      "Ocp1Connection.Monitor[\(_connectionID)]"
     }
   }
 
@@ -432,25 +341,6 @@ open class Ocp1Connection: CustomStringConvertible {
     add(object: deviceManager)
     _configureTracing()
     _configureBatching(options.batchingOptions)
-  }
-
-  /// The handle is the low 32 bits of the request counter, so it wraps rather
-  /// than trapping: it is a wire field with no meaning beyond matching a
-  /// response to its request, and a controller issuing 10k requests/sec reaches
-  /// 2^32 in about five days. The counter itself is 64-bit and won't wrap.
-  ///
-  /// Handles skip zero on wrap, because zero is the default value of
-  /// `Ocp1Response.handle`: a device answering a protocol error with a
-  /// zero-filled response must not match a live request.
-  func getNextCommandHandle() async -> OcaUint32 {
-    nextCommandHandle += 1
-    let handle = OcaUint32(truncatingIfNeeded: nextCommandHandle)
-    guard handle != 0 else {
-      // the counter value that would yield 1 is the one being skipped
-      nextCommandHandle += 1
-      return 1
-    }
-    return handle
   }
 
   open func connectDevice() async throws {}

--- a/Sources/SwiftOCA/OCP.1/Ocp1ConnectionMonitor.swift
+++ b/Sources/SwiftOCA/OCP.1/Ocp1ConnectionMonitor.swift
@@ -19,8 +19,252 @@ import FoundationEssentials
 #else
 import Foundation
 #endif
+import Synchronization
 
-/// Connection monitor delivers responses keyed by request handle
+// Connection monitor delivers responses keyed by request handle
+
+extension Ocp1Connection {
+  /// Monitor for matching requests and responses.
+  /// Deliberately not isolated to `@OcaConnection` so that the
+  /// receiveMessages/keepAlive loops run on the default executor and
+  /// are not starved by work on other connections sharing the global actor.
+  final class Monitor: Sendable, CustomStringConvertible {
+    typealias Continuation = UnsafeContinuation<Ocp1Response, Error>
+
+    /// A request is claimed before its command is written, because this class
+    /// is not isolated to `@OcaConnection`: it decodes responses concurrently
+    /// with the sender, so it can match one before the sender has suspended.
+    /// Until then there is nowhere to deliver a result, so it is held in
+    /// `completed` rather than dropped.
+    private enum Request {
+      /// claimed; the sender has not suspended yet
+      case pending
+      /// the sender is suspended awaiting a response
+      case waiting(Continuation)
+      /// a result arrived before the sender suspended
+      case completed(Result<Ocp1Response, Error>)
+    }
+
+    /// The counter shares the requests lock so a handle can be allocated and
+    /// claimed in one step, leaving no window in which it is merely reserved.
+    private struct Requests {
+      var entries = [OcaUint32: Request]()
+      var count = UInt64(0)
+    }
+
+    private let _connection: Weak<Ocp1Connection>
+    let _connectionID: Int
+    private let _requests = Mutex<Requests>(Requests())
+    private let _lastMessageReceivedTime = Mutex<ContinuousClock.Instant>(.now)
+
+    init(_ connection: Ocp1Connection, id: Int) {
+      _connection = Weak(connection)
+      _connectionID = id
+      updateLastMessageReceivedTime()
+    }
+
+    var connection: Ocp1Connection? {
+      _connection.object
+    }
+
+    func run() async throws {
+      guard let connection else { throw Ocp1Error.notConnected }
+      do {
+        try await receiveMessages(connection)
+      } catch Ocp1Error.notConnected {
+        _resumeAllNotConnected()
+      }
+    }
+
+    func stop() {
+      _resumeAllNotConnected()
+    }
+
+    /// Zero is a legal handle on the wire, but it is `Ocp1Response.handle`'s
+    /// default, so skip it: a zero-filled response must not match a request.
+    private static func _allocateCommandHandle(_ requests: inout Requests) -> OcaUint32 {
+      repeat {
+        requests.count += 1
+        let handle = OcaUint32(truncatingIfNeeded: requests.count)
+        if handle != 0 { return handle }
+      } while true
+    }
+
+    /// Allocates a handle and stamps it into `command`. An unmatched command
+    /// records nothing, but still advances the counter `requestCount` reports.
+    ///
+    /// A recorded handle is allocated and claimed under one lock, so a response
+    /// arriving before the sender suspends is kept rather than discarded, and
+    /// handles still outstanding are skipped, which is what makes this total:
+    /// the wire handle is 32 bits and is reissued after 2^32 requests.
+    @discardableResult
+    func allocateCommandHandle(
+      _ command: inout Ocp1Command,
+      responseRequired: Bool
+    ) -> OcaUint32 {
+      let handle = _requests.withLock { requests in
+        repeat {
+          let handle = Self._allocateCommandHandle(&requests)
+          guard responseRequired else { return handle }
+          if requests.entries[handle] == nil {
+            requests.entries[handle] = .pending
+            return handle
+          }
+        } while true
+      }
+      command.handle = handle
+      return handle
+    }
+
+    /// Claims a specific `handle`, for tests that need to name one. Returns
+    /// `false` if it is already outstanding.
+    func claimCommandHandle(_ handle: OcaUint32) -> Bool {
+      _requests.withLock { requests in
+        guard requests.entries[handle] == nil else { return false }
+        requests.entries[handle] = .pending
+        return true
+      }
+    }
+
+    /// Retires a claimed request, on whichever path the sender exits by. A
+    /// `waiting` entry stays: its continuation is the only way to resume it.
+    ///
+    /// Keyed by handle alone: were a handle reissued between a sender
+    /// completing and releasing, this would retire its successor.
+    /// Reaching that needs 2^32 requests on one connection, so it is accepted.
+    func releaseCommandHandle(_ handle: OcaUint32) {
+      _requests.withLock { requests in
+        if case .waiting = requests.entries[handle] { return }
+        requests.entries.removeValue(forKey: handle)
+      }
+    }
+
+    func response(for handle: OcaUint32) async throws -> Ocp1Response {
+      // withUnsafeThrowingContinuation is not cancellation-aware, so without
+      // this a cancelled sender would suspend on a continuation nobody resumes
+      // and its enclosing task group would never drain. _complete handles
+      // cancellation arriving before the suspension too, by parking the result.
+      try await withTaskCancellationHandler {
+        try await withUnsafeThrowingContinuation { continuation in
+          let completed: Result<Ocp1Response, Error>? = _requests.withLock { requests in
+            switch requests.entries[handle] {
+            case .pending:
+              requests.entries[handle] = .waiting(continuation)
+              return nil
+            case let .completed(result):
+              requests.entries.removeValue(forKey: handle)
+              return result
+            case .waiting:
+              // allocation makes this unreachable via sendCommandRrq; it catches
+              // direct misuse, where overwriting would strand the first sender
+              return .failure(Ocp1Error.invalidHandle)
+            case nil:
+              // the connection tore down between claiming and suspending
+              return .failure(Ocp1Error.notConnected)
+            }
+          }
+          // resume outside the lock
+          if let completed {
+            continuation.resume(with: completed)
+          }
+        }
+      } onCancel: {
+        _complete(handle: handle, with: .failure(CancellationError()))
+      }
+    }
+
+    /// The one transition table. Returns a continuation to resume outside the
+    /// lock, and whether `entry` was outstanding at all.
+    private static func _apply(
+      _ result: Result<Ocp1Response, Error>,
+      to request: inout Request?
+    ) -> (continuation: Continuation?, wasOutstanding: Bool) {
+      switch request {
+      case .pending:
+        // hold the result until the sender suspends
+        request = .completed(result)
+        return (nil, true)
+      case let .waiting(continuation):
+        request = nil
+        return (continuation, true)
+      case .completed:
+        // already resolved; first result wins, so a success is never displaced
+        return (nil, true)
+      case nil:
+        return (nil, false)
+      }
+    }
+
+    private func _resumeAllNotConnected() {
+      let error = Ocp1Error.notConnected
+      let continuations = _requests.withLock { requests in
+        // snapshot the keys: the loop mutates the dictionary it iterates
+        Array(requests.entries.keys).compactMap { handle in
+          Self._apply(.failure(error), to: &requests.entries[handle]).continuation
+        }
+      }
+      for continuation in continuations {
+        continuation.resume(throwing: error)
+      }
+    }
+
+    /// Completes a request whether or not its sender has suspended yet. Returns
+    /// `false` if `handle` is not outstanding.
+    @discardableResult
+    private func _complete(
+      handle: OcaUint32,
+      with result: Result<Ocp1Response, Error>
+    ) -> Bool {
+      let (continuation, wasOutstanding) = _requests.withLock { requests in
+        Self._apply(result, to: &requests.entries[handle])
+      }
+      // resume outside the lock
+      continuation?.resume(with: result)
+      return wasOutstanding
+    }
+
+    func resumeTimedOut(handle: OcaUint32) {
+      _complete(handle: handle, with: .failure(Ocp1Error.responseTimeout))
+    }
+
+    func resume(with response: Ocp1Response) throws {
+      guard _complete(handle: response.handle, with: .success(response)) else {
+        throw Ocp1Error.invalidHandle
+      }
+    }
+
+    /// Whether `handle`'s sender has suspended yet, so a test can wait for the
+    /// state it means to exercise instead of sleeping and hoping.
+    func isWaiting(handle: OcaUint32) -> Bool {
+      _requests.withLock {
+        if case .waiting = $0.entries[handle] { return true }
+        return false
+      }
+    }
+
+    func updateLastMessageReceivedTime() {
+      _lastMessageReceivedTime.withLock { $0 = .now }
+    }
+
+    /// Requests issued on this connection generation; the monitor, and so the
+    /// counter, is rebuilt on every reconnect.
+    var requestCount: UInt64 {
+      _requests.withLock { $0.count }
+    }
+
+    var outstandingRequests: [OcaUint32] {
+      _requests.withLock { Array($0.entries.keys) }
+    }
+
+    var lastMessageReceivedTime: ContinuousClock.Instant {
+      _lastMessageReceivedTime.withLock { $0 }
+    }
+
+    var description: String {
+      "Ocp1Connection.Monitor[\(_connectionID)]"
+    }
+  }
+}
 
 extension Ocp1Connection.Monitor {
   private func receiveMessagePdu(
@@ -32,8 +276,8 @@ extension Ocp1Connection.Monitor {
       throw Ocp1Error.notConnected
     }
 
-    /// just parse enough of the protocol in order to read rest of message
-    /// `syncVal: OcaUint8` || `protocolVersion: OcaUint16` || `pduSize: OcaUint32`
+    // just parse enough of the protocol in order to read rest of message
+    // `syncVal: OcaUint8` || `protocolVersion: OcaUint16` || `pduSize: OcaUint32`
     guard messagePduData.count >= Ocp1Connection.MinimumPduSize else {
       connection.logger.warning("PDU of size \(messagePduData.count) is too short")
       throw Ocp1Error.pduTooShort
@@ -102,7 +346,16 @@ extension Ocp1Connection.Monitor {
     await onDatagramConnectionOpen(connection)
 
     for message in messages {
-      try await processMessage(connection, message)
+      do {
+        try await processMessage(connection, message)
+      } catch {
+        // processMessage does no I/O, so nothing it throws says anything about
+        // the health of the connection: a response nobody is waiting for, an
+        // unknown PDU type, an event delivered as an exception. Drop the one
+        // message — the siblings sharing this batched PDU have senders of
+        // their own still waiting, and the connection is fine.
+        connection.logger.debug("dropping \(message): \(error)")
+      }
     }
   }
 
@@ -144,8 +397,6 @@ extension Ocp1Connection.Monitor {
             guard let self else { return }
             do {
               try await receiveMessage(connection)
-            } catch Ocp1Error.invalidHandle {
-            } catch Ocp1Error.unknownPduType {
             } catch Ocp1Error.retryOperation {}
           } while true
         }

--- a/Sources/SwiftOCA/OCP.1/Ocp1MessageBatcher.swift
+++ b/Sources/SwiftOCA/OCP.1/Ocp1MessageBatcher.swift
@@ -67,9 +67,9 @@ final class Ocp1MessageBatcher: Sendable {
     try await sendEncodedPdu(Data(encodedPdu))
   }
 
-  package func enqueue(_ message: Ocp1Message, type messageType: OcaMessageType) async throws {
+  func enqueue(_ message: some _Ocp1MessageCodable, type messageType: OcaMessageType) async throws {
     var encodedPdu = EncodedPDU()
-    try (message as! _Ocp1MessageCodable).encode(type: messageType, into: &encodedPdu)
+    try message.encode(type: messageType, into: &encodedPdu)
 
     // short-circuit, send immediately if batching is disabled
     guard dequeueInterval > .zero else {

--- a/Tests/SwiftOCATests/RequestContinuationTests.swift
+++ b/Tests/SwiftOCATests/RequestContinuationTests.swift
@@ -1,0 +1,448 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+@testable @_spi(SwiftOCAPrivate) import SwiftOCA
+import XCTest
+
+/// A connection whose transport is entirely under the test's control.
+///
+/// `connect()` is deliberately not used; the tests install a monitor directly,
+/// because what is under test is request bookkeeping rather than the connection
+/// handshake.
+private final class MockConnection: Ocp1Connection, @unchecked Sendable {
+  /// how long `write` stalls before reporting success
+  nonisolated(unsafe) var writeDelay: Duration = .zero
+  /// set when `write` is entered, so a test can tell a stalled write from one
+  /// that was never attempted
+  nonisolated(unsafe) private(set) var didAttemptWrite = false
+  nonisolated(unsafe) var writeError: (any Error)?
+
+  override nonisolated var connectionPrefix: String { "oca/mock" }
+
+  override var isDatagram: Bool { false }
+
+  override var heartbeatTime: Duration { .zero }
+
+  override func read(_ length: Int) async throws -> Data {
+    // no device on the other end: block until cancelled
+    try await Task.sleep(for: .seconds(3600))
+    throw Ocp1Error.notConnected
+  }
+
+  override func write(_ data: Data) async throws -> Int {
+    didAttemptWrite = true
+    if writeDelay > .zero {
+      try? await Task.sleep(for: writeDelay)
+    }
+    if let writeError {
+      throw writeError
+    }
+    return data.count
+  }
+}
+
+@OcaConnection
+private func makeConnection(
+  responseTimeout: Duration = .milliseconds(200)
+) -> MockConnection {
+  MockConnection(options: Ocp1ConnectionOptions(responseTimeout: responseTimeout))
+}
+
+@OcaConnection
+private func makeMonitor(_ connection: MockConnection) -> Ocp1Connection.Monitor {
+  Ocp1Connection.Monitor(connection, id: 1)
+}
+
+/// Installs a monitor without going through `connect()`, which would need a
+/// live device on the other end.
+@OcaConnection
+@discardableResult
+private func installMonitor(on connection: MockConnection) -> Ocp1Connection.Monitor {
+  let monitor = Ocp1Connection.Monitor(connection, id: 1)
+  connection.monitor = monitor
+  return monitor
+}
+
+private func makeResponse(handle: OcaUint32) -> Ocp1Response {
+  Ocp1Response(responseSize: 10, handle: handle, statusCode: .ok)
+}
+
+/// Waits for a sender to actually suspend. Sleeping a fixed interval instead
+/// would let a slow scheduler silently turn these tests into hangs.
+private func waitUntilWaiting(
+  _ monitor: Ocp1Connection.Monitor,
+  handle: OcaUint32,
+  file: StaticString = #filePath,
+  line: UInt = #line
+) async throws {
+  let deadline = ContinuousClock.now.advanced(by: .seconds(5))
+  while !monitor.isWaiting(handle: handle), ContinuousClock.now < deadline {
+    try await Task.sleep(for: .milliseconds(1))
+  }
+  XCTAssertTrue(monitor.isWaiting(handle: handle), "sender never suspended", file: file, line: line)
+}
+
+final class RequestContinuationTests: XCTestCase {
+  private static let handle: OcaUint32 = 4242
+
+  private func response(handle: OcaUint32 = RequestContinuationTests.handle) -> Ocp1Response {
+    makeResponse(handle: handle)
+  }
+
+  // MARK: - request bookkeeping
+
+  /// A response parsed before the sender suspends must be held, not dropped.
+  /// The monitor runs off `@OcaConnection`, so on a fast transport this is the
+  /// normal ordering, and dropping it stalled the caller until its timeout.
+  func testResponseArrivingBeforeSenderSuspends() async throws {
+    let connection = await makeConnection()
+    let monitor = await makeMonitor(connection)
+
+    XCTAssertTrue(monitor.claimCommandHandle(Self.handle))
+    try monitor.resume(with: response())
+
+    let received = try await monitor.response(for: Self.handle)
+    XCTAssertEqual(received.handle, Self.handle)
+    XCTAssertEqual(received.statusCode, .ok)
+  }
+
+  /// A timeout firing before the sender suspends must also be held. Previously
+  /// the sender went on to suspend on a continuation nobody would ever resume,
+  /// so the enclosing task group never drained and the call hung forever.
+  func testTimeoutFiringBeforeSenderSuspends() async throws {
+    let connection = await makeConnection()
+    let monitor = await makeMonitor(connection)
+
+    XCTAssertTrue(monitor.claimCommandHandle(Self.handle))
+    monitor.resumeTimedOut(handle: Self.handle)
+
+    do {
+      _ = try await monitor.response(for: Self.handle)
+      XCTFail("expected responseTimeout")
+    } catch Ocp1Error.responseTimeout {
+      // expected, and — critically — it returns at all
+    }
+  }
+
+  /// Ordinary ordering: the sender suspends first, the response arrives later.
+  func testResponseArrivingAfterSenderSuspends() async throws {
+    let connection = await makeConnection()
+    let monitor = await makeMonitor(connection)
+
+    XCTAssertTrue(monitor.claimCommandHandle(Self.handle))
+    async let pending = monitor.response(for: Self.handle)
+
+    try await waitUntilWaiting(monitor, handle: Self.handle)
+    try monitor.resume(with: response())
+
+    let received = try await pending
+    XCTAssertEqual(received.handle, Self.handle)
+  }
+
+  /// Only the first result is delivered; a late response for a handle that has
+  /// already timed out must not resume anything a second time.
+  func testFirstResultWins() async throws {
+    let connection = await makeConnection()
+    let monitor = await makeMonitor(connection)
+
+    XCTAssertTrue(monitor.claimCommandHandle(Self.handle))
+    monitor.resumeTimedOut(handle: Self.handle)
+    // late response for the same handle: accepted as "was outstanding", ignored
+    XCTAssertNoThrow(try monitor.resume(with: response()))
+
+    do {
+      _ = try await monitor.response(for: Self.handle)
+      XCTFail("expected responseTimeout")
+    } catch Ocp1Error.responseTimeout {}
+  }
+
+  /// A response for a handle nobody is waiting on is reported so the receive
+  /// loop can ignore it rather than treating it as a protocol error.
+  func testResponseForUnknownHandleThrowsInvalidHandle() async throws {
+    let connection = await makeConnection()
+    let monitor = await makeMonitor(connection)
+
+    XCTAssertThrowsError(try monitor.resume(with: response())) { error in
+      XCTAssertEqual(error as? Ocp1Error, .invalidHandle)
+    }
+  }
+
+  /// Withdrawing after a failed send must not leave the entry behind.
+  func testWithdrawnRequestIsNotOutstanding() async throws {
+    let connection = await makeConnection()
+    let monitor = await makeMonitor(connection)
+
+    XCTAssertTrue(monitor.claimCommandHandle(Self.handle))
+    monitor.releaseCommandHandle(Self.handle)
+
+    XCTAssertThrowsError(try monitor.resume(with: response())) { error in
+      XCTAssertEqual(error as? Ocp1Error, .invalidHandle)
+    }
+  }
+
+  /// Two requests cannot share a handle; the second must be refused rather than
+  /// overwriting the first, which would strand the first sender forever.
+  func testDuplicateWaiterIsRefused() async throws {
+    let connection = await makeConnection()
+    let monitor = await makeMonitor(connection)
+
+    XCTAssertTrue(monitor.claimCommandHandle(Self.handle))
+    async let first = monitor.response(for: Self.handle)
+    try await waitUntilWaiting(monitor, handle: Self.handle)
+
+    do {
+      _ = try await monitor.response(for: Self.handle)
+      XCTFail("expected invalidHandle")
+    } catch Ocp1Error.invalidHandle {}
+
+    // the original waiter is still intact and still resumable
+    try monitor.resume(with: response())
+    let received = try await first
+    XCTAssertEqual(received.handle, Self.handle)
+  }
+
+  /// Tearing the connection down resumes suspended senders...
+  func testStopResumesWaitingSenders() async throws {
+    let connection = await makeConnection()
+    let monitor = await makeMonitor(connection)
+
+    XCTAssertTrue(monitor.claimCommandHandle(Self.handle))
+    async let pending = monitor.response(for: Self.handle)
+    try await waitUntilWaiting(monitor, handle: Self.handle)
+
+    monitor.stop()
+
+    do {
+      _ = try await pending
+      XCTFail("expected notConnected")
+    } catch Ocp1Error.notConnected {}
+  }
+
+  /// ...and senders that have not suspended yet.
+  func testStopReleasesEnrolledSenders() async throws {
+    let connection = await makeConnection()
+    let monitor = await makeMonitor(connection)
+
+    XCTAssertTrue(monitor.claimCommandHandle(Self.handle))
+    monitor.stop()
+
+    do {
+      _ = try await monitor.response(for: Self.handle)
+      XCTFail("expected notConnected")
+    } catch Ocp1Error.notConnected {}
+  }
+
+  // MARK: - end-to-end
+
+  /// The regression that motivated the rework: when the write stalls past the
+  /// response timeout, `sendCommandRrq` must still return. Previously the
+  /// timeout had nowhere to record its result, the operation task suspended
+  /// afterwards on an orphaned continuation, and the task group never drained.
+  func testStalledWriteStillTimesOut() async throws {
+    let responseTimeout = Duration.milliseconds(200)
+    let connection = await makeConnection(responseTimeout: responseTimeout)
+    connection.writeDelay = .milliseconds(600)
+    await installMonitor(on: connection)
+
+    let command = Ocp1Command(
+      handle: Self.handle,
+      targetONo: 5000,
+      methodID: OcaMethodID("2.6")
+    )
+
+    let start = ContinuousClock.now
+    do {
+      _ = try await connection.sendCommandRrq(command)
+      XCTFail("expected responseTimeout")
+    } catch Ocp1Error.responseTimeout {}
+    let elapsed = ContinuousClock.now - start
+
+    XCTAssertTrue(connection.didAttemptWrite)
+    // must not hang: bounded by the stalled write, not by the 1h mock read
+    XCTAssertLessThan(elapsed, .seconds(5))
+  }
+
+  /// A handle that is still outstanding must not be re-enrolled: the 32-bit
+  /// wire handle wraps after 2^32 requests, and overwriting the entry would
+  /// strand the earlier sender forever.
+  func testEnrollRefusesAnOutstandingHandle() async throws {
+    let connection = await makeConnection()
+    let monitor = await makeMonitor(connection)
+
+    XCTAssertTrue(monitor.claimCommandHandle(Self.handle))
+    async let first = monitor.response(for: Self.handle)
+    try await waitUntilWaiting(monitor, handle: Self.handle)
+
+    // the collision is refused rather than clobbering the waiting sender
+    XCTAssertFalse(monitor.claimCommandHandle(Self.handle))
+
+    // ...and the original sender is still reachable
+    try monitor.resume(with: response())
+    let received = try await first
+    XCTAssertEqual(received.handle, Self.handle)
+  }
+
+  /// Re-enrolment is likewise refused while a result is parked but unclaimed.
+  func testEnrollRefusesAHandleWithAParkedResult() async throws {
+    let connection = await makeConnection()
+    let monitor = await makeMonitor(connection)
+
+    XCTAssertTrue(monitor.claimCommandHandle(Self.handle))
+    try monitor.resume(with: response())
+
+    XCTAssertFalse(monitor.claimCommandHandle(Self.handle))
+    let received = try await monitor.response(for: Self.handle)
+    XCTAssertEqual(received.handle, Self.handle)
+  }
+
+  /// Cancelling a suspended sender must resume it rather than leaving it parked
+  /// on a continuation nobody will ever resume.
+  func testCancellationResumesASuspendedSender() async throws {
+    let connection = await makeConnection()
+    let monitor = await makeMonitor(connection)
+
+    XCTAssertTrue(monitor.claimCommandHandle(Self.handle))
+    let handle = Self.handle
+    let task = Task { () async -> (any Error)? in
+      do {
+        _ = try await monitor.response(for: handle)
+        return nil
+      } catch {
+        return error
+      }
+    }
+    try await waitUntilWaiting(monitor, handle: Self.handle)
+    task.cancel()
+
+    // expected, and — critically — it returns at all
+    let error = await task.value
+    XCTAssertTrue(error is CancellationError, "expected CancellationError, got \(error as Any)")
+  }
+
+  /// Cancellation arriving before the sender suspends must also be retained.
+  func testCancellationBeforeSuspensionIsRetained() async throws {
+    let connection = await makeConnection()
+    let monitor = await makeMonitor(connection)
+
+    XCTAssertTrue(monitor.claimCommandHandle(Self.handle))
+    let handle = Self.handle
+    let task = Task { () async -> (any Error)? in
+      // already cancelled by the time the body reaches response(for:)
+      try? await Task.sleep(for: .milliseconds(200))
+      do {
+        _ = try await monitor.response(for: handle)
+        return nil
+      } catch {
+        return error
+      }
+    }
+    task.cancel()
+
+    let error = await task.value
+    XCTAssertTrue(error is CancellationError, "expected CancellationError, got \(error as Any)")
+  }
+
+  /// Teardown must not discard a response that already arrived — reporting
+  /// notConnected for a command the device completed could make a caller retry
+  /// a non-idempotent operation.
+  func testStopPreservesAnAlreadyArrivedResponse() async throws {
+    let connection = await makeConnection()
+    let monitor = await makeMonitor(connection)
+
+    XCTAssertTrue(monitor.claimCommandHandle(Self.handle))
+    try monitor.resume(with: response())
+
+    monitor.stop()
+
+    let received = try await monitor.response(for: Self.handle)
+    XCTAssertEqual(received.handle, Self.handle)
+    XCTAssertEqual(received.statusCode, .ok)
+  }
+
+  /// The sender withdraws on whichever path it exits by, so a result parked
+  /// for one that has already given up must not outlive it.
+  func testWithdrawDropsAnUncollectedResult() async throws {
+    let connection = await makeConnection()
+    let monitor = await makeMonitor(connection)
+
+    XCTAssertTrue(monitor.claimCommandHandle(Self.handle))
+    try monitor.resume(with: response())
+
+    // the send reported failure, but the device answered anyway. Its sender
+    // has thrown by now and will never collect, so the entry has to go.
+    monitor.releaseCommandHandle(Self.handle)
+
+    XCTAssertTrue(monitor.claimCommandHandle(Self.handle))
+  }
+
+  /// Withdrawing a suspended sender must not strand it either.
+  func testWithdrawDoesNotStrandASuspendedSender() async throws {
+    let connection = await makeConnection()
+    let monitor = await makeMonitor(connection)
+
+    XCTAssertTrue(monitor.claimCommandHandle(Self.handle))
+    async let pending = monitor.response(for: Self.handle)
+    try await waitUntilWaiting(monitor, handle: Self.handle)
+
+    monitor.releaseCommandHandle(Self.handle)
+
+    // still reachable, so the response can still complete it
+    try monitor.resume(with: response())
+    let received = try await pending
+    XCTAssertEqual(received.handle, Self.handle)
+  }
+
+  /// Withdrawing an enrolment nothing has touched does release it.
+  func testWithdrawClearsAPendingEnrolment() async throws {
+    let connection = await makeConnection()
+    let monitor = await makeMonitor(connection)
+
+    XCTAssertTrue(monitor.claimCommandHandle(Self.handle))
+    monitor.releaseCommandHandle(Self.handle)
+
+    // released, so the handle can be reused
+    XCTAssertTrue(monitor.claimCommandHandle(Self.handle))
+  }
+
+  /// A send that fails must surface the send error, and must not leave the
+  /// request enrolled.
+  func testFailedSendWithdrawsRequest() async throws {
+    let connection = await makeConnection(responseTimeout: .seconds(30))
+    connection.writeError = Ocp1Error.pduSendingFailed
+    await installMonitor(on: connection)
+
+    let command = Ocp1Command(
+      handle: Self.handle,
+      targetONo: 5000,
+      methodID: OcaMethodID("2.6")
+    )
+
+    do {
+      _ = try await connection.sendCommandRrq(command)
+      XCTFail("expected a send failure")
+    } catch let error as Ocp1Error {
+      XCTAssertNotEqual(error, .responseTimeout)
+    }
+
+    let outstanding = await connection.statistics.outstandingRequests
+    XCTAssertEqual(outstanding, [])
+  }
+}


### PR DESCRIPTION
sendCommandRrq registered its continuation only after the write completed, which lost results arriving in that window.

The monitor is deliberately not isolated to @OcaConnection, so on a fast transport it can decode the response concurrently with the sender, before it suspends. resume(with:) then found no continuation, threw invalidHandle, and the receive loop silently ignored it — the caller waited out the full responseTimeout for a response that had already arrived.

Worse, if the write stalled past the timeout, onTimeout also found nothing to resume and Task+Timeout swallowed the error with try?. The operation task was cancelled, but withUnsafeThrowingContinuation is not cancellation-aware: once the write finally completed the sender suspended on a continuation nobody would ever resume, and since withThrowingTaskGroup drains its children before returning, sendCommandRrq never returned at all.

Requests are now enrolled before the write, and a result arriving before the sender suspends is held rather than dropped:

  - enrol refuses a handle that is already outstanding rather than clobbering it, which would strand the earlier sender.
  - the sender owns its entry for the whole of its scope and retires it with defer, so no exit path can leak one.
  - response(for:) runs under withTaskCancellationHandler, so a cancelled sender is resumed instead of parking forever on an unsafe continuation.
  - teardown no longer discards a result that already arrived. Reporting notConnected for a command the device completed could make a caller retry a non-idempotent operation.

Note that isolating the monitor to @OcaConnection would not have avoided any of this. Actors are reentrant at every suspension point, so shared isolation excludes between awaits but not across the one this race spans; it would only serialise decoding and notification dispatch behind every other connection in the process, and force the cancellation handler — which is synchronous and non-isolated — to defer its resume to a Task.

Finally, an unmatched response no longer aborts its whole PDU. resume(with:) throws for a handle nobody is waiting on, and the receive loop processed messages in a batched PDU one after another without catching it, so a single stale response — routine once cancellation can retire a handle — discarded every sibling response behind it. The catch moves inward, next to the message it concerns, and the now-dead outer copies go.

Monitor moves to Ocp1ConnectionMonitor.swift, alongside the receiveMessages and keepAlive loops that are its only other code.


Claude-Session: https://claude.ai/code/session_018h2Hb6NqUeE5TrRSbw8cnc