### PR TITLE
Represent non-finite numbers in JSON as strings

### DIFF
--- a/Sources/SwiftOCA/OCC/ControlClasses/Root+JSON.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Root+JSON.swift
@@ -52,11 +52,20 @@ package func _jsonDecoder() -> JSONDecoder {
 }
 
 /// A non-finite number in a hand-built JSON container bypasses JSONEncoder;
-/// replace it with its .convertFromString spelling.
+/// replace it (recursing through containers) with its .convertFromString
+/// spelling.
 package func _jsonNonFiniteSafe(_ value: any Sendable) -> any Sendable {
-  guard let float = value as? any BinaryFloatingPoint, !float.isFinite else { return value }
-  if float.isNaN { return _jsonNaN }
-  return float.sign == .minus ? _jsonNegativeInfinity : _jsonPositiveInfinity
+  switch value {
+  case let float as any BinaryFloatingPoint where !float.isFinite:
+    if float.isNaN { return _jsonNaN }
+    return float.sign == .minus ? _jsonNegativeInfinity : _jsonPositiveInfinity
+  case let array as [any Sendable]:
+    return array.map { _jsonNonFiniteSafe($0) }
+  case let dictionary as [String: any Sendable]:
+    return dictionary.mapValues { _jsonNonFiniteSafe($0) }
+  default:
+    return value
+  }
 }
 
 /// Re-encode `value` for a *typed* destination: non-finite numbers round-trip

--- a/Sources/SwiftOCA/OCC/ControlClasses/Root+JSON.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Root+JSON.swift
@@ -25,34 +25,53 @@ import Foundation
 /// JSON has no encoding for non-finite numbers, and on Darwin one reaching
 /// NSJSONSerialization raises an unrecoverable ObjC exception. Spell them the
 /// way JSONDecoder's .convertFromString accepts, so they survive a round-trip.
-package let _nonConformingFloatEncodingStrategy = JSONEncoder.NonConformingFloatEncodingStrategy
-  .convertToString(positiveInfinity: "Infinity", negativeInfinity: "-Infinity", nan: "NaN")
+private let _jsonPositiveInfinity = "Infinity"
+private let _jsonNegativeInfinity = "-Infinity"
+private let _jsonNaN = "NaN"
 
-package let _nonConformingFloatDecodingStrategy = JSONDecoder.NonConformingFloatDecodingStrategy
-  .convertFromString(positiveInfinity: "Infinity", negativeInfinity: "-Infinity", nan: "NaN")
+/// A JSONEncoder that spells non-finite numbers as strings.
+package func _jsonEncoder() -> JSONEncoder {
+  let encoder = JSONEncoder()
+  encoder.nonConformingFloatEncodingStrategy = .convertToString(
+    positiveInfinity: _jsonPositiveInfinity,
+    negativeInfinity: _jsonNegativeInfinity,
+    nan: _jsonNaN
+  )
+  return encoder
+}
+
+/// A JSONDecoder that revives `_jsonEncoder()`'s non-finite spellings.
+package func _jsonDecoder() -> JSONDecoder {
+  let decoder = JSONDecoder()
+  decoder.nonConformingFloatDecodingStrategy = .convertFromString(
+    positiveInfinity: _jsonPositiveInfinity,
+    negativeInfinity: _jsonNegativeInfinity,
+    nan: _jsonNaN
+  )
+  return decoder
+}
 
 /// A non-finite number in a hand-built JSON container bypasses JSONEncoder;
 /// replace it with its .convertFromString spelling.
 package func _jsonNonFiniteSafe(_ value: any Sendable) -> any Sendable {
   guard let float = value as? any BinaryFloatingPoint, !float.isFinite else { return value }
-  if float.isNaN { return "NaN" }
-  return float.sign == .minus ? "-Infinity" : "Infinity"
+  if float.isNaN { return _jsonNaN }
+  return float.sign == .minus ? _jsonNegativeInfinity : _jsonPositiveInfinity
 }
 
-package extension JSONEncoder {
-  func reencodeAsValidJSONObject<Value: Codable>(_ value: some Codable) throws -> Value {
-    nonConformingFloatEncodingStrategy = _nonConformingFloatEncodingStrategy
-    let decoder = JSONDecoder()
-    decoder.nonConformingFloatDecodingStrategy = _nonConformingFloatDecodingStrategy
-    let data = try encode(value)
-    return try decoder.decode(Value.self, from: data)
-  }
+/// Re-encode `value` for a *typed* destination: non-finite numbers round-trip
+/// through their string spelling back to real floats, so the result is NOT
+/// necessarily valid for a JSONSerialization container — use the untyped
+/// overload when the destination is one.
+package func reencodeAsValidJSONObject<Value: Codable>(_ value: some Codable) throws -> Value {
+  try _jsonDecoder().decode(Value.self, from: _jsonEncoder().encode(value))
+}
 
-  func reencodeAsValidJSONObject(_ value: some Codable) throws -> any Sendable {
-    nonConformingFloatEncodingStrategy = _nonConformingFloatEncodingStrategy
-    let data = try encode(value)
-    return try JSONDecoder().decode(AnyDecodable.self, from: data).value as! any Sendable
-  }
+/// Re-encode `value` into JSONSerialization-safe types; non-finite numbers
+/// come back as their string spelling.
+package func reencodeAsValidJSONObject(_ value: some Codable) throws -> any Sendable {
+  try JSONDecoder().decode(AnyDecodable.self, from: _jsonEncoder().encode(value))
+    .value as! any Sendable
 }
 
 enum OcaJSONPropertyKeys: String {

--- a/Sources/SwiftOCA/OCC/ControlClasses/Root+JSON.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Root+JSON.swift
@@ -22,13 +22,34 @@ import FoundationEssentials
 import Foundation
 #endif
 
+/// JSON has no encoding for non-finite numbers, and on Darwin one reaching
+/// NSJSONSerialization raises an unrecoverable ObjC exception. Spell them the
+/// way JSONDecoder's .convertFromString accepts, so they survive a round-trip.
+package let _nonConformingFloatEncodingStrategy = JSONEncoder.NonConformingFloatEncodingStrategy
+  .convertToString(positiveInfinity: "Infinity", negativeInfinity: "-Infinity", nan: "NaN")
+
+package let _nonConformingFloatDecodingStrategy = JSONDecoder.NonConformingFloatDecodingStrategy
+  .convertFromString(positiveInfinity: "Infinity", negativeInfinity: "-Infinity", nan: "NaN")
+
+/// A non-finite number in a hand-built JSON container bypasses JSONEncoder;
+/// replace it with its .convertFromString spelling.
+package func _jsonNonFiniteSafe(_ value: any Sendable) -> any Sendable {
+  guard let float = value as? any BinaryFloatingPoint, !float.isFinite else { return value }
+  if float.isNaN { return "NaN" }
+  return float.sign == .minus ? "-Infinity" : "Infinity"
+}
+
 package extension JSONEncoder {
   func reencodeAsValidJSONObject<Value: Codable>(_ value: some Codable) throws -> Value {
+    nonConformingFloatEncodingStrategy = _nonConformingFloatEncodingStrategy
+    let decoder = JSONDecoder()
+    decoder.nonConformingFloatDecodingStrategy = _nonConformingFloatDecodingStrategy
     let data = try encode(value)
-    return try JSONDecoder().decode(Value.self, from: data)
+    return try decoder.decode(Value.self, from: data)
   }
 
   func reencodeAsValidJSONObject(_ value: some Codable) throws -> any Sendable {
+    nonConformingFloatEncodingStrategy = _nonConformingFloatEncodingStrategy
     let data = try encode(value)
     return try JSONDecoder().decode(AnyDecodable.self, from: data).value as! any Sendable
   }

--- a/Sources/SwiftOCA/OCC/ControlClasses/Root.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Root.swift
@@ -358,7 +358,7 @@ public extension OcaRoot {
       let jsonValue: any Sendable = if JSONSerialization.isValidJSONObject(value) {
         value
       } else {
-        try JSONEncoder().reencodeAsValidJSONObject(value)
+        try reencodeAsValidJSONObject(value)
       }
       return try [keyPath.jsonKey: jsonValue]
     }

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/BlocksAndMatrices/Matrix.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/BlocksAndMatrices/Matrix.swift
@@ -110,8 +110,7 @@ Sendable {
   ) async -> [String: any Sendable] {
     var jsonObject = await super.getJsonValue(flags: flags)
     let membersJson = try? await resolveMembers().map(defaultValue: nil, \.?.objectNumber)
-    jsonObject[OcaJSONPropertyKeys.members.rawValue] = try? JSONEncoder()
-      .reencodeAsValidJSONObject(membersJson)
+    jsonObject[OcaJSONPropertyKeys.members.rawValue] = try? reencodeAsValidJSONObject(membersJson)
     return jsonObject
   }
   #endif

--- a/Sources/SwiftOCA/OCC/PropertyTypes/BoundedProperty.swift
+++ b/Sources/SwiftOCA/OCC/PropertyTypes/BoundedProperty.swift
@@ -199,10 +199,11 @@ public struct OcaBoundedProperty<
   ) async throws -> [String: any Sendable] {
     let value = try await _getValue(object, flags: flags)
     let jsonKey = try keyPath.jsonKey
+    // a gain's range is commonly bounded by -inf dB, which JSON cannot encode
     return [
-      "Min\(jsonKey)": value.minValue,
-      "Max\(jsonKey)": value.maxValue,
-      "\(jsonKey)": value.value,
+      "Min\(jsonKey)": _jsonNonFiniteSafe(value.minValue),
+      "Max\(jsonKey)": _jsonNonFiniteSafe(value.maxValue),
+      "\(jsonKey)": _jsonNonFiniteSafe(value.value),
     ]
   }
   #endif

--- a/Sources/SwiftOCA/OCC/PropertyTypes/Property.swift
+++ b/Sources/SwiftOCA/OCC/PropertyTypes/Property.swift
@@ -459,7 +459,7 @@ public struct OcaProperty<Value: Codable & Sendable>: Codable, Sendable,
     } else if JSONSerialization.isValidJSONObject(value) {
       value
     } else {
-      try JSONEncoder().reencodeAsValidJSONObject(value)
+      try reencodeAsValidJSONObject(value)
     }
 
     return try [keyPath.jsonKey: jsonValue]

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Root.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Root.swift
@@ -391,7 +391,8 @@ open class OcaRoot: CustomStringConvertible, Codable, Sendable, _OcaObjectKeyPat
         case .ignore:
           continue
         case let .replace(newValue):
-          dict[property.propertyID.description] = newValue
+          // a caller-supplied replacement bypasses getJsonValue's sanitization
+          dict[property.propertyID.description] = _jsonNonFiniteSafe(newValue)
           continue
         }
       }

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/BlocksAndMatrices/Matrix.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/BlocksAndMatrices/Matrix.swift
@@ -425,7 +425,7 @@ open class OcaMatrix<Member: OcaRoot>: OcaWorker {
 
     let membersJson = members.map(defaultValue: nil, \.?.objectNumber)
     do {
-      jsonObject["3.5"] = try JSONEncoder().reencodeAsValidJSONObject(membersJson)
+      jsonObject["3.5"] = try reencodeAsValidJSONObject(membersJson)
     } catch {
       guard flags.contains(.ignoreEncodingErrors) else {
         throw error

--- a/Sources/SwiftOCADevice/OCC/PropertyTypes/BoundedDeviceProperty.swift
+++ b/Sources/SwiftOCADevice/OCC/PropertyTypes/BoundedDeviceProperty.swift
@@ -95,9 +95,7 @@ public struct OcaBoundedDeviceProperty<
       valueDict = dict
     } else if JSONSerialization.isValidJSONObject(jsonValue) {
       let data = try JSONSerialization.data(withJSONObject: jsonValue)
-      let decoder = JSONDecoder()
-      decoder.nonConformingFloatDecodingStrategy = _nonConformingFloatDecodingStrategy
-      valueDict = try decoder.decode([String: Value].self, from: data)
+      valueDict = try _jsonDecoder().decode([String: Value].self, from: data)
     } else {
       throw Ocp1Error.status(.badFormat)
     }
@@ -111,6 +109,12 @@ public struct OcaBoundedDeviceProperty<
           lowerBound <= upperBound
     else {
       throw Ocp1Error.status(.badFormat)
+    }
+
+    // matches the OCP.1 set path's _validate: reject a current value outside
+    // the incoming bounds (this also rejects NaN, which fails every comparison)
+    guard value >= lowerBound, value <= upperBound else {
+      throw Ocp1Error.status(.parameterOutOfRange)
     }
 
     await setAndNotifySubscribers(

--- a/Sources/SwiftOCADevice/OCC/PropertyTypes/BoundedDeviceProperty.swift
+++ b/Sources/SwiftOCADevice/OCC/PropertyTypes/BoundedDeviceProperty.swift
@@ -70,10 +70,11 @@ public struct OcaBoundedDeviceProperty<
 
   #if NonEmbeddedBuild
   func getJsonValue() throws -> any Sendable {
-    let valueDict: [String: Value] =
-      ["v": storage.subject.value.value,
-       "l": storage.subject.value.range.lowerBound,
-       "u": storage.subject.value.range.upperBound]
+    // a gain's range is commonly bounded by -inf dB, which JSON cannot encode
+    let valueDict: [String: any Sendable] =
+      ["v": _jsonNonFiniteSafe(storage.subject.value.value),
+       "l": _jsonNonFiniteSafe(storage.subject.value.range.lowerBound),
+       "u": _jsonNonFiniteSafe(storage.subject.value.range.upperBound)]
 
     return valueDict
   }
@@ -94,7 +95,9 @@ public struct OcaBoundedDeviceProperty<
       valueDict = dict
     } else if JSONSerialization.isValidJSONObject(jsonValue) {
       let data = try JSONSerialization.data(withJSONObject: jsonValue)
-      valueDict = try JSONDecoder().decode([String: Value].self, from: data)
+      let decoder = JSONDecoder()
+      decoder.nonConformingFloatDecodingStrategy = _nonConformingFloatDecodingStrategy
+      valueDict = try decoder.decode([String: Value].self, from: data)
     } else {
       throw Ocp1Error.status(.badFormat)
     }

--- a/Sources/SwiftOCADevice/OCC/PropertyTypes/DeviceProperty.swift
+++ b/Sources/SwiftOCADevice/OCC/PropertyTypes/DeviceProperty.swift
@@ -242,7 +242,9 @@ public struct OcaDeviceProperty<Value: Codable & Sendable>: OcaDevicePropertyRep
         // (e.g. NSDictionary/NSArray from a JSONSerialization round-trip that
         // doesn't conform to Codable) — serialize to JSON data then decode
         let data = try JSONSerialization.data(withJSONObject: jsonValue)
-        let decoded = try JSONDecoder().decode(Value.self, from: data)
+        let decoder = JSONDecoder()
+        decoder.nonConformingFloatDecodingStrategy = _nonConformingFloatDecodingStrategy
+        let decoded = try decoder.decode(Value.self, from: data)
         await setAndNotifySubscribers(object: object, decoded)
       } else if Value.self is any RawRepresentable.Type,
                 let jsonValue = jsonValue as? Int

--- a/Sources/SwiftOCADevice/OCC/PropertyTypes/DeviceProperty.swift
+++ b/Sources/SwiftOCADevice/OCC/PropertyTypes/DeviceProperty.swift
@@ -156,7 +156,7 @@ public struct OcaDeviceProperty<Value: Codable & Sendable>: OcaDevicePropertyRep
     } else if JSONSerialization.isValidJSONObject(subject.value) {
       subject.value
     } else {
-      try JSONEncoder().reencodeAsValidJSONObject(subject.value)
+      try reencodeAsValidJSONObject(subject.value)
     }
 
     return jsonValue
@@ -230,21 +230,24 @@ public struct OcaDeviceProperty<Value: Codable & Sendable>: OcaDevicePropertyRep
       {
         // Value is a JSON-native type (e.g. dictionary, array) — direct cast
         await setAndNotifySubscribers(object: object, newValue)
+      } else if let string = jsonValue as? String {
+        // Darwin's JSONSerialization yields fragments as NSString, which does
+        // not cast to Codable; round-trip explicitly so a saved "Infinity" or
+        // "NaN" scalar restores to its float value
+        try await setAndNotifySubscribers(object: object, reencodeAsValidJSONObject(string))
       } else if let codableValue = jsonValue as? Codable {
         // Value is a non-JSON Codable type and input conforms to Codable —
         // round-trip through JSONEncoder to decode as Value
         try await setAndNotifySubscribers(
           object: object,
-          JSONEncoder().reencodeAsValidJSONObject(codableValue)
+          reencodeAsValidJSONObject(codableValue)
         )
       } else if JSONSerialization.isValidJSONObject(jsonValue) {
         // Value is a non-JSON Codable type and input is a Foundation container
         // (e.g. NSDictionary/NSArray from a JSONSerialization round-trip that
         // doesn't conform to Codable) — serialize to JSON data then decode
         let data = try JSONSerialization.data(withJSONObject: jsonValue)
-        let decoder = JSONDecoder()
-        decoder.nonConformingFloatDecodingStrategy = _nonConformingFloatDecodingStrategy
-        let decoded = try decoder.decode(Value.self, from: data)
+        let decoded = try _jsonDecoder().decode(Value.self, from: data)
         await setAndNotifySubscribers(object: object, decoded)
       } else if Value.self is any RawRepresentable.Type,
                 let jsonValue = jsonValue as? Int
@@ -254,7 +257,7 @@ public struct OcaDeviceProperty<Value: Codable & Sendable>: OcaDevicePropertyRep
         // bridge to Int
         try await setAndNotifySubscribers(
           object: object,
-          JSONEncoder().reencodeAsValidJSONObject(jsonValue)
+          reencodeAsValidJSONObject(jsonValue)
         )
       } else {
         guard let newValue = jsonValue as? Value else {

--- a/Tests/SwiftOCADeviceTests/NonFiniteDatasetTests.swift
+++ b/Tests/SwiftOCADeviceTests/NonFiniteDatasetTests.swift
@@ -1,0 +1,126 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+@_spi(SwiftOCAPrivate) import SwiftOCA
+@testable import SwiftOCADevice
+import XCTest
+
+private final class FloatWorker: SwiftOCADevice.OcaWorker {
+  @OcaDeviceProperty(
+    propertyID: OcaPropertyID("5.1"),
+    getMethodID: OcaMethodID("5.1"),
+    setMethodID: OcaMethodID("5.2")
+  )
+  var level: OcaFloat32 = 0
+}
+
+/// A dataset holding non-finite numbers (a gain bounded by -inf dB) must both
+/// serialize without crashing NSJSONSerialization and restore to the same
+/// values — including after a JSONSerialization round-trip, which on Darwin
+/// hands values back as NSString/NSNumber.
+final class NonFiniteDatasetTests: XCTestCase {
+  private let gainPropertyKey = "4.1"
+  private let levelPropertyKey = "5.1"
+
+  func testBoundedNonFiniteValuesRoundTrip() async throws {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    let gain = try await SwiftOCADevice.OcaGain(
+      role: "Gain",
+      deviceDelegate: device,
+      addToRootBlock: false
+    )
+
+    var json = try await gain.serialize()
+    json[gainPropertyKey] = ["v": "-Infinity", "l": "-Infinity", "u": OcaDB(20)] as [String: any Sendable]
+    try await gain.deserialize(jsonObject: json)
+
+    var value = await gain.gain
+    XCTAssertEqual(value.value, -.infinity)
+    XCTAssertEqual(value.range, -OcaDB.infinity...20)
+
+    // the reserialized form spells the non-finite values as strings and
+    // survives NSJSONSerialization, unlike the raw floats it round-trips
+    let reserialized = try await gain.serialize()
+    XCTAssertTrue(JSONSerialization.isValidJSONObject(reserialized))
+    let bounded = reserialized[gainPropertyKey] as? [String: Any]
+    XCTAssertEqual(bounded?["v"] as? String, "-Infinity")
+    XCTAssertEqual(bounded?["l"] as? String, "-Infinity")
+    XCTAssertEqual(bounded?["u"] as? OcaDB, 20)
+
+    // restore from the wire format: on Darwin JSONSerialization yields
+    // NSString/NSNumber values, the exact shapes the restore path must accept
+    let data = try JSONSerialization.data(withJSONObject: reserialized)
+    let decoded = try JSONSerialization.jsonObject(with: data) as! [String: Sendable]
+    try await gain.deserialize(jsonObject: decoded)
+
+    value = await gain.gain
+    XCTAssertEqual(value.value, -.infinity)
+    XCTAssertEqual(value.range, -OcaDB.infinity...20)
+  }
+
+  func testBoundedRestoreRejectsOutOfRangeValue() async throws {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    let gain = try await SwiftOCADevice.OcaGain(
+      role: "Gain",
+      deviceDelegate: device,
+      addToRootBlock: false
+    )
+
+    var json = try await gain.serialize()
+    json[gainPropertyKey] = ["v": OcaDB(100), "l": OcaDB(0), "u": OcaDB(10)] as [String: any Sendable]
+    do {
+      try await gain.deserialize(jsonObject: json)
+      XCTFail("expected out-of-range value to be rejected")
+    } catch Ocp1Error.status(.parameterOutOfRange) {}
+
+    json[gainPropertyKey] = ["v": "NaN", "l": OcaDB(0), "u": OcaDB(10)] as [String: any Sendable]
+    do {
+      try await gain.deserialize(jsonObject: json)
+      XCTFail("expected NaN value to be rejected")
+    } catch Ocp1Error.status(.parameterOutOfRange) {}
+  }
+
+  func testScalarNonFiniteValueRoundTrips() async throws {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    let worker = try await FloatWorker(
+      role: "Worker",
+      deviceDelegate: device,
+      addToRootBlock: false
+    )
+
+    var json = try await worker.serialize()
+    json[levelPropertyKey] = "NaN"
+    try await worker.deserialize(jsonObject: json)
+    var level = await worker.level
+    XCTAssertTrue(level.isNaN)
+
+    let reserialized = try await worker.serialize()
+    XCTAssertTrue(JSONSerialization.isValidJSONObject(reserialized))
+    XCTAssertEqual(reserialized[levelPropertyKey] as? String, "NaN")
+
+    // a saved scalar fragment must restore after the NSString round-trip that
+    // previously fell through every branch of set(object:jsonValue:device:)
+    let data = try JSONSerialization.data(withJSONObject: reserialized)
+    let decoded = try JSONSerialization.jsonObject(with: data) as! [String: Sendable]
+    try await worker.deserialize(jsonObject: decoded)
+    level = await worker.level
+    XCTAssertTrue(level.isNaN)
+  }
+}

--- a/Tests/SwiftOCATests/JSONNonFiniteTests.swift
+++ b/Tests/SwiftOCATests/JSONNonFiniteTests.swift
@@ -31,6 +31,17 @@ struct JSONNonFiniteTests {
   }
 
   @Test
+  func containersAreSanitizedRecursively() {
+    let sanitized = _jsonNonFiniteSafe(
+      ["bounds": [-Float.infinity, Float(20)] as [any Sendable]] as [String: any Sendable]
+    )
+    #expect(JSONSerialization.isValidJSONObject(sanitized))
+    let bounds = (sanitized as? [String: any Sendable])?["bounds"] as? [any Sendable]
+    #expect(bounds?.first as? String == "-Infinity")
+    #expect(bounds?.last as? Float == 20)
+  }
+
+  @Test
   func finiteValuesPassThroughUnchanged() {
     #expect(_jsonNonFiniteSafe(Float(-10)) as? Float == -10)
     #expect(_jsonNonFiniteSafe(OcaUint16(42)) as? OcaUint16 == 42)

--- a/Tests/SwiftOCATests/JSONNonFiniteTests.swift
+++ b/Tests/SwiftOCATests/JSONNonFiniteTests.swift
@@ -1,0 +1,55 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+@testable import SwiftOCA
+import Testing
+
+/// A non-finite number reaching NSJSONSerialization raises an unrecoverable
+/// ObjC exception on Darwin, so a -inf dB gain bound must be re-spelled as a
+/// string before it lands in a JSON object.
+@Suite
+struct JSONNonFiniteTests {
+  @Test
+  func nonFiniteValuesAreSpelledAsStrings() {
+    #expect(_jsonNonFiniteSafe(Float.infinity) as? String == "Infinity")
+    #expect(_jsonNonFiniteSafe(-Double.infinity) as? String == "-Infinity")
+    #expect(_jsonNonFiniteSafe(Float.nan) as? String == "NaN")
+  }
+
+  @Test
+  func finiteValuesPassThroughUnchanged() {
+    #expect(_jsonNonFiniteSafe(Float(-10)) as? Float == -10)
+    #expect(_jsonNonFiniteSafe(OcaUint16(42)) as? OcaUint16 == 42)
+    #expect(_jsonNonFiniteSafe("Control Network") as? String == "Control Network")
+  }
+
+  @Test
+  func reencodingProducesAValidJSONObject() throws {
+    let reencoded = try JSONEncoder()
+      .reencodeAsValidJSONObject(["Gain": Float(3), "MinGain": -Float.infinity])
+    #expect(JSONSerialization.isValidJSONObject(["value": reencoded]))
+  }
+
+  @Test
+  func typedReencodingRoundTripsNonFiniteValues() throws {
+    let value: [Float] = try JSONEncoder()
+      .reencodeAsValidJSONObject([-Float.infinity, 3, Float.nan])
+    #expect(value[0] == -.infinity)
+    #expect(value[1] == 3)
+    #expect(value[2].isNaN)
+  }
+}

--- a/Tests/SwiftOCATests/JSONNonFiniteTests.swift
+++ b/Tests/SwiftOCATests/JSONNonFiniteTests.swift
@@ -39,15 +39,13 @@ struct JSONNonFiniteTests {
 
   @Test
   func reencodingProducesAValidJSONObject() throws {
-    let reencoded = try JSONEncoder()
-      .reencodeAsValidJSONObject(["Gain": Float(3), "MinGain": -Float.infinity])
+    let reencoded = try reencodeAsValidJSONObject(["Gain": Float(3), "MinGain": -Float.infinity])
     #expect(JSONSerialization.isValidJSONObject(["value": reencoded]))
   }
 
   @Test
   func typedReencodingRoundTripsNonFiniteValues() throws {
-    let value: [Float] = try JSONEncoder()
-      .reencodeAsValidJSONObject([-Float.infinity, 3, Float.nan])
+    let value: [Float] = try reencodeAsValidJSONObject([-Float.infinity, 3, Float.nan])
     #expect(value[0] == -.infinity)
     #expect(value[1] == 3)
     #expect(value[2].isNaN)

--- a/Tests/SwiftOCATests/LengthTaggedDataJSONTests.swift
+++ b/Tests/SwiftOCATests/LengthTaggedDataJSONTests.swift
@@ -49,7 +49,7 @@ import Testing
     storage["testKey"] = LengthTaggedData16(Data([0xDE, 0xAD, 0xBE, 0xEF]))
 
     // This is what getJsonValue() does when isValidJSONObject returns false
-    let reencoded: any Sendable = try JSONEncoder().reencodeAsValidJSONObject(storage)
+    let reencoded: any Sendable = try SwiftOCA.reencodeAsValidJSONObject(storage)
     print("Reencoded type: \(type(of: reencoded)), value: \(reencoded)")
 
     // Then it gets serialized via JSONSerialization.data(withJSONObject:)
@@ -76,7 +76,7 @@ import Testing
     if isValid {
       reencoded = storage
     } else {
-      reencoded = try JSONEncoder().reencodeAsValidJSONObject(storage)
+      reencoded = try SwiftOCA.reencodeAsValidJSONObject(storage)
     }
     print("Reencoded type: \(type(of: reencoded)), value: \(reencoded)")
 


### PR DESCRIPTION
JSON has no encoding for non-finite numbers, and on Darwin one reaching NSJSONSerialization raises an unrecoverable ObjC exception: a gain bounded by -inf dB crashed both ocacli's `dump` and device-side dataset serialization.

- Spell non-finite values the way `JSONDecoder`'s `.convertFromString` accepts (`Infinity`/`-Infinity`/`NaN`), sanitize the hand-built bounded-property dictionaries on both the client and device sides, and give the restore paths the matching decoding strategy so datasets round-trip.
- Restore a saved scalar fragment (Darwin's JSONSerialization yields it as NSString, which fell through every restore branch — a dataset written with a NaN level could previously never be read back), and validate a restored bounded value against its incoming bounds as the OCP.1 set path does.
- Sanitize a serialization filter's `.replace` value, recursing through containers — the one route left for a raw non-finite float to reach NSJSONSerialization.
- Single-source the spellings and strategies in `_jsonEncoder()`/`_jsonDecoder()` factories; `reencodeAsValidJSONObject` is now a pair of documented free functions that no longer mutate the caller's encoder.

New coverage: `JSONNonFiniteTests` (5) and `NonFiniteDatasetTests` (3, including the Darwin NSString wire-format round-trip and out-of-range/NaN rejection). Full suite green on Darwin and Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uz2gte23zuupawAMHfwg1J