### PR TITLE
Roll back the local subscription entry when AddSubscription fails

### DIFF
--- a/Sources/SwiftOCA/OCP.1/Ocp1Connection+Subscribe.swift
+++ b/Sources/SwiftOCA/OCP.1/Ocp1Connection+Subscribe.swift
@@ -92,15 +92,27 @@ public extension Ocp1Connection {
     } else {
       let eventSubscriptions = EventSubscriptions()
       eventSubscriptions.subscriptions.insert(cancellable)
+      // inserted before the await so concurrent callers coalesce onto this
+      // subscription rather than each issuing their own
       subscriptions[event] = eventSubscriptions
 
-      try await subscriptionManager.addSubscription(
-        event: event,
-        subscriber: subscriber,
-        subscriberContext: OcaBlob(),
-        notificationDeliveryMode: .normal,
-        destinationInformation: OcaNetworkAddress()
-      )
+      do {
+        try await subscriptionManager.addSubscription(
+          event: event,
+          subscriber: subscriber,
+          subscriberContext: OcaBlob(),
+          notificationDeliveryMode: .normal,
+          destinationInformation: OcaNetworkAddress()
+        )
+      } catch {
+        // roll back, otherwise isSubscribed(event:) reports true with nothing
+        // registered on the device and callers never retry
+        eventSubscriptions.subscriptions.remove(cancellable)
+        if eventSubscriptions.subscriptions.isEmpty {
+          subscriptions[event] = nil
+        }
+        throw error
+      }
       logger.trace("addSubscription: added new OCA subscription for \(event)")
     }
     logger.trace("addSubscription: added \(cancellable) to subscription set")


### PR DESCRIPTION
## Problem

`addSubscription()` inserts into `subscriptions[event]` *before* awaiting the device-side `AddSubscription`, so concurrent callers coalesce onto one subscription instead of each issuing their own. If that call throws, the entry is left behind.

The connection then reports `isSubscribed(event:) == true` with nothing registered on the device. `OcaRoot.subscribe()` short-circuits on an existing subscription, so the object never retries — every property fed by that event goes quiet for the life of the connection, and nothing surfaces the failure: `_getValue()` drives `subscribe()` from an unstructured `Task { }` and discards the result.

## Change

Remove the cancellable on failure, and drop the event entry if it was the only one, so a later `subscribe()` starts cleanly. The pre-await insert is kept — the coalescing it provides is deliberate — and now carries a comment saying so.

## Testing

Full suite passes (235 tests, 0 failures).

I have **not** added a regression test. Reproducing it needs a connection whose `AddSubscription` fails while the transport stays usable; the in-process `OcaLocalDeviceEndpoint` harness I tried could not issue commands at all after a disconnect/connect cycle, so any test built on it asserted the wrong thing. The change is argued from inspection rather than demonstrated, and is worth review on that basis.

## Related, not included

While reviewing the reconnect/subscription interaction I also found that `disconnect()` clears the connection's subscription map without clearing each `OcaRoot.subscriptionCancellable`. With `.retainObjectCacheAfterDisconnect`, retained objects keep a cancellable the connection no longer holds, and `subscribe()`'s `guard subscriptionCancellable == nil` makes every later re-subscribe a no-op.

A scratch probe showed re-registration recovering when both gates validate the cancellable against `Ocp1Connection.isSubscribed(_ cancellable:)`, but I could not build a sound test for it on the same harness, so it is deliberately left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPFwV6nUMuFm6tMZNne2dN