### PR TITLE
Only migrate a live connection when its address is withdrawn

### DIFF
--- a/Sources/SwiftOCA/OCP.1/Ocp1Connection.swift
+++ b/Sources/SwiftOCA/OCP.1/Ocp1Connection.swift
@@ -420,6 +420,19 @@ package struct Ocp1DeviceAddressState: Sendable {
     self.connectedAddress = connectedAddress
     self.networkAddress = networkAddress
   }
+
+  /// Whether replacing the candidates with `newAddresses` requires migrating a
+  /// live connection.
+  ///
+  /// Only when the candidate actually connected to is no longer offered. A
+  /// multi-homed host advertises the same device on every interface, so the set
+  /// legitimately gains and loses *secondary* addresses while the connected one
+  /// stays reachable; migrating on those tears down a working connection, and
+  /// with `.automaticReconnect` it repeats on every advertisement.
+  package func requiresMigration(replacingWith newAddresses: [AnySocketAddress]) -> Bool {
+    guard let connectedAddress else { return true }
+    return !newAddresses.contains(connectedAddress)
+  }
 }
 
 /// A mutable connection that targets one or more resolved socket addresses (as
@@ -448,18 +461,40 @@ package extension Ocp1MutableSocketAddressConnection {
   /// The candidate device addresses, in preference order. A hostname can resolve
   /// to several addresses (e.g. an IPv4 and an IPv6 ULA) and only some may be
   /// reachable at any moment; `connectDevice()` tries them in order and connects
-  /// to the first that answers. Setting replaces the entire set; a change
-  /// re-resolves the live connection (`deviceAddressesDidChange()`), an unchanged
-  /// set is a no-op.
+  /// to the first that answers. Setting replaces the entire set; an unchanged set
+  /// is a no-op.
+  ///
+  /// A change re-resolves the live connection (`deviceAddressesDidChange()`)
+  /// only when the address actually in use is no longer among the candidates.
+  /// A multi-homed host advertises the same device on every interface, so the
+  /// candidate set legitimately gains and loses *secondary* addresses while the
+  /// connected one remains reachable; migrating on those would tear down a
+  /// working connection, and with `.automaticReconnect` it would happen again on
+  /// every subsequent advertisement.
   nonisolated var deviceAddresses: [AnySocketAddress] {
     get { _deviceAddressState.criticalValue.addresses }
     set {
-      let changed = _deviceAddressState.withLock { state -> Bool in
-        guard state.addresses != newValue else { return false }
-        state.addresses = newValue
-        return true
+      let outcome = _deviceAddressState
+        .withLock { state -> (migrate: Bool, from: [AnySocketAddress])? in
+          guard state.addresses != newValue else { return nil }
+          let previous = state.addresses
+          let migrate = state.requiresMigration(replacingWith: newValue)
+          state.addresses = newValue
+          return (migrate, previous)
+        }
+
+      guard let outcome else { return }
+
+      let from = outcome.from.map(\._presentationAddress)
+      let to = newValue.map(\._presentationAddress)
+      if outcome.migrate {
+        logger.info("device addresses changed from \(from) to \(to), migrating connection")
+        deviceAddressesDidChange()
+      } else {
+        logger.debug(
+          "device addresses changed from \(from) to \(to), keeping connection to \(_currentPresentationAddress)"
+        )
       }
-      if changed { deviceAddressesDidChange() }
     }
   }
 

--- a/Tests/SwiftOCATests/DeviceAddressMigrationTests.swift
+++ b/Tests/SwiftOCATests/DeviceAddressMigrationTests.swift
@@ -1,0 +1,86 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Android)
+import Android
+#endif
+@testable import SocketAddress
+@testable import SwiftOCA
+import Testing
+
+/// A device advertised by a multi-homed host is offered on every interface, so
+/// its candidate address set gains and loses secondary entries while the
+/// address in use stays reachable. Migrating the live connection on those
+/// changes drops a working connection, and `.automaticReconnect` then repeats
+/// it on the next advertisement.
+@Suite
+struct DeviceAddressMigrationTests {
+  static func address(_ presentation: String) throws -> AnySocketAddress {
+    try AnySocketAddress(family: sockaddr_in.family, presentationAddress: presentation)
+  }
+
+  @Test
+  func migratesWhenTheConnectedAddressIsWithdrawn() throws {
+    let a = try Self.address("10.10.32.3")
+    let b = try Self.address("10.10.33.252")
+    let state = Ocp1DeviceAddressState(addresses: [a], connectedAddress: a)
+
+    #expect(state.requiresMigration(replacingWith: [b]))
+  }
+
+  @Test
+  func doesNotMigrateWhenASecondaryAddressIsAdded() throws {
+    let a = try Self.address("10.10.32.3")
+    let b = try Self.address("10.10.33.252")
+    let state = Ocp1DeviceAddressState(addresses: [a], connectedAddress: a)
+
+    #expect(!state.requiresMigration(replacingWith: [a, b]))
+  }
+
+  @Test
+  func doesNotMigrateWhenASecondaryAddressIsWithdrawn() throws {
+    let a = try Self.address("10.10.32.3")
+    let b = try Self.address("10.10.33.252")
+    let state = Ocp1DeviceAddressState(addresses: [a, b], connectedAddress: a)
+
+    #expect(!state.requiresMigration(replacingWith: [a]))
+  }
+
+  @Test
+  func doesNotMigrateWhenOnlyThePreferenceOrderChanges() throws {
+    let a = try Self.address("10.10.32.3")
+    let b = try Self.address("10.10.33.252")
+    // connected to the non-preferred candidate, as happens when the preferred
+    // one was unreachable at connect time
+    let state = Ocp1DeviceAddressState(addresses: [a, b], connectedAddress: b)
+
+    #expect(!state.requiresMigration(replacingWith: [b, a]))
+  }
+
+  @Test
+  func migratesWhileDisconnected() throws {
+    // nothing to preserve: the decision is left to deviceAddressesDidChange(),
+    // which no-ops unless a connection is live
+    let a = try Self.address("10.10.32.3")
+    let state = Ocp1DeviceAddressState(addresses: [a], connectedAddress: nil)
+
+    #expect(state.requiresMigration(replacingWith: [try Self.address("10.10.33.252")]))
+  }
+}


### PR DESCRIPTION
## Problem

A device advertised by a multi-homed host is offered on every interface, so the candidate address set for one `DeviceIdentifier` gains and loses secondary entries as mDNS records appear and expire — while the address actually in use stays perfectly reachable.

`deviceAddresses` migrated the live connection on *any* change to the set. With `.automaticReconnect` that repeats on every advertisement, so the device sees a rolling add/remove of controllers and eventually times the abandoned sockets out (`responseTimeout` → `controller removed`), while the controller side reports `no heartbeat packet received`.

Sorting the candidates already stopped resolver *reordering* from looking like a change. This covers the remaining case: membership genuinely changes, but the connected candidate survives it.

## Change

- `Ocp1DeviceAddressState.requiresMigration(replacingWith:)` — `true` only when the connected candidate is absent from the new set. With no connected candidate it stays `true`, preserving today's behaviour, since `deviceAddressesDidChange()` already no-ops while disconnected.
- The `deviceAddresses` setter consults it, so a set change that still offers the connected address updates the candidates without tearing the connection down.
- Both outcomes are logged (`info` when migrating, `debug` when keeping). The flap has so far only been observable through its downstream reconnects.

## Tests

Five cases over the decision itself: connected address withdrawn → migrate; secondary added / secondary withdrawn / preference order changed → don't; disconnected → migrate. Full suite green (235 XCTest, 17 swift-testing, 0 failures).

## Caveat

The address flap was **diagnosed from code, not reproduced**. It fits the observed evidence — a multi-homed host (`en0`/`en1` plus loopback) advertising one device on four interfaces, controllers rolling between `10.10.32.3` and `127.0.0.1`, while single-homed hardware held one stable connection — but I never caught the set changing live. The new `info` log is what settles that: if it never prints when the churn recurs, the cause is elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xu9b2gG853E9NZYpTYZMHT