### PR TITLE
Re-register a subscription the connection no longer holds

### DIFF
--- a/Sources/SwiftOCA/OCC/ControlClasses/Root.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Root.swift
@@ -258,8 +258,12 @@ public extension OcaRoot {
 
   @OcaConnection
   func subscribe() async throws {
-    guard subscriptionCancellable == nil else { return } // already subscribed
     guard let connectionDelegate else { throw Ocp1Error.noConnectionDelegate }
+    if let subscriptionCancellable, connectionDelegate.isSubscribed(subscriptionCancellable) {
+      return // already subscribed
+    }
+    // a cancellable the connection no longer holds is stale; re-register
+    subscriptionCancellable = nil
     let event = OcaEvent(emitterONo: objectNumber, eventID: OcaPropertyChangedEventID)
     do {
       subscriptionCancellable = try await connectionDelegate.addSubscription(
@@ -301,10 +305,12 @@ public extension OcaRoot {
 
   internal var isSubscribed: Bool {
     get async throws {
-      guard connectionDelegate != nil else { throw Ocp1Error.noConnectionDelegate }
-      // this object's own handler, not the connection's: another component's
-      // subscription to the same event doesn't feed our property subjects
-      return subscriptionCancellable != nil
+      guard let connectionDelegate else { throw Ocp1Error.noConnectionDelegate }
+      // this object's own live registration: another component's handler
+      // doesn't feed our property subjects, and a cancellable the connection
+      // has dropped is stale
+      guard let subscriptionCancellable else { return false }
+      return await connectionDelegate.isSubscribed(subscriptionCancellable)
     }
   }
 

--- a/Tests/SwiftOCADeviceTests/PropertySubscriptionTests.swift
+++ b/Tests/SwiftOCADeviceTests/PropertySubscriptionTests.swift
@@ -162,4 +162,52 @@ final class PropertySubscriptionTests: XCTestCase {
 
     try await harness.connection.disconnect()
   }
+
+  /// disconnect() empties the connection's subscription map without clearing
+  /// each object's cancellable. With .retainObjectCacheAfterDisconnect the
+  /// object survives holding one the connection no longer has; treating that as
+  /// "already subscribed" makes every later subscribe() a permanent no-op.
+  ///
+  /// Asserts on the connection, not the object's own isSubscribed, which is the
+  /// stale value under test.
+  func testObjectReRegistersAfterConnectionDroppedItsSubscription() async throws {
+    let harness = try await makeHarness()
+    defer { harness.endpointTask.cancel() }
+
+    let objectNumber: OcaONo = 0x0001_0003
+    let event = OcaEvent(emitterONo: objectNumber, eventID: OcaPropertyChangedEventID)
+    let (_, clientBlock) = try await makeBlockPair(
+      harness, objectNumber: objectNumber, role: "Retained"
+    )
+
+    await clientBlock.$label.subscribe(clientBlock)
+    let subscribed = await awaitConnectionSubscription(harness, event)
+    XCTAssertTrue(subscribed, "precondition: object should have subscribed")
+    // isSubscribed(event:) goes true when the entry is inserted, which is before
+    // the device-side AddSubscription completes; let it land before tearing down
+    try await Task.sleep(for: .milliseconds(300))
+
+    await harness.connection.removeSubscriptions()
+    let cleared = await harness.connection.isSubscribed(event: event)
+    XCTAssertFalse(cleared, "precondition: subscription map should be empty")
+
+    await clientBlock.$label.subscribe(clientBlock)
+    let reRegistered = await awaitConnectionSubscription(harness, event)
+    XCTAssertTrue(
+      reRegistered,
+      "object did not re-register after the connection dropped its subscription"
+    )
+  }
+
+  /// Waits until the connection holds a subscription for `event`.
+  private func awaitConnectionSubscription(
+    _ harness: Harness, _ event: OcaEvent, timeout: Duration = .seconds(5)
+  ) async -> Bool {
+    let deadline = ContinuousClock.now + timeout
+    while ContinuousClock.now < deadline {
+      if await harness.connection.isSubscribed(event: event) { return true }
+      try? await Task.sleep(for: .milliseconds(25))
+    }
+    return await harness.connection.isSubscribed(event: event)
+  }
 }


### PR DESCRIPTION
## Problem

`disconnect()` calls `removeSubscriptions()`, which empties the connection's subscription map. Nothing clears each `OcaRoot`'s `subscriptionCancellable`, so with `.retainObjectCacheAfterDisconnect` the object survives holding a cancellable the connection has dropped.

`subscribe()` guarded on `subscriptionCancellable == nil` and so treated that stale token as "already subscribed". The object could then never re-register for the life of the process — the device delivers nothing (its subscription was removed), and the connection would drop any notification anyway since it has no handler for the event. `isSubscribed` had the same flaw, so `_getValue()` wouldn't even attempt a re-subscribe.

Because explicit disconnect deliberately drops subscriptions, lazy re-subscribe is the intended recovery — which is exactly what this defeats. The automatic-reconnect path is unaffected: it retains the map and re-adds via `refreshSubscriptions()`.

## Change

Both gates now test the cancellable against what the connection actually holds, using the existing `isSubscribed(_ cancellable:)`.

## Testing

New `testObjectReRegistersAfterConnectionDroppedItsSubscription`: subscribe, drop the connection's map as `disconnect()` does, subscribe again, and assert the connection holds a subscription again. Passes with the change (0.34s), fails without it (times out). Full suite: 236 tests, 0 failures.

The test asserts on `Ocp1Connection.isSubscribed(event:)` rather than the object's own `isSubscribed`, since the latter is the stale value under test.

## Note on timing

`addSubscription()` inserts into the map before awaiting the device-side `AddSubscription` (deliberate — it coalesces concurrent callers). `isSubscribed(event:)` therefore reports true before the device has confirmed. The test sleeps briefly after the initial subscribe so teardown doesn't race an in-flight add; worth knowing if you write similar tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPFwV6nUMuFm6tMZNne2dN