### PR TITLE
Add OCP.2 (AES70-4 JSON protocol) support

### DIFF
--- a/Documentation/OCP2.md
+++ b/Documentation/OCP2.md
@@ -1,0 +1,130 @@
+# OCP.2 (AES70-4) support
+
+SwiftOCA speaks both AES70 control protocols:
+
+- **OCP.1** (AES70-3): binary PDUs with positional parameters. The default.
+- **OCP.2** (AES70-4): newline-delimited JSON PDUs with named parameters.
+
+Both carry the same message model (`Ocp1Command`, `Ocp1Response`,
+`Ocp1Notification2`, keep-alives) over the same transports; the protocol is a
+per-connection or per-endpoint option, not a separate class hierarchy. OCP.2 is
+available in non-embedded builds only (it uses Foundation's JSON).
+
+## Selecting the protocol
+
+Controller:
+
+```swift
+let options = Ocp1ConnectionOptions(controlProtocol: .ocp2)
+let connection = try Ocp1TCPConnection(deviceAddress: address, options: options)
+// or
+let ws = Ocp1FlyingFoxConnection(host: "device.local", port: 50001, options: options)
+```
+
+Device:
+
+```swift
+let tcp = try await Ocp1FlyingSocksStreamDeviceEndpoint(
+  address: address, device: device, controlProtocol: .ocp2)
+let ws = try await Ocp1FlyingFoxDeviceEndpoint(
+  address: address, device: device, controlProtocol: .ocp2, path: "/aes70")
+```
+
+`OcaConnectionBroker` browses the OCP.2 service types (`_ocajson._tcp`,
+`_ocajsonws._tcp`) alongside the OCP.1 ones and picks the protocol from the
+service type; an OCP.2 endpoint advertises itself under the JSON service type
+and, for WebSocket, the `path` TXT record.
+
+Transports in this release: TCP, UDP, WebSocket, and the in-process local loopback.
+TLS-PSK (`_ocajsonsec._tcp`) is not yet wired up; the `DeviceReset` PDU is decoded
+and logged but not acted on.
+
+UDP is a Control Session Transport Type in its own right (AES70-4 10.4.3), served
+by passing `controlProtocol: .ocp2` to a datagram endpoint and advertised as
+`_ocajson._udp`. A session opens on the controller's first keep-alive and the
+device ignores anything sent before it, as the standard requires; `connect()`
+sends one for datagram transports. Note that a PDU must fit a datagram, and JSON
+is bulkier than OCP.1 binary for the same message.
+
+## Framing and marshaling
+
+`Ocp2WireFormat` frames one JSON object per line (AES70-4 6.3) and validates
+the envelope strictly: `ProtocolVersion` must be 1, exactly one payload member
+is allowed, and a command with a missing or spurious member is rejected (the
+standard's malformed examples X01–X03). WebSocket connections use the
+`AES70-OCP.2` subprotocol and text frames; a binary frame closes the socket
+with 1003 and a malformed message with 1007.
+
+`Ocp2Encoder` / `Ocp2Decoder` marshal OCA values per AES70-4 clause 8: blobs
+as base64, maps as arrays of `[key, value]` pairs, class IDs as arrays with a
+nonstandard authority as `[65535, "FA2AE9"]`, property/method/event IDs as
+`[DefLevel, Index]`, enumerations as numbers (names are accepted on receipt),
+composite datatypes as objects keyed by field name. Non-finite floats use the
+`"Infinity"` / `"-Infinity"` / `"NaN"` spellings.
+
+The controller-side JSON export (`OcaRoot.jsonObject`,
+`OcaProperty.getJsonValue`) is this same representation: each property under
+its OCP.2 wire name with its AES70-4 value, plus `ONo`, `ClassID`,
+`ClassVersion`. A bounded property
+takes the shape of its getter response (`Gain`, `MinGain`, `MaxGain`). The
+device-side dataset/patch serialisation is unchanged.
+
+## Parameter names
+
+OCP.2 keys method parameters by their AES70-2A names. SwiftOCA derives them
+from Swift identifiers rather than carrying a copy of the model:
+
+1. **Property accessors** are named after the Swift property, first letter
+   upper-cased (`gain` → `Gain`; a bounded property's getter returns `Gain`,
+   `MinGain`, `MaxGain`). Where the model's spelling differs, pass `ocp2Name:`
+   to the property wrapper on both sides, e.g. `OcaDeviceManager`'s
+   `deviceName` is the model's `Name`.
+2. **Parameter records** (`Ocp1ParametersReflectable` structs) use their field
+   names, upper-cased; an explicit `CodingKeys` enum forces a spelling.
+3. **Hand-written methods** name single parameters explicitly:
+   `encodeResponse(value, name: "Result")` on the device,
+   `sendCommandRrq(methodID:parameters:parameterNames:)` on the controller.
+   An unnamed scalar goes out as `"Value"`.
+
+Receiving is lenient whatever the sender spells: names match
+case-insensitively, a single-parameter object is accepted under any member
+name, enumerations may be names or numbers, and an integer may arrive as a
+string (as in the standard's own examples).
+
+OCA 1.5B makes every method and event argument UpperCamelCase, getter
+out-parameters included (`MinGain`, `Lockable`, `MemberONo`), and that is what
+SwiftOCA sends; the 2023 model's lower-case spellings (`lockable`, `delayTime`)
+still match on receipt. Derived names can differ from the model by more than
+case for a minority of accessors. The `Ocp2NamingOracleTests` test lists them:
+point `AES70_2_XMI` at the AES70-2 UML export (`AES70-2-2023-231218.xmi`) and
+run
+
+```
+AES70_2_XMI=/path/to/AES70-2-2023-231218.xmi swift test --filter Ocp2NamingOracleTests
+```
+
+and add `ocp2Name:` overrides where exact spelling matters for a peer.
+
+## API notes
+
+- `OcaControlProtocol`, `Ocp1ConnectionOptions.controlProtocol`,
+  `.maximumPduSize` and `.heartbeatTime` (overrides a transport's default
+  keep-alive; WebSocket OCP.1 relies on ping/pong, so set one for OCP.2 if the
+  device requires keep-alives).
+- `Ocp1Parameters.format` says whether `parameterData` is OCP.1 bytes or a
+  serialised OCP.2 `Parameters` object; `Ocp1Parameters(ocp2ParameterData:)`
+  builds the latter.
+- `OcaEventParameters.encoded(as:)` encodes event data for either protocol;
+  `OcaControllerDefaultSubscribing.notifySubscribers(_:parameters:)` takes it
+  so each controller is notified in its own protocol. EV1 subscriptions are
+  refused with `NotImplemented` on OCP.2 connections; the controller uses
+  `AddSubscription2` there.
+- `encodeResponse` moved from `OcaRoot` to `OcaController`, which knows the protocol
+  it speaks, so a device `handleCommand` override encodes for the controller it was
+  handed: `try controller.encodeResponse(value, name: "Objects")`. This is a source
+  break for out-of-tree overrides — the old `OcaRoot` entry points are marked
+  unavailable, and the call sites need the receiver added. Nothing is carried
+  implicitly; a property accessor's OCP.2 parameter names are passed to
+  `getResponse(for:names:)` rather than bound ambiently.
+- The `Ocp1*` message and connection types are the protocol-neutral model;
+  their names are historical.

--- a/Documentation/OCP2.md
+++ b/Documentation/OCP2.md
@@ -76,7 +76,7 @@ from Swift identifiers rather than carrying a copy of the model:
 
 1. **Property accessors** are named after the Swift property, first letter
    upper-cased (`gain` → `Gain`; a bounded property's getter returns `Gain`,
-   `MinGain`, `MaxGain`). Where the model's spelling differs, pass `ocp2Name:`
+   `MinGain`, `MaxGain`). Where the model's spelling differs, pass `ocp2GetName:`
    to the property wrapper on both sides, e.g. `OcaDeviceManager`'s
    `deviceName` is the model's `Name`.
 2. **Parameter records** (`Ocp1ParametersReflectable` structs) use their field
@@ -103,7 +103,7 @@ run
 AES70_2_XMI=/path/to/AES70-2-2023-231218.xmi swift test --filter Ocp2NamingOracleTests
 ```
 
-and add `ocp2Name:` overrides where exact spelling matters for a peer.
+and add `ocp2GetName:` overrides where exact spelling matters for a peer.
 
 ## API notes
 

--- a/Examples/OCADevice/DeviceApp.swift
+++ b/Examples/OCADevice/DeviceApp.swift
@@ -31,8 +31,8 @@ import Glibc
 #elseif canImport(Android)
 import Android
 #elseif canImport(WinSDK)
-import WinSDK
 import SocketAddress // for the Windows sa_family_t typealias
+import WinSDK
 #endif
 
 final class DeviceEventDelegate: OcaDeviceEventDelegate {
@@ -145,7 +145,21 @@ public enum DeviceApp {
     #if canImport(Darwin) || os(FreeBSD) || os(OpenBSD)
     listenAddress.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
     #endif
-    let webSocketEndpoint = try await Ocp1WSDeviceEndpoint(address: listenAddress.data)
+    // OCP.1 and OCP.2 share the WebSocket port: OCP.2 clients offer the AES70-OCP.2
+    // subprotocol
+    let webSocketEndpoint = try await Ocp1WSDeviceEndpoint(
+      address: listenAddress.data,
+      controlProtocols: [.ocp1, .ocp2]
+    )
+    #endif
+
+    // OCP.2 (AES70-4, JSON) over TCP on its own port, port+3
+    #if (os(Linux) || canImport(FlyingSocks)) && NonEmbeddedBuild
+    listenAddress.sin_port = (port + 3).bigEndian
+    let jsonStreamEndpoint = try await Ocp1DeviceEndpoint(
+      address: listenAddress.data,
+      controlProtocol: .ocp2
+    )
     #endif
     #if os(macOS)
     let machPortEndpoint = try await Ocp1MachPortDeviceEndpoint(
@@ -181,7 +195,9 @@ public enum DeviceApp {
     #endif
 
     class MyBooleanActuator: SwiftOCADevice.OcaBooleanActuator {
-      override open class var classID: OcaClassID { OcaClassID(parent: super.classID, 65280) }
+      override open class var classID: OcaClassID {
+        OcaClassID(parent: super.classID, 65280)
+      }
     }
 
     let blockONo: OcaONo = 10000
@@ -283,8 +299,14 @@ public enum DeviceApp {
       #endif
       #if canImport(FlyingSocks)
       taskGroup.addTask {
-        print("Starting OCP.1 WebSocket endpoint \(webSocketEndpoint)...")
+        print("Starting OCP.1 and OCP.2 WebSocket endpoint \(webSocketEndpoint)...")
         try await webSocketEndpoint.run()
+      }
+      #endif
+      #if os(Linux) || canImport(FlyingSocks)
+      taskGroup.addTask {
+        print("Starting OCP.2 IPv4 stream endpoint \(jsonStreamEndpoint)...")
+        try await jsonStreamEndpoint.run()
       }
       #endif
       #if os(macOS)

--- a/Examples/Scripts/ocp2-nc.sh
+++ b/Examples/Scripts/ocp2-nc.sh
@@ -1,0 +1,105 @@
+#!/bin/sh
+#
+# Drive an OCP.2 (AES70-4) device with nothing but nc(1).
+#
+# OCP.2 frames one JSON PDU per line, so a whole exchange is a line in and a
+# line out and no client library is needed to poke at a device. Point it at the
+# OCP.2 stream endpoint of Examples/OCADevice (port 65003) or at any other
+# AES70-4 device:
+#
+#   sh Examples/Scripts/ocp2-nc.sh [host] [port]
+#
+# If jq(1) is installed, it checks and compacts each PDU before it is sent and
+# pretty-prints the replies. Set JQ to use another jq, or JQ= to send and show
+# the PDUs as they are.
+#
+# The WebSocket endpoint (port 65002 in the sample device, which serves OCP.1
+# and OCP.2 there) is not reachable this way: it needs the HTTP upgrade, and the
+# AES70-OCP.2 subprotocol to select OCP.2. Use websocat or a browser for that one.
+
+set -e
+
+HOST=${1:-localhost}
+PORT=${2:-65003}
+
+JQ=${JQ-jq}
+if [ -n "$JQ" ] && ! command -v "$JQ" >/dev/null 2>&1; then
+  JQ=
+fi
+
+# The PDUs below are written across several lines for legibility, so fold each
+# back into the single line OCP.2 frames.
+compact() {
+  if [ -n "$JQ" ]; then "$JQ" -c .; else tr -d '\n'; echo; fi
+}
+
+show() {
+  if [ -n "$JQ" ]; then "$JQ" .; else cat; fi
+}
+
+# Send one PDU, print the reply. -w bounds the read: the device holds the
+# connection open for further commands, so nc would otherwise wait forever.
+pdu() {
+  printf '%s' "$1" | compact | nc -w 2 "$HOST" "$PORT" | show
+}
+
+# ONo 1 is OcaDeviceManager, ONo 4 OcaSubscriptionManager and ONo 100 the root
+# block (AES70-1 well-known object numbers); MethodID is [DefLevel, Index] and
+# Parameters are keyed by the AES70-2A parameter names.
+
+echo "== GetDeviceName (OcaDeviceManager 3.4)"
+pdu '{"ProtocolVersion":1,"Commands":[{"Handle":1,"TargetONo":1,"MethodID":[3,4]}]}'
+
+echo
+echo "== two commands in one PDU: GetDeviceName, GetModelDescription (3.6)"
+pdu '{"ProtocolVersion":1,"Commands":[
+        {"Handle":2,"TargetONo":1,"MethodID":[3,4]},
+        {"Handle":3,"TargetONo":1,"MethodID":[3,6]}]}'
+
+echo
+echo "== GetActionObjects on the root block (OcaBlock 3.5)"
+pdu '{"ProtocolVersion":1,"Commands":[{"Handle":4,"TargetONo":100,"MethodID":[3,5]}]}'
+
+echo
+echo "== SetDeviceName (3.5), then read it back"
+pdu '{"ProtocolVersion":1,"Commands":[
+        {"Handle":5,"TargetONo":1,"MethodID":[3,5],"Parameters":{"Name":"Kitchen Amp"}}]}'
+pdu '{"ProtocolVersion":1,"Commands":[{"Handle":6,"TargetONo":1,"MethodID":[3,4]}]}'
+
+echo
+echo "== the same set as a CommandNRs: no response is sent"
+pdu '{"ProtocolVersion":1,"CommandNRs":[
+        {"Handle":7,"TargetONo":1,"MethodID":[3,5],"Parameters":{"Name":"OCA Test"}}]}'
+
+echo
+echo "== KeepAlive (HeartbeatTimeout is in milliseconds); the device echoes one back"
+pdu '{"ProtocolVersion":1,"KeepAlive":{"HeartbeatTimeout":5000}}'
+
+echo
+echo "== a bad object number, to show the status names"
+pdu '{"ProtocolVersion":1,"Commands":[{"Handle":8,"TargetONo":65536,"MethodID":[3,4]}]}'
+
+echo
+echo "== subscribe to OcaDeviceManager's PropertyChanged event, then change a property"
+# AddSubscription2 (OcaSubscriptionManager 3.8) has to be sent on the connection
+# that is to receive the notifications, so this nc stays up while a second one
+# makes the change. EventID [1,1] is OcaRoot's PropertyChanged; EV2 notifications
+# come back over the same connection, so DestinationInformation is empty.
+{
+  printf '%s' '{"ProtocolVersion":1,"Commands":[
+        {"Handle":9,"TargetONo":4,"MethodID":[3,8],"Parameters":{
+          "Event":{"EmitterONo":1,"EventID":[1,1]},
+          "NotificationDeliveryMode":1,"DestinationInformation":""}}]}' | compact
+  sleep 4
+} | nc "$HOST" "$PORT" | show &
+subscriber=$!
+
+sleep 1
+pdu '{"ProtocolVersion":1,"CommandNRs":[
+        {"Handle":10,"TargetONo":1,"MethodID":[3,5],"Parameters":{"Name":"Studio B"}}]}'
+wait $subscriber
+
+echo
+echo "== restoring the device name"
+pdu '{"ProtocolVersion":1,"CommandNRs":[
+        {"Handle":11,"TargetONo":1,"MethodID":[3,5],"Parameters":{"Name":"OCA Test"}}]}'

--- a/Examples/Scripts/ocp2-nc.sh
+++ b/Examples/Scripts/ocp2-nc.sh
@@ -27,6 +27,17 @@ if [ -n "$JQ" ] && ! command -v "$JQ" >/dev/null 2>&1; then
   JQ=
 fi
 
+# Half-closing the send side after each PDU makes the device answer and hang up
+# at once, instead of holding the session open until nc gives up: -N is OpenBSD
+# nc, -q 0 GNU. WAIT caps the wait when nc can do neither.
+NC_EOF=
+if nc -h 2>&1 | grep -q -- '-N'; then
+  NC_EOF=-N
+elif nc -h 2>&1 | grep -q -- '-q '; then
+  NC_EOF='-q 0'
+fi
+WAIT=${WAIT:-2}
+
 # The PDUs below are written across several lines for legibility, so fold each
 # back into the single line OCP.2 frames.
 compact() {
@@ -37,10 +48,11 @@ show() {
   if [ -n "$JQ" ]; then "$JQ" .; else cat; fi
 }
 
-# Send one PDU, print the reply. -w bounds the read: the device holds the
-# connection open for further commands, so nc would otherwise wait forever.
+# Send one PDU, print the reply. $NC_EOF is unquoted so that -q 0 splits into
+# the two words nc wants; the device closes on end-of-input, so the reply ends
+# the exchange and a CommandNR that answers nothing costs nothing either.
 pdu() {
-  printf '%s' "$1" | compact | nc -w 2 "$HOST" "$PORT" | show
+  printf '%s' "$1" | compact | nc $NC_EOF -w "$WAIT" "$HOST" "$PORT" | show
 }
 
 # ONo 1 is OcaDeviceManager, ONo 4 OcaSubscriptionManager and ONo 100 the root
@@ -91,7 +103,7 @@ echo "== subscribe to OcaDeviceManager's PropertyChanged event, then change a pr
           "Event":{"EmitterONo":1,"EventID":[1,1]},
           "NotificationDeliveryMode":1,"DestinationInformation":""}}]}' | compact
   sleep 4
-} | nc "$HOST" "$PORT" | show &
+} | nc $NC_EOF "$HOST" "$PORT" | show &
 subscriber=$!
 
 sleep 1

--- a/Package.swift
+++ b/Package.swift
@@ -390,18 +390,18 @@ let CommonTargets: [Target] = [
       .target(name: "SwiftOCADevice"),
       .target(name: "SwiftOCASecure", condition: .when(traits: ["NonEmbeddedBuild"])),
       .target(name: "SwiftOCASecureDevice", condition: .when(traits: ["NonEmbeddedBuild"])),
-      // Apple-only test files (WebSocketConnectionTests, AppleTLSPolicyRegressionTests)
-      // import these directly. SwiftPM doesn't re-export a target's deps, so
-      // we have to declare them on the test target too.
+      // Ocp2TransportTests and the Apple-only test files (WebSocketConnectionTests,
+      // AppleTLSPolicyRegressionTests) import these directly. SwiftPM doesn't
+      // re-export a target's deps, so we have to declare them on the test target too.
       .product(
         name: "FlyingSocks",
         package: "FlyingFox",
-        condition: .when(platforms: [.macOS, .iOS])
+        condition: .when(platforms: [.macOS, .iOS, .linux])
       ),
       .product(
         name: "FlyingFox",
         package: "FlyingFox",
-        condition: .when(platforms: [.macOS, .iOS], traits: ["NonEmbeddedBuild"])
+        condition: .when(platforms: [.macOS, .iOS, .linux], traits: ["NonEmbeddedBuild"])
       ),
     ],
     swiftSettings: [

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The WebSocket client (WS client) uses Apple's `URLSessionWebSocketTask` and is t
 
 * **Device discovery**: `OcaConnectionBroker` discovers AES70 devices via DNS-SD/Bonjour (using `NetServiceBrowser` on Apple platforms, or `libdns_sd` on Linux), with support for TCP, UDP, and WebSocket service types. Devices can also be registered manually for direct connection without DNS-SD.
 * **WebSocket transport**: `Ocp1FlyingFoxConnection` provides client-side WebSocket connectivity on Apple platforms using `URLSessionWebSocketTask`.
+* **OCP.2 (AES70-4)**: the JSON protocol is a per-connection option (`Ocp1ConnectionOptions(controlProtocol: .ocp2)`) over TCP, WebSocket and the local loopback; the broker discovers `_ocajson._tcp` and `_ocajsonws._tcp` services. See [Documentation/OCP2.md](Documentation/OCP2.md).
 * **Mach port transport**: `Ocp1MachPortConnection` provides fast local IPC between processes on macOS using Mach ports.
 * **Property observation**: `@OcaProperty` and `@OcaBoundedProperty` wrappers expose property changes as `AsyncSequence` streams, enabling reactive UI updates.
 * **JSON serialization**: read the full state of any remote object or block tree as a JSON-compatible dictionary via `jsonObject`.
@@ -38,6 +39,7 @@ The WebSocket client (WS client) uses Apple's `URLSessionWebSocketTask` and is t
 * **Block and matrix containers**: `OcaBlock` and `OcaMatrix` for organizing objects into hierarchical or grid-based topologies.
 * **JSON serialization/deserialization**: persist and restore device state via `serialize`/`deserialize` and the parameter dataset API.
 * **Multiple transport endpoints**: run TCP, UDP, WebSocket, Unix domain socket, and Mach port (macOS) endpoints concurrently.
+* **OCP.2 (AES70-4)** endpoints: pass `controlProtocol: .ocp2` to the TCP or WebSocket endpoint to serve JSON controllers; they advertise the `_ocajson` service types.
 * **TLS-secured TCP** (`ocasec`): PSK (AES70 baseline) and X.509 certificate credentials on both Apple and Linux, with optional mTLS and TLS 1.3 external PSK. See [Documentation/TLS.md](Documentation/TLS.md).
 
 ### SwiftOCAUI
@@ -55,6 +57,7 @@ Sample code can be found in [Examples](Examples):
 * **[OCADevice](Examples/OCADevice)** — a sample AES70 device with a gain control, boolean actuator matrix, and multiple transport endpoints.
 * **[OCABrowser](Examples/OCABrowser)** — a macOS SwiftUI app that discovers devices via Bonjour and provides a navigable block browser with specialized control views.
 * **[OCABrokerTest](Examples/OCABrokerTest)** — a command-line tool that discovers devices and auto-connects as they appear.
+* **[Scripts/ocp2-nc.sh](Examples/Scripts/ocp2-nc.sh)** — a shell script that drives an OCP.2 (AES70-4) device with `nc`, for poking at one without a controller.
 
 [ocacli](https://github.com/PADL/ocacli) is a command-line OCA controller that is implemented using SwiftOCA. SwiftOCA is also compatible with third-party OCA controllers such as [AES70Explorer](https://aes70explorer.com).
 
@@ -125,6 +128,25 @@ let gain = try await OcaGain(
 let endpoint = try await Ocp1FlyingSocksStreamDeviceEndpoint(address: listenAddress)
 try await endpoint.run()
 ```
+
+### Talking to a device with `nc`
+
+An OCP.2 device frames one JSON PDU per line, so a single `nc` is enough to poke
+at one — no client library, no framing to get right. Against the sample device's
+OCP.2 stream endpoint (port 65003):
+
+```sh
+$ echo '{"ProtocolVersion":1,"Commands":[{"Handle":1,"TargetONo":1,"MethodID":[3,4]}]}' \
+    | nc -w 2 localhost 65003
+{"ProtocolVersion":1,"Responses":[{"StatusCode":"OK","Parameters":{"Name":"OCA Test"},"Handle":1}]}
+```
+
+`TargetONo` 1 is `OcaDeviceManager`, `MethodID` is `[DefLevel, Index]` (3.4 is
+`GetDeviceName`), and `Parameters` are keyed by their AES70-2A names.
+[Examples/Scripts/ocp2-nc.sh](Examples/Scripts/ocp2-nc.sh) goes further: several
+commands in one PDU, `CommandNRs`, keep-alives, and an EV2 subscription that
+receives a notification. The WebSocket endpoint negotiates the `AES70-OCP.2`
+subprotocol, so reach that one with `websocat` rather than `nc`.
 
 ### Discovering devices with OcaConnectionBroker
 

--- a/Sources/SwiftOCA/OCA/Browsing/ConnectionBroker.swift
+++ b/Sources/SwiftOCA/OCA/Browsing/ConnectionBroker.swift
@@ -213,8 +213,10 @@ public actor OcaConnectionBroker {
 
     func openConnection(options: Ocp1ConnectionOptions) async throws -> Ocp1Connection {
       let connection: Ocp1Connection
+      // the service type decides the protocol; the caller's options decide the rest
+      let options = options.copy(controlProtocol: serviceType.controlProtocol)
 
-      switch serviceType {
+      switch serviceType.transport {
       case .tcp:
         connection = try await Ocp1TCPConnection(
           deviceAddresses: addresses,
@@ -305,6 +307,9 @@ public actor OcaConnectionBroker {
     OcaNetworkAdvertisingServiceType.tcp,
     OcaNetworkAdvertisingServiceType.udp,
     OcaNetworkAdvertisingServiceType.tcpWebSocket,
+    OcaNetworkAdvertisingServiceType.tcpJson,
+    OcaNetworkAdvertisingServiceType.udpJson,
+    OcaNetworkAdvertisingServiceType.tcpWebSocketJson,
   ])
 
   /// An async sequence of events emitted by the connection broker.

--- a/Sources/SwiftOCA/OCA/ClassRegistry.swift
+++ b/Sources/SwiftOCA/OCA/ClassRegistry.swift
@@ -21,6 +21,11 @@ public class OcaClassRegistry {
   /// Mapping of classID to class name
   private var classIDMap = [OcaClassIdentification: OcaRoot.Type]()
 
+  /// Every registered class, for tooling and tests.
+  package var registeredClasses: [OcaClassIdentification: OcaRoot.Type] {
+    classIDMap
+  }
+
   public func register<T: OcaRoot>(
     classID: OcaClassID = T.classID,
     classVersion: OcaClassVersionNumber = T.classVersion,

--- a/Sources/SwiftOCA/OCC/ControlClasses/Agents/CounterSetAgent.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Agents/CounterSetAgent.swift
@@ -33,7 +33,8 @@ open class OcaCounterSetAgent: OcaAgent, @unchecked Sendable {
   public func get(counter id: OcaID16) async throws -> OcaCounter {
     try await sendCommandRrq(
       methodID: OcaMethodID("3.3"),
-      parameters: id
+      parameters: id,
+      parameterNames: ["ID"]
     )
   }
 
@@ -62,7 +63,8 @@ open class OcaCounterSetAgent: OcaAgent, @unchecked Sendable {
   public func reset(counter id: OcaID16) async throws {
     try await sendCommandRrq(
       methodID: OcaMethodID("3.7"),
-      parameters: id
+      parameters: id,
+      parameterNames: ["ID"]
     )
   }
 }

--- a/Sources/SwiftOCA/OCC/ControlClasses/Agents/EventHandler.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Agents/EventHandler.swift
@@ -30,6 +30,6 @@ Sendable {
 }
 
 protocol OcaPropertyChangeEventNotifiable: OcaPropertySubjectRepresentable {
-  /// `eventData` is in `format`: OCP.1 bytes or an OCP.2 JSON object.
-  func onEvent(_ object: OcaRoot, event: OcaEvent, eventData: Data, format: OcaParameterFormat) throws
+  /// `eventData` is as it arrived: OCP.1 bytes or a parsed OCP.2 JSON object.
+  func onEvent(_ object: OcaRoot, event: OcaEvent, eventData: OcaEncodedEventData) throws
 }

--- a/Sources/SwiftOCA/OCC/ControlClasses/Agents/EventHandler.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Agents/EventHandler.swift
@@ -30,5 +30,6 @@ Sendable {
 }
 
 protocol OcaPropertyChangeEventNotifiable: OcaPropertySubjectRepresentable {
-  func onEvent(_ object: OcaRoot, event: OcaEvent, eventData: Data) throws
+  /// `eventData` is in `format`: OCP.1 bytes or an OCP.2 JSON object.
+  func onEvent(_ object: OcaRoot, event: OcaEvent, eventData: Data, format: OcaParameterFormat) throws
 }

--- a/Sources/SwiftOCA/OCC/ControlClasses/Agents/Group.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Agents/Group.swift
@@ -50,14 +50,16 @@ Sendable {
   public func add(member objectNumber: OcaONo) async throws {
     try await sendCommandRrq(
       methodID: OcaMethodID("3.3"),
-      parameters: objectNumber
+      parameters: objectNumber,
+      parameterNames: ["Member"] // name not in AES70-2023 model
     )
   }
 
   public func delete(member objectNumber: OcaONo) async throws {
     try await sendCommandRrq(
       methodID: OcaMethodID("3.4"),
-      parameters: objectNumber
+      parameters: objectNumber,
+      parameterNames: ["Member"] // name not in AES70-2023 model
     )
   }
 }

--- a/Sources/SwiftOCA/OCC/ControlClasses/Agents/MediaClock3.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Agents/MediaClock3.swift
@@ -45,7 +45,7 @@ open class OcaMediaClock3: OcaAgent, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("3.5"),
     getMethodID: OcaMethodID("3.7"),
-    ocp2Name: "Rates"
+    ocp2GetName: "Rates"
   )
   public var supportedRates: OcaMultiMapProperty<OcaONo, OcaMediaClockRate>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Agents/MediaClock3.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Agents/MediaClock3.swift
@@ -44,7 +44,8 @@ open class OcaMediaClock3: OcaAgent, @unchecked Sendable {
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.5"),
-    getMethodID: OcaMethodID("3.7")
+    getMethodID: OcaMethodID("3.7"),
+    ocp2Name: "Rates"
   )
   public var supportedRates: OcaMultiMapProperty<OcaONo, OcaMediaClockRate>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Agents/MediaTransportSessionAgent.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Agents/MediaTransportSessionAgent.swift
@@ -115,13 +115,17 @@ open class OcaMediaTransportSessionAgent: OcaAgent, @unchecked Sendable {
   public func getSession(_ id: OcaMediaTransportSessionID) async throws
     -> OcaMediaTransportSession
   {
-    try await sendCommandRrq(methodID: OcaMethodID("3.3"), parameters: id)
+    try await sendCommandRrq(methodID: OcaMethodID("3.3"), parameters: id, parameterNames: ["ID"])
   }
 
   /// Returns the given descriptor with its IDInternal set to the ID the device allocated.
   @discardableResult
   public func add(session: OcaMediaTransportSession) async throws -> OcaMediaTransportSession {
-    try await sendCommandRrq(methodID: OcaMethodID("3.4"), parameters: session)
+    try await sendCommandRrq(
+      methodID: OcaMethodID("3.4"),
+      parameters: session,
+      parameterNames: ["Session"]
+    )
   }
 
   public func configure(session: OcaMediaTransportSession) async throws {
@@ -129,11 +133,11 @@ open class OcaMediaTransportSessionAgent: OcaAgent, @unchecked Sendable {
   }
 
   public func delete(session id: OcaMediaTransportSessionID) async throws {
-    try await sendCommandRrq(methodID: OcaMethodID("3.6"), parameters: id)
+    try await sendCommandRrq(methodID: OcaMethodID("3.6"), parameters: id, parameterNames: ["ID"])
   }
 
   public func reset(session id: OcaMediaTransportSessionID) async throws {
-    try await sendCommandRrq(methodID: OcaMethodID("3.7"), parameters: id)
+    try await sendCommandRrq(methodID: OcaMethodID("3.7"), parameters: id, parameterNames: ["ID"])
   }
 
   public func set(session id: OcaMediaTransportSessionID, streamingEnabled: OcaBoolean) async throws {
@@ -144,17 +148,17 @@ open class OcaMediaTransportSessionAgent: OcaAgent, @unchecked Sendable {
   }
 
   public func startStreaming(session id: OcaMediaTransportSessionID) async throws {
-    try await sendCommandRrq(methodID: OcaMethodID("3.9"), parameters: id)
+    try await sendCommandRrq(methodID: OcaMethodID("3.9"), parameters: id, parameterNames: ["ID"])
   }
 
   public func stopStreaming(session id: OcaMediaTransportSessionID) async throws {
-    try await sendCommandRrq(methodID: OcaMethodID("3.10"), parameters: id)
+    try await sendCommandRrq(methodID: OcaMethodID("3.10"), parameters: id, parameterNames: ["ID"])
   }
 
   public func getSessionStatus(_ id: OcaMediaTransportSessionID) async throws
     -> OcaMediaTransportSessionStatus
   {
-    try await sendCommandRrq(methodID: OcaMethodID("3.12"), parameters: id)
+    try await sendCommandRrq(methodID: OcaMethodID("3.12"), parameters: id, parameterNames: ["ID"])
   }
 
   // MARK: - Connections
@@ -199,6 +203,10 @@ open class OcaMediaTransportSessionAgent: OcaAgent, @unchecked Sendable {
   }
 
   public func deleteConnections(session id: OcaMediaTransportSessionID) async throws {
-    try await sendCommandRrq(methodID: OcaMethodID("3.16"), parameters: id)
+    try await sendCommandRrq(
+      methodID: OcaMethodID("3.16"),
+      parameters: id,
+      parameterNames: ["SessionID"]
+    )
   }
 }

--- a/Sources/SwiftOCA/OCC/ControlClasses/Agents/MediaTransportSessionAgent.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Agents/MediaTransportSessionAgent.swift
@@ -82,7 +82,7 @@ open class OcaMediaTransportSessionAgent: OcaAgent, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("3.1"),
     getMethodID: OcaMethodID("3.1"),
-    ocp2Name: "Type"
+    ocp2GetName: "Type"
   )
   public var sessionType: OcaProperty<OcaString>.PropertyValue
 
@@ -95,7 +95,7 @@ open class OcaMediaTransportSessionAgent: OcaAgent, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("3.3"),
     getMethodID: OcaMethodID("3.11"),
-    ocp2Name: "Sessions"
+    ocp2GetName: "Sessions"
   )
   public var sessionStatuses: OcaMapProperty<
     OcaMediaTransportSessionID,
@@ -106,7 +106,7 @@ open class OcaMediaTransportSessionAgent: OcaAgent, @unchecked Sendable {
     propertyID: OcaPropertyID("3.4"),
     getMethodID: OcaMethodID("3.17"),
     setMethodID: OcaMethodID("3.18"),
-    ocp2Name: "Data",
+    ocp2GetName: "Data",
     ocp2SetName: "Data"
   )
   public var adaptationData: OcaProperty<OcaAdaptationData>.PropertyValue

--- a/Sources/SwiftOCA/OCC/ControlClasses/Agents/MediaTransportSessionAgent.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Agents/MediaTransportSessionAgent.swift
@@ -81,7 +81,8 @@ open class OcaMediaTransportSessionAgent: OcaAgent, @unchecked Sendable {
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.1"),
-    getMethodID: OcaMethodID("3.1")
+    getMethodID: OcaMethodID("3.1"),
+    ocp2Name: "Type"
   )
   public var sessionType: OcaProperty<OcaString>.PropertyValue
 
@@ -93,7 +94,8 @@ open class OcaMediaTransportSessionAgent: OcaAgent, @unchecked Sendable {
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.3"),
-    getMethodID: OcaMethodID("3.11")
+    getMethodID: OcaMethodID("3.11"),
+    ocp2Name: "Sessions"
   )
   public var sessionStatuses: OcaMapProperty<
     OcaMediaTransportSessionID,
@@ -103,7 +105,8 @@ open class OcaMediaTransportSessionAgent: OcaAgent, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("3.4"),
     getMethodID: OcaMethodID("3.17"),
-    setMethodID: OcaMethodID("3.18")
+    setMethodID: OcaMethodID("3.18"),
+    ocp2Name: "Data"
   )
   public var adaptationData: OcaProperty<OcaAdaptationData>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Agents/MediaTransportSessionAgent.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Agents/MediaTransportSessionAgent.swift
@@ -106,7 +106,8 @@ open class OcaMediaTransportSessionAgent: OcaAgent, @unchecked Sendable {
     propertyID: OcaPropertyID("3.4"),
     getMethodID: OcaMethodID("3.17"),
     setMethodID: OcaMethodID("3.18"),
-    ocp2Name: "Data"
+    ocp2Name: "Data",
+    ocp2SetName: "Data"
   )
   public var adaptationData: OcaProperty<OcaAdaptationData>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Agents/PhysicalPosition.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Agents/PhysicalPosition.swift
@@ -105,7 +105,8 @@ open class OcaPhysicalPosition: OcaAgent, @unchecked Sendable {
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.2"),
-    getMethodID: OcaMethodID("3.2")
+    getMethodID: OcaMethodID("3.2"),
+    ocp2Name: "Flags"
   )
   public var positionDescriptorFieldFlags: OcaProperty<OcaPositionDescriptorFieldFlags>
     .PropertyValue

--- a/Sources/SwiftOCA/OCC/ControlClasses/Agents/PhysicalPosition.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Agents/PhysicalPosition.swift
@@ -106,7 +106,7 @@ open class OcaPhysicalPosition: OcaAgent, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("3.2"),
     getMethodID: OcaMethodID("3.2"),
-    ocp2Name: "Flags"
+    ocp2GetName: "Flags"
   )
   public var positionDescriptorFieldFlags: OcaProperty<OcaPositionDescriptorFieldFlags>
     .PropertyValue

--- a/Sources/SwiftOCA/OCC/ControlClasses/Agents/PowerSupply.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Agents/PowerSupply.swift
@@ -27,7 +27,7 @@ open class OcaPowerSupply: OcaAgent, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("3.2"),
     getMethodID: OcaMethodID("3.2"),
-    ocp2Name: "Info"
+    ocp2GetName: "Info"
   )
   public var modelInfo: OcaProperty<OcaString>.PropertyValue
 
@@ -50,7 +50,7 @@ open class OcaPowerSupply: OcaAgent, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("3.5"),
     getMethodID: OcaMethodID("3.6"),
-    ocp2Name: "Fraction"
+    ocp2GetName: "Fraction"
   )
   public var loadFractionAvailable: OcaProperty<OcaFloat32>.PropertyValue
 
@@ -59,7 +59,7 @@ open class OcaPowerSupply: OcaAgent, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("3.6"),
     getMethodID: OcaMethodID("3.7"),
-    ocp2Name: "Fraction"
+    ocp2GetName: "Fraction"
   )
   public var storageFractionAvailable: OcaProperty<OcaFloat32>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Agents/PowerSupply.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Agents/PowerSupply.swift
@@ -26,7 +26,8 @@ open class OcaPowerSupply: OcaAgent, @unchecked Sendable {
   /// implementation-dependent model information
   @OcaProperty(
     propertyID: OcaPropertyID("3.2"),
-    getMethodID: OcaMethodID("3.2")
+    getMethodID: OcaMethodID("3.2"),
+    ocp2Name: "Info"
   )
   public var modelInfo: OcaProperty<OcaString>.PropertyValue
 
@@ -48,7 +49,8 @@ open class OcaPowerSupply: OcaAgent, @unchecked Sendable {
   /// range zero to one; a negative value indicates the data is unavailable
   @OcaProperty(
     propertyID: OcaPropertyID("3.5"),
-    getMethodID: OcaMethodID("3.6")
+    getMethodID: OcaMethodID("3.6"),
+    ocp2Name: "Fraction"
   )
   public var loadFractionAvailable: OcaProperty<OcaFloat32>.PropertyValue
 
@@ -56,7 +58,8 @@ open class OcaPowerSupply: OcaAgent, @unchecked Sendable {
   /// range zero to one; a negative value indicates the data is unavailable
   @OcaProperty(
     propertyID: OcaPropertyID("3.6"),
-    getMethodID: OcaMethodID("3.7")
+    getMethodID: OcaMethodID("3.7"),
+    ocp2Name: "Fraction"
   )
   public var storageFractionAvailable: OcaProperty<OcaFloat32>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Agents/TimeSource.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Agents/TimeSource.swift
@@ -86,14 +86,16 @@ open class OcaTimeSource: OcaAgent, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("3.2"),
     getMethodID: OcaMethodID("3.2"),
-    setMethodID: OcaMethodID("3.3")
+    setMethodID: OcaMethodID("3.3"),
+    ocp2Name: "Mechanism"
   )
   public var timeDeliveryMechanism: OcaProperty<OcaTimeDeliveryMechanism>.PropertyValue
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.3"),
     getMethodID: OcaMethodID("3.4"),
-    setMethodID: OcaMethodID("3.5")
+    setMethodID: OcaMethodID("3.5"),
+    ocp2Name: "Parameters"
   )
   public var referenceSDPDescription: OcaProperty<OcaSDPString>.PropertyValue
 
@@ -107,7 +109,8 @@ open class OcaTimeSource: OcaAgent, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("3.5"),
     getMethodID: OcaMethodID("3.8"),
-    setMethodID: OcaMethodID("3.9")
+    setMethodID: OcaMethodID("3.9"),
+    ocp2Name: "ID"
   )
   public var referenceID: OcaProperty<OcaString>.PropertyValue
 
@@ -120,7 +123,8 @@ open class OcaTimeSource: OcaAgent, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("3.7"),
     getMethodID: OcaMethodID("3.12"),
-    setMethodID: OcaMethodID("3.13")
+    setMethodID: OcaMethodID("3.13"),
+    ocp2Name: "Record"
   )
   public var timeDeliveryParameters: OcaProperty<OcaParameterRecord>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Agents/TimeSource.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Agents/TimeSource.swift
@@ -87,7 +87,7 @@ open class OcaTimeSource: OcaAgent, @unchecked Sendable {
     propertyID: OcaPropertyID("3.2"),
     getMethodID: OcaMethodID("3.2"),
     setMethodID: OcaMethodID("3.3"),
-    ocp2Name: "Mechanism",
+    ocp2GetName: "Mechanism",
     ocp2SetName: "Mechanism"
   )
   public var timeDeliveryMechanism: OcaProperty<OcaTimeDeliveryMechanism>.PropertyValue
@@ -96,7 +96,7 @@ open class OcaTimeSource: OcaAgent, @unchecked Sendable {
     propertyID: OcaPropertyID("3.3"),
     getMethodID: OcaMethodID("3.4"),
     setMethodID: OcaMethodID("3.5"),
-    ocp2Name: "Parameters",
+    ocp2GetName: "Parameters",
     ocp2SetName: "Parameters"
   )
   public var referenceSDPDescription: OcaProperty<OcaSDPString>.PropertyValue
@@ -112,7 +112,7 @@ open class OcaTimeSource: OcaAgent, @unchecked Sendable {
     propertyID: OcaPropertyID("3.5"),
     getMethodID: OcaMethodID("3.8"),
     setMethodID: OcaMethodID("3.9"),
-    ocp2Name: "ID",
+    ocp2GetName: "ID",
     ocp2SetName: "ID"
   )
   public var referenceID: OcaProperty<OcaString>.PropertyValue
@@ -127,7 +127,7 @@ open class OcaTimeSource: OcaAgent, @unchecked Sendable {
     propertyID: OcaPropertyID("3.7"),
     getMethodID: OcaMethodID("3.12"),
     setMethodID: OcaMethodID("3.13"),
-    ocp2Name: "Record",
+    ocp2GetName: "Record",
     ocp2SetName: "Record"
   )
   public var timeDeliveryParameters: OcaProperty<OcaParameterRecord>.PropertyValue

--- a/Sources/SwiftOCA/OCC/ControlClasses/Agents/TimeSource.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Agents/TimeSource.swift
@@ -87,7 +87,8 @@ open class OcaTimeSource: OcaAgent, @unchecked Sendable {
     propertyID: OcaPropertyID("3.2"),
     getMethodID: OcaMethodID("3.2"),
     setMethodID: OcaMethodID("3.3"),
-    ocp2Name: "Mechanism"
+    ocp2Name: "Mechanism",
+    ocp2SetName: "Mechanism"
   )
   public var timeDeliveryMechanism: OcaProperty<OcaTimeDeliveryMechanism>.PropertyValue
 
@@ -95,7 +96,8 @@ open class OcaTimeSource: OcaAgent, @unchecked Sendable {
     propertyID: OcaPropertyID("3.3"),
     getMethodID: OcaMethodID("3.4"),
     setMethodID: OcaMethodID("3.5"),
-    ocp2Name: "Parameters"
+    ocp2Name: "Parameters",
+    ocp2SetName: "Parameters"
   )
   public var referenceSDPDescription: OcaProperty<OcaSDPString>.PropertyValue
 
@@ -110,7 +112,8 @@ open class OcaTimeSource: OcaAgent, @unchecked Sendable {
     propertyID: OcaPropertyID("3.5"),
     getMethodID: OcaMethodID("3.8"),
     setMethodID: OcaMethodID("3.9"),
-    ocp2Name: "ID"
+    ocp2Name: "ID",
+    ocp2SetName: "ID"
   )
   public var referenceID: OcaProperty<OcaString>.PropertyValue
 
@@ -124,7 +127,8 @@ open class OcaTimeSource: OcaAgent, @unchecked Sendable {
     propertyID: OcaPropertyID("3.7"),
     getMethodID: OcaMethodID("3.12"),
     setMethodID: OcaMethodID("3.13"),
-    ocp2Name: "Record"
+    ocp2Name: "Record",
+    ocp2SetName: "Record"
   )
   public var timeDeliveryParameters: OcaProperty<OcaParameterRecord>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/ApplicationNetworks/ApplicationNetwork.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/ApplicationNetworks/ApplicationNetwork.swift
@@ -39,7 +39,8 @@ Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("2.3"),
     getMethodID: OcaMethodID("2.4"),
-    setMethodID: OcaMethodID("2.5")
+    setMethodID: OcaMethodID("2.5"),
+    ocp2Name: "Name"
   )
   public var serviceID: OcaProperty<OcaApplicationNetworkServiceID>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/ApplicationNetworks/ApplicationNetwork.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/ApplicationNetworks/ApplicationNetwork.swift
@@ -66,7 +66,8 @@ Sendable {
   public func control(_ command: OcaApplicationNetworkCommand) async throws {
     try await sendCommandRrq(
       methodID: OcaMethodID("2.10"),
-      parameters: command
+      parameters: command,
+      parameterNames: ["Command"]
     )
   }
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/ApplicationNetworks/ApplicationNetwork.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/ApplicationNetworks/ApplicationNetwork.swift
@@ -40,7 +40,7 @@ Sendable {
     propertyID: OcaPropertyID("2.3"),
     getMethodID: OcaMethodID("2.4"),
     setMethodID: OcaMethodID("2.5"),
-    ocp2Name: "Name",
+    ocp2GetName: "Name",
     ocp2SetName: "Name"
   )
   public var serviceID: OcaProperty<OcaApplicationNetworkServiceID>.PropertyValue
@@ -49,7 +49,7 @@ Sendable {
     propertyID: OcaPropertyID("2.4"),
     getMethodID: OcaMethodID("2.6"),
     setMethodID: OcaMethodID("2.7"),
-    ocp2Name: "SystemInterfaces",
+    ocp2GetName: "SystemInterfaces",
     ocp2SetName: "Descriptors"
   )
   public var systemInterfaces: OcaListProperty<OcaNetworkSystemInterfaceDescriptor>

--- a/Sources/SwiftOCA/OCC/ControlClasses/ApplicationNetworks/ApplicationNetwork.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/ApplicationNetworks/ApplicationNetwork.swift
@@ -40,14 +40,17 @@ Sendable {
     propertyID: OcaPropertyID("2.3"),
     getMethodID: OcaMethodID("2.4"),
     setMethodID: OcaMethodID("2.5"),
-    ocp2Name: "Name"
+    ocp2Name: "Name",
+    ocp2SetName: "Name"
   )
   public var serviceID: OcaProperty<OcaApplicationNetworkServiceID>.PropertyValue
 
   @OcaProperty(
     propertyID: OcaPropertyID("2.4"),
     getMethodID: OcaMethodID("2.6"),
-    setMethodID: OcaMethodID("2.7")
+    setMethodID: OcaMethodID("2.7"),
+    ocp2Name: "SystemInterfaces",
+    ocp2SetName: "Descriptors"
   )
   public var systemInterfaces: OcaListProperty<OcaNetworkSystemInterfaceDescriptor>
     .PropertyValue

--- a/Sources/SwiftOCA/OCC/ControlClasses/ApplicationNetworks/MediaTransportNetwork.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/ApplicationNetworks/MediaTransportNetwork.swift
@@ -31,7 +31,8 @@ open class OcaMediaTransportNetwork: OcaApplicationNetwork, @unchecked Sendable 
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.2"),
-    getMethodID: OcaMethodID("3.2")
+    getMethodID: OcaMethodID("3.2"),
+    ocp2Name: "OcaPorts"
   )
   public var ports: OcaListProperty<OcaPort>.PropertyValue
 
@@ -65,13 +66,15 @@ open class OcaMediaTransportNetwork: OcaApplicationNetwork, @unchecked Sendable 
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.5"),
-    getMethodID: OcaMethodID("3.7")
+    getMethodID: OcaMethodID("3.7"),
+    ocp2Name: "MaxPins"
   )
   public var maxPinsPerConnector: OcaProperty<OcaUint16>.PropertyValue
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.6"),
-    getMethodID: OcaMethodID("3.8")
+    getMethodID: OcaMethodID("3.8"),
+    ocp2Name: "MaxPins"
   )
   public var maxPortsPerPin: OcaProperty<OcaUint16>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/ApplicationNetworks/MediaTransportNetwork.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/ApplicationNetworks/MediaTransportNetwork.swift
@@ -94,7 +94,11 @@ open class OcaMediaTransportNetwork: OcaApplicationNetwork, @unchecked Sendable 
   public func getSourceConnector(_ id: OcaMediaConnectorID) async throws
     -> OcaMediaSourceConnector
   {
-    try await sendCommandRrq(methodID: OcaMethodID("3.10"), parameters: id)
+    try await sendCommandRrq(
+      methodID: OcaMethodID("3.10"),
+      parameters: id,
+      parameterNames: ["ID"]
+    )
   }
 
   public func getSinkConnectors() async throws -> [OcaMediaSinkConnector] {
@@ -102,7 +106,11 @@ open class OcaMediaTransportNetwork: OcaApplicationNetwork, @unchecked Sendable 
   }
 
   public func getSinkConnector(_ id: OcaMediaConnectorID) async throws -> OcaMediaSinkConnector {
-    try await sendCommandRrq(methodID: OcaMethodID("3.12"), parameters: id)
+    try await sendCommandRrq(
+      methodID: OcaMethodID("3.12"),
+      parameters: id,
+      parameterNames: ["ID"]
+    )
   }
 
   public func getConnectorsStatuses() async throws -> [OcaMediaConnectorStatus] {
@@ -112,7 +120,11 @@ open class OcaMediaTransportNetwork: OcaApplicationNetwork, @unchecked Sendable 
   public func getConnectorStatus(_ id: OcaMediaConnectorID) async throws
     -> OcaMediaConnectorStatus
   {
-    try await sendCommandRrq(methodID: OcaMethodID("3.14"), parameters: id)
+    try await sendCommandRrq(
+      methodID: OcaMethodID("3.14"),
+      parameters: id,
+      parameterNames: ["ConnectorID"]
+    )
   }
 
   public struct AddSourceConnectorParameters: Ocp1ParametersReflectable {
@@ -230,6 +242,10 @@ open class OcaMediaTransportNetwork: OcaApplicationNetwork, @unchecked Sendable 
   }
 
   public func deleteConnector(_ id: OcaMediaConnectorID) async throws {
-    try await sendCommandRrq(methodID: OcaMethodID("3.24"), parameters: id)
+    try await sendCommandRrq(
+      methodID: OcaMethodID("3.24"),
+      parameters: id,
+      parameterNames: ["ID"]
+    )
   }
 }

--- a/Sources/SwiftOCA/OCC/ControlClasses/ApplicationNetworks/MediaTransportNetwork.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/ApplicationNetworks/MediaTransportNetwork.swift
@@ -32,7 +32,7 @@ open class OcaMediaTransportNetwork: OcaApplicationNetwork, @unchecked Sendable 
   @OcaProperty(
     propertyID: OcaPropertyID("3.2"),
     getMethodID: OcaMethodID("3.2"),
-    ocp2Name: "OcaPorts"
+    ocp2GetName: "OcaPorts"
   )
   public var ports: OcaListProperty<OcaPort>.PropertyValue
 
@@ -67,14 +67,14 @@ open class OcaMediaTransportNetwork: OcaApplicationNetwork, @unchecked Sendable 
   @OcaProperty(
     propertyID: OcaPropertyID("3.5"),
     getMethodID: OcaMethodID("3.7"),
-    ocp2Name: "MaxPins"
+    ocp2GetName: "MaxPins"
   )
   public var maxPinsPerConnector: OcaProperty<OcaUint16>.PropertyValue
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.6"),
     getMethodID: OcaMethodID("3.8"),
-    ocp2Name: "MaxPins"
+    ocp2GetName: "MaxPins"
   )
   public var maxPortsPerPin: OcaProperty<OcaUint16>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Dataset/Dataset.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Dataset/Dataset.swift
@@ -49,7 +49,7 @@ Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("2.5"),
     getMethodID: OcaMethodID("2.14"),
-    ocp2Name: "Time"
+    ocp2GetName: "Time"
   )
   public var lastModificationTime: OcaProperty<OcaTime>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Dataset/Dataset.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Dataset/Dataset.swift
@@ -71,7 +71,8 @@ Sendable {
   public func openRead(lockState: OcaLockState) async throws -> (OcaUint64, OcaIOSessionHandle) {
     let result: OpenReadParameters = try await sendCommandRrq(
       methodID: OcaMethodID("2.1"),
-      parameters: lockState
+      parameters: lockState,
+      parameterNames: ["RequestedLockState"]
     )
     return (result.datasetSize, result.handle)
   }
@@ -90,7 +91,8 @@ Sendable {
   public func openWrite(lockState: OcaLockState) async throws -> (OcaUint64, OcaIOSessionHandle) {
     let result: OpenWriteParameters = try await sendCommandRrq(
       methodID: OcaMethodID("2.2"),
-      parameters: lockState
+      parameters: lockState,
+      parameterNames: ["RequestedLockState"]
     )
     return (result.maxPartSize, result.handle)
   }
@@ -98,7 +100,8 @@ Sendable {
   public func close(handle: OcaIOSessionHandle) async throws {
     try await sendCommandRrq(
       methodID: OcaMethodID("2.3"),
-      parameters: handle
+      parameters: handle,
+      parameterNames: ["Handle"]
     )
   }
 
@@ -159,7 +162,8 @@ Sendable {
   public func clear(handle: OcaIOSessionHandle) async throws {
     try await sendCommandRrq(
       methodID: OcaMethodID("2.6"),
-      parameters: handle
+      parameters: handle,
+      parameterNames: ["Handle"]
     )
   }
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Dataset/Dataset.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Dataset/Dataset.swift
@@ -48,7 +48,8 @@ Sendable {
 
   @OcaProperty(
     propertyID: OcaPropertyID("2.5"),
-    getMethodID: OcaMethodID("2.14")
+    getMethodID: OcaMethodID("2.14"),
+    ocp2Name: "Time"
   )
   public var lastModificationTime: OcaProperty<OcaTime>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Dataset/Log.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Dataset/Log.swift
@@ -35,7 +35,8 @@ open class OcaLog: OcaDataset, @unchecked Sendable {
   public func add(logRecord entry: OcaLogRecord) async throws {
     try await sendCommandRrq(
       methodID: OcaMethodID("3.1"),
-      parameters: entry
+      parameters: entry,
+      parameterNames: ["Entry"]
     )
   }
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Managers/CodingManager.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Managers/CodingManager.swift
@@ -20,14 +20,16 @@ open class OcaCodingManager: OcaManager, @unchecked Sendable {
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.1"),
-    getMethodID: OcaMethodID("3.1")
+    getMethodID: OcaMethodID("3.1"),
+    ocp2Name: "Schemes"
   )
   public var availableEncodingSchemes: OcaMapProperty<OcaMediaCodingSchemeID, OcaString>
     .PropertyValue
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.2"),
-    getMethodID: OcaMethodID("3.2")
+    getMethodID: OcaMethodID("3.2"),
+    ocp2Name: "Schemes"
   )
   public var availableDecodingSchemes: OcaMapProperty<OcaMediaCodingSchemeID, OcaString>
     .PropertyValue

--- a/Sources/SwiftOCA/OCC/ControlClasses/Managers/CodingManager.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Managers/CodingManager.swift
@@ -21,7 +21,7 @@ open class OcaCodingManager: OcaManager, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("3.1"),
     getMethodID: OcaMethodID("3.1"),
-    ocp2Name: "Schemes"
+    ocp2GetName: "Schemes"
   )
   public var availableEncodingSchemes: OcaMapProperty<OcaMediaCodingSchemeID, OcaString>
     .PropertyValue
@@ -29,7 +29,7 @@ open class OcaCodingManager: OcaManager, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("3.2"),
     getMethodID: OcaMethodID("3.2"),
-    ocp2Name: "Schemes"
+    ocp2GetName: "Schemes"
   )
   public var availableDecodingSchemes: OcaMapProperty<OcaMediaCodingSchemeID, OcaString>
     .PropertyValue

--- a/Sources/SwiftOCA/OCC/ControlClasses/Managers/DeviceManager.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Managers/DeviceManager.swift
@@ -14,6 +14,12 @@
 // limitations under the License.
 //
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
 public enum OcaResetCause: OcaUint8, Sendable, Codable, CaseIterable {
   case powerOn = 0
   case internalError = 1
@@ -27,7 +33,8 @@ open class OcaDeviceManager: OcaManager, @unchecked Sendable {
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.1"),
-    getMethodID: OcaMethodID("3.2")
+    getMethodID: OcaMethodID("3.2"),
+    ocp2Name: "GUID"
   )
   public var modelGUID: OcaProperty<OcaModelGUID>.PropertyValue
 
@@ -39,34 +46,39 @@ open class OcaDeviceManager: OcaManager, @unchecked Sendable {
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.3"),
-    getMethodID: OcaMethodID("3.6")
+    getMethodID: OcaMethodID("3.6"),
+    ocp2Name: "Description"
   )
   public var modelDescription: OcaProperty<OcaModelDescription>.PropertyValue
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.4"),
     getMethodID: OcaMethodID("3.4"),
-    setMethodID: OcaMethodID("3.5")
+    setMethodID: OcaMethodID("3.5"),
+    ocp2Name: "Name"
   )
   public var deviceName: OcaProperty<OcaString>.PropertyValue
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.5"),
-    getMethodID: OcaMethodID("3.1")
+    getMethodID: OcaMethodID("3.1"),
+    ocp2Name: "OcaVersion"
   )
   public var version: OcaProperty<OcaUint16>.PropertyValue
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.6"),
     getMethodID: OcaMethodID("3.7"),
-    setMethodID: OcaMethodID("3.8")
+    setMethodID: OcaMethodID("3.8"),
+    ocp2Name: "Role"
   )
   public var deviceRole: OcaProperty<OcaString>.PropertyValue
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.7"),
     getMethodID: OcaMethodID("3.9"),
-    setMethodID: OcaMethodID("3.10")
+    setMethodID: OcaMethodID("3.10"),
+    ocp2Name: "Code"
   )
   public var userInventoryCode: OcaProperty<OcaString>.PropertyValue
 
@@ -128,6 +140,12 @@ open class OcaDeviceManager: OcaManager, @unchecked Sendable {
        key.8, key.9, key.10, key.11, key.12, key.13, key.14, key.15]
     }
 
+    /// `bytes.count` must be 16.
+    private static func _resetKey(from bytes: [OcaUint8]) -> ResetKey {
+      (bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
+       bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15])
+    }
+
     private static func _decodeResetKey(
       from container: inout UnkeyedDecodingContainer
     ) throws -> ResetKey {
@@ -162,6 +180,16 @@ open class OcaDeviceManager: OcaManager, @unchecked Sendable {
 
     public init(from decoder: Decoder) throws {
       let container = try decoder.container(keyedBy: CodingKeys.self)
+      #if NonEmbeddedBuild
+      if decoder._isOcp2Decoder {
+        // OcaBlobFixedLen<16>: base64
+        let bytes = try container.decode(Data.self, forKey: .key)
+        guard bytes.count == 16 else { throw Ocp1Error.status(.badFormat) }
+        key = Self._resetKey(from: Array(bytes))
+        address = try container.decode(OcaNetworkAddress.self, forKey: .address)
+        return
+      }
+      #endif
       var keyContainer = try container.nestedUnkeyedContainer(forKey: .key)
       key = try Self._decodeResetKey(from: &keyContainer)
       address = try container.decode(OcaNetworkAddress.self, forKey: .address)
@@ -169,6 +197,13 @@ open class OcaDeviceManager: OcaManager, @unchecked Sendable {
 
     public func encode(to encoder: Encoder) throws {
       var container = encoder.container(keyedBy: CodingKeys.self)
+      #if NonEmbeddedBuild
+      if encoder._isOcp2Encoder {
+        try container.encode(Data(Self._resetKeyToBytes(key)), forKey: .key)
+        try container.encode(address, forKey: .address)
+        return
+      }
+      #endif
       var keyContainer = container.nestedUnkeyedContainer(forKey: .key)
       try Self._encodeResetKey(key, to: &keyContainer)
       try container.encode(address, forKey: .address)
@@ -207,7 +242,8 @@ open class OcaDeviceManager: OcaManager, @unchecked Sendable {
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.14"),
-    getMethodID: OcaMethodID("3.20")
+    getMethodID: OcaMethodID("3.20"),
+    ocp2Name: "ID"
   )
   public var deviceRevisionID: OcaProperty<OcaString>.PropertyValue
 
@@ -225,20 +261,23 @@ open class OcaDeviceManager: OcaManager, @unchecked Sendable {
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.17"),
-    getMethodID: OcaMethodID("3.23")
+    getMethodID: OcaMethodID("3.23"),
+    ocp2Name: "State"
   )
   public var operationalState: OcaProperty<OcaDeviceOperationalState>.PropertyValue
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.18"),
     getMethodID: OcaMethodID("3.24"),
-    setMethodID: OcaMethodID("3.25")
+    setMethodID: OcaMethodID("3.25"),
+    ocp2Name: "Enabled"
   )
   public var loggingEnabled: OcaProperty<OcaBoolean>.PropertyValue
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.19"),
-    getMethodID: OcaMethodID("3.26")
+    getMethodID: OcaMethodID("3.26"),
+    ocp2Name: "ONo"
   )
   public var mostRecentPatchDatasetONo: OcaProperty<OcaONo>.PropertyValue
 
@@ -247,10 +286,18 @@ open class OcaDeviceManager: OcaManager, @unchecked Sendable {
   }
 
   public func set(deviceName: String) async throws {
-    try await sendCommandRrq(methodID: OcaMethodID("3.5"), parameters: deviceName)
+    try await sendCommandRrq(
+      methodID: OcaMethodID("3.5"),
+      parameters: deviceName,
+      parameterNames: ["Name"]
+    )
   }
 
   public func applyPatch(datasetONo: OcaONo) async throws {
-    try await sendCommandRrq(methodID: OcaMethodID("3.27"), parameters: datasetONo)
+    try await sendCommandRrq(
+      methodID: OcaMethodID("3.27"),
+      parameters: datasetONo,
+      parameterNames: ["ONo"]
+    )
   }
 }

--- a/Sources/SwiftOCA/OCC/ControlClasses/Managers/DeviceManager.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Managers/DeviceManager.swift
@@ -34,7 +34,7 @@ open class OcaDeviceManager: OcaManager, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("3.1"),
     getMethodID: OcaMethodID("3.2"),
-    ocp2Name: "GUID"
+    ocp2GetName: "GUID"
   )
   public var modelGUID: OcaProperty<OcaModelGUID>.PropertyValue
 
@@ -47,7 +47,7 @@ open class OcaDeviceManager: OcaManager, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("3.3"),
     getMethodID: OcaMethodID("3.6"),
-    ocp2Name: "Description"
+    ocp2GetName: "Description"
   )
   public var modelDescription: OcaProperty<OcaModelDescription>.PropertyValue
 
@@ -55,7 +55,7 @@ open class OcaDeviceManager: OcaManager, @unchecked Sendable {
     propertyID: OcaPropertyID("3.4"),
     getMethodID: OcaMethodID("3.4"),
     setMethodID: OcaMethodID("3.5"),
-    ocp2Name: "Name",
+    ocp2GetName: "Name",
     ocp2SetName: "Name"
   )
   public var deviceName: OcaProperty<OcaString>.PropertyValue
@@ -63,7 +63,7 @@ open class OcaDeviceManager: OcaManager, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("3.5"),
     getMethodID: OcaMethodID("3.1"),
-    ocp2Name: "OcaVersion"
+    ocp2GetName: "OcaVersion"
   )
   public var version: OcaProperty<OcaUint16>.PropertyValue
 
@@ -71,7 +71,7 @@ open class OcaDeviceManager: OcaManager, @unchecked Sendable {
     propertyID: OcaPropertyID("3.6"),
     getMethodID: OcaMethodID("3.7"),
     setMethodID: OcaMethodID("3.8"),
-    ocp2Name: "Role",
+    ocp2GetName: "Role",
     ocp2SetName: "Role"
   )
   public var deviceRole: OcaProperty<OcaString>.PropertyValue
@@ -80,7 +80,7 @@ open class OcaDeviceManager: OcaManager, @unchecked Sendable {
     propertyID: OcaPropertyID("3.7"),
     getMethodID: OcaMethodID("3.9"),
     setMethodID: OcaMethodID("3.10"),
-    ocp2Name: "Code",
+    ocp2GetName: "Code",
     ocp2SetName: "Code"
   )
   public var userInventoryCode: OcaProperty<OcaString>.PropertyValue
@@ -234,7 +234,7 @@ open class OcaDeviceManager: OcaManager, @unchecked Sendable {
     propertyID: OcaPropertyID("3.12"),
     getMethodID: OcaMethodID("3.17"),
     setMethodID: OcaMethodID("3.18"),
-    ocp2Name: "Message",
+    ocp2GetName: "Message",
     ocp2SetName: "Text"
   )
   public var message: OcaProperty<OcaString>.PropertyValue
@@ -248,7 +248,7 @@ open class OcaDeviceManager: OcaManager, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("3.14"),
     getMethodID: OcaMethodID("3.20"),
-    ocp2Name: "ID"
+    ocp2GetName: "ID"
   )
   public var deviceRevisionID: OcaProperty<OcaString>.PropertyValue
 
@@ -267,7 +267,7 @@ open class OcaDeviceManager: OcaManager, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("3.17"),
     getMethodID: OcaMethodID("3.23"),
-    ocp2Name: "State"
+    ocp2GetName: "State"
   )
   public var operationalState: OcaProperty<OcaDeviceOperationalState>.PropertyValue
 
@@ -275,7 +275,7 @@ open class OcaDeviceManager: OcaManager, @unchecked Sendable {
     propertyID: OcaPropertyID("3.18"),
     getMethodID: OcaMethodID("3.24"),
     setMethodID: OcaMethodID("3.25"),
-    ocp2Name: "Enabled",
+    ocp2GetName: "Enabled",
     ocp2SetName: "Enabled"
   )
   public var loggingEnabled: OcaProperty<OcaBoolean>.PropertyValue
@@ -283,7 +283,7 @@ open class OcaDeviceManager: OcaManager, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("3.19"),
     getMethodID: OcaMethodID("3.26"),
-    ocp2Name: "ONo"
+    ocp2GetName: "ONo"
   )
   public var mostRecentPatchDatasetONo: OcaProperty<OcaONo>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Managers/DeviceManager.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Managers/DeviceManager.swift
@@ -55,7 +55,8 @@ open class OcaDeviceManager: OcaManager, @unchecked Sendable {
     propertyID: OcaPropertyID("3.4"),
     getMethodID: OcaMethodID("3.4"),
     setMethodID: OcaMethodID("3.5"),
-    ocp2Name: "Name"
+    ocp2Name: "Name",
+    ocp2SetName: "Name"
   )
   public var deviceName: OcaProperty<OcaString>.PropertyValue
 
@@ -70,7 +71,8 @@ open class OcaDeviceManager: OcaManager, @unchecked Sendable {
     propertyID: OcaPropertyID("3.6"),
     getMethodID: OcaMethodID("3.7"),
     setMethodID: OcaMethodID("3.8"),
-    ocp2Name: "Role"
+    ocp2Name: "Role",
+    ocp2SetName: "Role"
   )
   public var deviceRole: OcaProperty<OcaString>.PropertyValue
 
@@ -78,7 +80,8 @@ open class OcaDeviceManager: OcaManager, @unchecked Sendable {
     propertyID: OcaPropertyID("3.7"),
     getMethodID: OcaMethodID("3.9"),
     setMethodID: OcaMethodID("3.10"),
-    ocp2Name: "Code"
+    ocp2Name: "Code",
+    ocp2SetName: "Code"
   )
   public var userInventoryCode: OcaProperty<OcaString>.PropertyValue
 
@@ -230,7 +233,9 @@ open class OcaDeviceManager: OcaManager, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("3.12"),
     getMethodID: OcaMethodID("3.17"),
-    setMethodID: OcaMethodID("3.18")
+    setMethodID: OcaMethodID("3.18"),
+    ocp2Name: "Message",
+    ocp2SetName: "Text"
   )
   public var message: OcaProperty<OcaString>.PropertyValue
 
@@ -270,7 +275,8 @@ open class OcaDeviceManager: OcaManager, @unchecked Sendable {
     propertyID: OcaPropertyID("3.18"),
     getMethodID: OcaMethodID("3.24"),
     setMethodID: OcaMethodID("3.25"),
-    ocp2Name: "Enabled"
+    ocp2Name: "Enabled",
+    ocp2SetName: "Enabled"
   )
   public var loggingEnabled: OcaProperty<OcaBoolean>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Managers/DeviceTimeManager.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Managers/DeviceTimeManager.swift
@@ -35,7 +35,7 @@ open class OcaDeviceTimeManager: OcaManager, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("3.1"),
     getMethodID: OcaMethodID("3.3"),
-    ocp2Name: "TimeSourceONos"
+    ocp2GetName: "TimeSourceONos"
   )
   public var timeSources: OcaListProperty<OcaONo>.PropertyValue
 
@@ -43,7 +43,7 @@ open class OcaDeviceTimeManager: OcaManager, @unchecked Sendable {
     propertyID: OcaPropertyID("3.2"),
     getMethodID: OcaMethodID("3.4"),
     setMethodID: OcaMethodID("3.5"),
-    ocp2Name: "TimeSourceONo",
+    ocp2GetName: "TimeSourceONo",
     ocp2SetName: "TimeSourceONo"
   )
   public var currentDeviceTimeSource: OcaProperty<OcaONo>.PropertyValue

--- a/Sources/SwiftOCA/OCC/ControlClasses/Managers/DeviceTimeManager.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Managers/DeviceTimeManager.swift
@@ -43,7 +43,8 @@ open class OcaDeviceTimeManager: OcaManager, @unchecked Sendable {
     propertyID: OcaPropertyID("3.2"),
     getMethodID: OcaMethodID("3.4"),
     setMethodID: OcaMethodID("3.5"),
-    ocp2Name: "TimeSourceONo"
+    ocp2Name: "TimeSourceONo",
+    ocp2SetName: "TimeSourceONo"
   )
   public var currentDeviceTimeSource: OcaProperty<OcaONo>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Managers/DeviceTimeManager.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Managers/DeviceTimeManager.swift
@@ -34,14 +34,16 @@ open class OcaDeviceTimeManager: OcaManager, @unchecked Sendable {
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.1"),
-    getMethodID: OcaMethodID("3.3")
+    getMethodID: OcaMethodID("3.3"),
+    ocp2Name: "TimeSourceONos"
   )
   public var timeSources: OcaListProperty<OcaONo>.PropertyValue
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.2"),
     getMethodID: OcaMethodID("3.4"),
-    setMethodID: OcaMethodID("3.5")
+    setMethodID: OcaMethodID("3.5"),
+    ocp2Name: "TimeSourceONo"
   )
   public var currentDeviceTimeSource: OcaProperty<OcaONo>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Managers/DeviceTimeManager.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Managers/DeviceTimeManager.swift
@@ -25,7 +25,11 @@ open class OcaDeviceTimeManager: OcaManager, @unchecked Sendable {
   }
 
   public func set(deviceTimeNTP time: OcaTimeNTP) async throws {
-    try await sendCommandRrq(methodID: OcaMethodID("3.2"), parameters: time)
+    try await sendCommandRrq(
+      methodID: OcaMethodID("3.2"),
+      parameters: time,
+      parameterNames: ["DeviceTime"]
+    )
   }
 
   @OcaProperty(
@@ -48,7 +52,11 @@ open class OcaDeviceTimeManager: OcaManager, @unchecked Sendable {
   }
 
   public func set(deviceTimePTP time: OcaTime) async throws {
-    try await sendCommandRrq(methodID: OcaMethodID("3.7"), parameters: time)
+    try await sendCommandRrq(
+      methodID: OcaMethodID("3.7"),
+      parameters: time,
+      parameterNames: ["DeviceTime"]
+    )
   }
 
   public convenience init() {

--- a/Sources/SwiftOCA/OCC/ControlClasses/Managers/DiagnosticManager.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Managers/DiagnosticManager.swift
@@ -23,6 +23,10 @@ open class OcaDiagnosticManager: OcaManager, @unchecked Sendable {
   }
 
   public func getLockStatus(_ oNo: OcaONo) async throws -> OcaString {
-    try await sendCommandRrq(methodID: OcaMethodID("3.1"), parameters: oNo)
+    try await sendCommandRrq(
+      methodID: OcaMethodID("3.1"),
+      parameters: oNo,
+      parameterNames: ["ONo"] // name not in AES70-2023 model
+    )
   }
 }

--- a/Sources/SwiftOCA/OCC/ControlClasses/Managers/FirmwareManager.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Managers/FirmwareManager.swift
@@ -33,7 +33,11 @@ open class OcaFirmwareManager: OcaManager, @unchecked Sendable {
   }
 
   public func beginActiveImageUpdate(component: OcaComponent) async throws {
-    try await sendCommandRrq(methodID: OcaMethodID("3.3"), parameters: component)
+    try await sendCommandRrq(
+      methodID: OcaMethodID("3.3"),
+      parameters: component,
+      parameterNames: ["Component"]
+    )
   }
 
   public struct AddImageDataParameters: Ocp1ParametersReflectable {
@@ -61,7 +65,11 @@ open class OcaFirmwareManager: OcaManager, @unchecked Sendable {
   }
 
   public func verifyImage(_ verifyData: OcaBlob) async throws {
-    try await sendCommandRrq(methodID: OcaMethodID("3.5"), parameters: verifyData)
+    try await sendCommandRrq(
+      methodID: OcaMethodID("3.5"),
+      parameters: verifyData,
+      parameterNames: ["VerifyData"]
+    )
   }
 
   public func endActiveImageUpdate() async throws {

--- a/Sources/SwiftOCA/OCC/ControlClasses/Managers/LibraryManager.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Managers/LibraryManager.swift
@@ -32,7 +32,7 @@ open class OcaLibraryManager: OcaManager, @unchecked Sendable {
     propertyID: OcaPropertyID("3.2"),
     getMethodID: OcaMethodID("3.5"),
     setMethodID: OcaMethodID("3.6"),
-    ocp2Name: "ID",
+    ocp2GetName: "ID",
     ocp2SetName: "ID"
   )
   public var currentPatch: OcaProperty<OcaLibVolIdentifier>.PropertyValue

--- a/Sources/SwiftOCA/OCC/ControlClasses/Managers/LibraryManager.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Managers/LibraryManager.swift
@@ -31,7 +31,8 @@ open class OcaLibraryManager: OcaManager, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("3.2"),
     getMethodID: OcaMethodID("3.5"),
-    setMethodID: OcaMethodID("3.6")
+    setMethodID: OcaMethodID("3.6"),
+    ocp2Name: "ID"
   )
   public var currentPatch: OcaProperty<OcaLibVolIdentifier>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Managers/LibraryManager.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Managers/LibraryManager.swift
@@ -32,7 +32,8 @@ open class OcaLibraryManager: OcaManager, @unchecked Sendable {
     propertyID: OcaPropertyID("3.2"),
     getMethodID: OcaMethodID("3.5"),
     setMethodID: OcaMethodID("3.6"),
-    ocp2Name: "ID"
+    ocp2Name: "ID",
+    ocp2SetName: "ID"
   )
   public var currentPatch: OcaProperty<OcaLibVolIdentifier>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Managers/LockManager.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Managers/LockManager.swift
@@ -34,7 +34,11 @@ open class OcaLockManager: OcaManager, @unchecked Sendable {
   }
 
   public func abortWaits(oNo: OcaONo) async throws {
-    try await sendCommandRrq(methodID: OcaMethodID("3.2"), parameters: oNo)
+    try await sendCommandRrq(
+      methodID: OcaMethodID("3.2"),
+      parameters: oNo,
+      parameterNames: ["ONo"]
+    )
   }
 
   public convenience init() {

--- a/Sources/SwiftOCA/OCC/ControlClasses/Managers/MediaClockManager.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Managers/MediaClockManager.swift
@@ -21,7 +21,7 @@ open class OcaMediaClockManager: OcaManager, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("3.1"),
     getMethodID: OcaMethodID("3.2"),
-    ocp2Name: "MediaClockTypes"
+    ocp2GetName: "MediaClockTypes"
   )
   public var clockTypesSupported: OcaListProperty<OcaMediaClockType>.PropertyValue
 
@@ -34,7 +34,7 @@ open class OcaMediaClockManager: OcaManager, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("3.3"),
     getMethodID: OcaMethodID("3.3"),
-    ocp2Name: "Clocks"
+    ocp2GetName: "Clocks"
   )
   public var clock3s: OcaListProperty<OcaONo>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Managers/MediaClockManager.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Managers/MediaClockManager.swift
@@ -20,7 +20,8 @@ open class OcaMediaClockManager: OcaManager, @unchecked Sendable {
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.1"),
-    getMethodID: OcaMethodID("3.2")
+    getMethodID: OcaMethodID("3.2"),
+    ocp2Name: "MediaClockTypes"
   )
   public var clockTypesSupported: OcaListProperty<OcaMediaClockType>.PropertyValue
 
@@ -32,7 +33,8 @@ open class OcaMediaClockManager: OcaManager, @unchecked Sendable {
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.3"),
-    getMethodID: OcaMethodID("3.3")
+    getMethodID: OcaMethodID("3.3"),
+    ocp2Name: "Clocks"
   )
   public var clock3s: OcaListProperty<OcaONo>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Managers/NetworkManager.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Managers/NetworkManager.swift
@@ -45,14 +45,14 @@ open class OcaNetworkManager: OcaManager, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("3.5"),
     getMethodID: OcaMethodID("3.5"),
-    ocp2Name: "ONos"
+    ocp2GetName: "ONos"
   )
   public var networkInterfaces: OcaListProperty<OcaONo>.PropertyValue
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.6"),
     getMethodID: OcaMethodID("3.6"),
-    ocp2Name: "ONos"
+    ocp2GetName: "ONos"
   )
   public var networkApplications: OcaListProperty<OcaONo>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Managers/NetworkManager.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Managers/NetworkManager.swift
@@ -44,13 +44,15 @@ open class OcaNetworkManager: OcaManager, @unchecked Sendable {
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.5"),
-    getMethodID: OcaMethodID("3.5")
+    getMethodID: OcaMethodID("3.5"),
+    ocp2Name: "ONos"
   )
   public var networkInterfaces: OcaListProperty<OcaONo>.PropertyValue
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.6"),
-    getMethodID: OcaMethodID("3.6")
+    getMethodID: OcaMethodID("3.6"),
+    ocp2Name: "ONos"
   )
   public var networkApplications: OcaListProperty<OcaONo>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Managers/PowerManager.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Managers/PowerManager.swift
@@ -28,14 +28,14 @@ open class OcaPowerManager: OcaManager, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("3.2"),
     getMethodID: OcaMethodID("3.3"),
-    ocp2Name: "PsuList"
+    ocp2GetName: "PsuList"
   )
   public var powerSupplies: OcaListProperty<OcaONo>.PropertyValue
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.3"),
     getMethodID: OcaMethodID("3.4"),
-    ocp2Name: "PsuList"
+    ocp2GetName: "PsuList"
   )
   public var activePowerSupplies: OcaListProperty<OcaONo>.PropertyValue
 
@@ -68,7 +68,7 @@ open class OcaPowerManager: OcaManager, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("3.4"),
     getMethodID: OcaMethodID("3.6"),
-    ocp2Name: "State"
+    ocp2GetName: "State"
   )
   public var autoState: OcaProperty<OcaBoolean>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Managers/PowerManager.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Managers/PowerManager.swift
@@ -27,13 +27,15 @@ open class OcaPowerManager: OcaManager, @unchecked Sendable {
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.2"),
-    getMethodID: OcaMethodID("3.3")
+    getMethodID: OcaMethodID("3.3"),
+    ocp2Name: "PsuList"
   )
   public var powerSupplies: OcaListProperty<OcaONo>.PropertyValue
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.3"),
-    getMethodID: OcaMethodID("3.4")
+    getMethodID: OcaMethodID("3.4"),
+    ocp2Name: "PsuList"
   )
   public var activePowerSupplies: OcaListProperty<OcaONo>.PropertyValue
 
@@ -65,7 +67,8 @@ open class OcaPowerManager: OcaManager, @unchecked Sendable {
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.4"),
-    getMethodID: OcaMethodID("3.6")
+    getMethodID: OcaMethodID("3.6"),
+    ocp2Name: "State"
   )
   public var autoState: OcaProperty<OcaBoolean>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Managers/SecurityManager.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Managers/SecurityManager.swift
@@ -72,6 +72,10 @@ open class OcaSecurityManager: OcaManager, @unchecked Sendable {
   }
 
   public func deletePreSharedKey(identity: OcaString) async throws {
-    try await sendCommandRrq(methodID: OcaMethodID("3.5"), parameters: identity)
+    try await sendCommandRrq(
+      methodID: OcaMethodID("3.5"),
+      parameters: identity,
+      parameterNames: ["Identity"]
+    )
   }
 }

--- a/Sources/SwiftOCA/OCC/ControlClasses/Networks/MediaTransportApplication.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Networks/MediaTransportApplication.swift
@@ -157,7 +157,8 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, @unchecked Senda
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.1"),
-    getMethodID: OcaMethodID("3.3")
+    getMethodID: OcaMethodID("3.3"),
+    ocp2Name: "OcaPorts"
   )
   public var ports: OcaListProperty<OcaPort>.PropertyValue
 
@@ -178,7 +179,8 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, @unchecked Senda
   @OcaProperty(
     propertyID: OcaPropertyID("3.2"),
     getMethodID: OcaMethodID("3.6"),
-    setMethodID: OcaMethodID("3.7")
+    setMethodID: OcaMethodID("3.7"),
+    ocp2Name: "Map"
   )
   public var portClockMap: OcaMapProperty<OcaPortID, OcaPortClockMapEntry>.PropertyValue
 
@@ -235,13 +237,15 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, @unchecked Senda
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.5"),
-    getMethodID: OcaMethodID("3.12")
+    getMethodID: OcaMethodID("3.12"),
+    ocp2Name: "Value"
   )
   public var maxPortsPerChannel: OcaProperty<OcaUint16>.PropertyValue
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.6"),
-    getMethodID: OcaMethodID("3.13")
+    getMethodID: OcaMethodID("3.13"),
+    ocp2Name: "Value"
   )
   public var maxChannelsPerEndpoint: OcaProperty<OcaUint16>.PropertyValue
 
@@ -250,7 +254,8 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, @unchecked Senda
   @OcaProperty(
     propertyID: OcaPropertyID("3.7"),
     getMethodID: OcaMethodID("3.15"),
-    setMethodID: OcaMethodID("3.16")
+    setMethodID: OcaMethodID("3.16"),
+    ocp2Name: "Capabilities"
   )
   public var mediaStreamModeCapabilities: OcaListProperty<OcaMediaStreamModeCapability>
     .PropertyValue
@@ -264,7 +269,8 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, @unchecked Senda
   @OcaProperty(
     propertyID: OcaPropertyID("3.8"),
     getMethodID: OcaMethodID("3.18"),
-    setMethodID: OcaMethodID("3.19")
+    setMethodID: OcaMethodID("3.19"),
+    ocp2Name: "Parameters"
   )
   public var transportTimingParameters: OcaProperty<OcaMediaTransportTimingParameters>
     .PropertyValue
@@ -272,7 +278,8 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, @unchecked Senda
   @OcaProperty(
     propertyID: OcaPropertyID("3.9"),
     getMethodID: OcaMethodID("3.20"),
-    setMethodID: OcaMethodID("3.14")
+    setMethodID: OcaMethodID("3.14"),
+    ocp2Name: "Limits"
   )
   public var alignmentLevelLimits: OcaProperty<OcaInterval<OcaDBFS>>.PropertyValue
 
@@ -290,7 +297,8 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, @unchecked Senda
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.11"),
-    getMethodID: OcaMethodID("3.23")
+    getMethodID: OcaMethodID("3.23"),
+    ocp2Name: "Statuses"
   )
   public var endpointStatuses: OcaMapProperty<
     OcaMediaStreamEndpointID,
@@ -380,7 +388,8 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, @unchecked Senda
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.12"),
-    getMethodID: OcaMethodID("3.34")
+    getMethodID: OcaMethodID("3.34"),
+    ocp2Name: "Sets"
   )
   public var endpointCounterSets: OcaMapProperty<OcaID16, OcaCounterSet>.PropertyValue
 
@@ -444,7 +453,8 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, @unchecked Senda
   @OcaProperty(
     propertyID: OcaPropertyID("3.13"),
     getMethodID: OcaMethodID("3.40"),
-    setMethodID: OcaMethodID("3.41")
+    setMethodID: OcaMethodID("3.41"),
+    ocp2Name: "ONos"
   )
   public var transportSessionControlAgentONos: OcaListProperty<OcaONo>.PropertyValue
 }

--- a/Sources/SwiftOCA/OCC/ControlClasses/Networks/MediaTransportApplication.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Networks/MediaTransportApplication.swift
@@ -150,7 +150,8 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, @unchecked Senda
   public func delete(port id: OcaPortID) async throws {
     try await sendCommandRrq(
       methodID: OcaMethodID("3.2"),
-      parameters: id
+      parameters: id,
+      parameterNames: ["ID"]
     )
   }
 
@@ -203,14 +204,16 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, @unchecked Senda
   public func deletePortClockMapEntry(portID: OcaPortID) async throws {
     try await sendCommandRrq(
       methodID: OcaMethodID("3.9"),
-      parameters: portID
+      parameters: portID,
+      parameterNames: ["ID"]
     )
   }
 
   public func get(portID: OcaPortID) async throws -> OcaPortClockMapEntry {
     try await sendCommandRrq(
       methodID: OcaMethodID("3.10"),
-      parameters: portID
+      parameters: portID,
+      parameterNames: ["ID"]
     )
   }
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Networks/MediaTransportApplication.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Networks/MediaTransportApplication.swift
@@ -263,7 +263,11 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, @unchecked Senda
   public func getMediaStreamModeCapability(
     id: OcaID16
   ) async throws -> OcaMediaStreamModeCapability {
-    try await sendCommandRrq(methodID: OcaMethodID("3.17"), parameters: id)
+    try await sendCommandRrq(
+      methodID: OcaMethodID("3.17"),
+      parameters: id,
+      parameterNames: ["CapabilityID"]
+    )
   }
 
   @OcaProperty(
@@ -292,7 +296,7 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, @unchecked Senda
   public var endpoints: OcaListProperty<OcaMediaStreamEndpoint>.PropertyValue
 
   public func getEndpoint(_ id: OcaMediaStreamEndpointID) async throws -> OcaMediaStreamEndpoint {
-    try await sendCommandRrq(methodID: OcaMethodID("3.22"), parameters: id)
+    try await sendCommandRrq(methodID: OcaMethodID("3.22"), parameters: id, parameterNames: ["ID"])
   }
 
   @OcaProperty(
@@ -308,17 +312,21 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, @unchecked Senda
   public func getEndpointStatus(
     _ id: OcaMediaStreamEndpointID
   ) async throws -> OcaMediaStreamEndpointStatus {
-    try await sendCommandRrq(methodID: OcaMethodID("3.24"), parameters: id)
+    try await sendCommandRrq(methodID: OcaMethodID("3.24"), parameters: id, parameterNames: ["ID"])
   }
 
   /// Returns the given descriptor with its IDInternal set to the ID the device allocated.
   @discardableResult
   public func add(endpoint: OcaMediaStreamEndpoint) async throws -> OcaMediaStreamEndpoint {
-    try await sendCommandRrq(methodID: OcaMethodID("3.25"), parameters: endpoint)
+    try await sendCommandRrq(
+      methodID: OcaMethodID("3.25"),
+      parameters: endpoint,
+      parameterNames: ["Endpoint"]
+    )
   }
 
   public func delete(endpoint id: OcaMediaStreamEndpointID) async throws {
-    try await sendCommandRrq(methodID: OcaMethodID("3.26"), parameters: id)
+    try await sendCommandRrq(methodID: OcaMethodID("3.26"), parameters: id, parameterNames: ["ID"])
   }
 
   public func applyEndpointCommand(
@@ -371,7 +379,7 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, @unchecked Senda
   public func getEndpointTimeSource(
     _ id: OcaMediaStreamEndpointID
   ) async throws -> EndpointTimeSource {
-    try await sendCommandRrq(methodID: OcaMethodID("3.32"), parameters: id)
+    try await sendCommandRrq(methodID: OcaMethodID("3.32"), parameters: id, parameterNames: ["ID"])
   }
 
   public func setEndpoint(
@@ -394,7 +402,11 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, @unchecked Senda
   public var endpointCounterSets: OcaMapProperty<OcaID16, OcaCounterSet>.PropertyValue
 
   public func getEndpointCounterSet(_ id: OcaMediaStreamEndpointID) async throws -> OcaCounterSet {
-    try await sendCommandRrq(methodID: OcaMethodID("3.35"), parameters: id)
+    try await sendCommandRrq(
+      methodID: OcaMethodID("3.35"),
+      parameters: id,
+      parameterNames: ["EndpointID"]
+    )
   }
 
   public func getEndpointCounter(

--- a/Sources/SwiftOCA/OCC/ControlClasses/Networks/MediaTransportApplication.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Networks/MediaTransportApplication.swift
@@ -180,7 +180,8 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, @unchecked Senda
     propertyID: OcaPropertyID("3.2"),
     getMethodID: OcaMethodID("3.6"),
     setMethodID: OcaMethodID("3.7"),
-    ocp2Name: "Map"
+    ocp2Name: "Map",
+    ocp2SetName: "Map"
   )
   public var portClockMap: OcaMapProperty<OcaPortID, OcaPortClockMapEntry>.PropertyValue
 
@@ -255,7 +256,8 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, @unchecked Senda
     propertyID: OcaPropertyID("3.7"),
     getMethodID: OcaMethodID("3.15"),
     setMethodID: OcaMethodID("3.16"),
-    ocp2Name: "Capabilities"
+    ocp2Name: "Capabilities",
+    ocp2SetName: "Capabilities"
   )
   public var mediaStreamModeCapabilities: OcaListProperty<OcaMediaStreamModeCapability>
     .PropertyValue
@@ -274,7 +276,8 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, @unchecked Senda
     propertyID: OcaPropertyID("3.8"),
     getMethodID: OcaMethodID("3.18"),
     setMethodID: OcaMethodID("3.19"),
-    ocp2Name: "Parameters"
+    ocp2Name: "Parameters",
+    ocp2SetName: "Parameters"
   )
   public var transportTimingParameters: OcaProperty<OcaMediaTransportTimingParameters>
     .PropertyValue
@@ -283,7 +286,8 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, @unchecked Senda
     propertyID: OcaPropertyID("3.9"),
     getMethodID: OcaMethodID("3.20"),
     setMethodID: OcaMethodID("3.14"),
-    ocp2Name: "Limits"
+    ocp2Name: "Limits",
+    ocp2SetName: "Limits"
   )
   public var alignmentLevelLimits: OcaProperty<OcaInterval<OcaDBFS>>.PropertyValue
 
@@ -466,7 +470,8 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, @unchecked Senda
     propertyID: OcaPropertyID("3.13"),
     getMethodID: OcaMethodID("3.40"),
     setMethodID: OcaMethodID("3.41"),
-    ocp2Name: "ONos"
+    ocp2Name: "ONos",
+    ocp2SetName: "ONos"
   )
   public var transportSessionControlAgentONos: OcaListProperty<OcaONo>.PropertyValue
 }

--- a/Sources/SwiftOCA/OCC/ControlClasses/Networks/MediaTransportApplication.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Networks/MediaTransportApplication.swift
@@ -158,7 +158,7 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, @unchecked Senda
   @OcaProperty(
     propertyID: OcaPropertyID("3.1"),
     getMethodID: OcaMethodID("3.3"),
-    ocp2Name: "OcaPorts"
+    ocp2GetName: "OcaPorts"
   )
   public var ports: OcaListProperty<OcaPort>.PropertyValue
 
@@ -180,7 +180,7 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, @unchecked Senda
     propertyID: OcaPropertyID("3.2"),
     getMethodID: OcaMethodID("3.6"),
     setMethodID: OcaMethodID("3.7"),
-    ocp2Name: "Map",
+    ocp2GetName: "Map",
     ocp2SetName: "Map"
   )
   public var portClockMap: OcaMapProperty<OcaPortID, OcaPortClockMapEntry>.PropertyValue
@@ -239,14 +239,14 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, @unchecked Senda
   @OcaProperty(
     propertyID: OcaPropertyID("3.5"),
     getMethodID: OcaMethodID("3.12"),
-    ocp2Name: "Value"
+    ocp2GetName: "Value"
   )
   public var maxPortsPerChannel: OcaProperty<OcaUint16>.PropertyValue
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.6"),
     getMethodID: OcaMethodID("3.13"),
-    ocp2Name: "Value"
+    ocp2GetName: "Value"
   )
   public var maxChannelsPerEndpoint: OcaProperty<OcaUint16>.PropertyValue
 
@@ -256,7 +256,7 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, @unchecked Senda
     propertyID: OcaPropertyID("3.7"),
     getMethodID: OcaMethodID("3.15"),
     setMethodID: OcaMethodID("3.16"),
-    ocp2Name: "Capabilities",
+    ocp2GetName: "Capabilities",
     ocp2SetName: "Capabilities"
   )
   public var mediaStreamModeCapabilities: OcaListProperty<OcaMediaStreamModeCapability>
@@ -276,7 +276,7 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, @unchecked Senda
     propertyID: OcaPropertyID("3.8"),
     getMethodID: OcaMethodID("3.18"),
     setMethodID: OcaMethodID("3.19"),
-    ocp2Name: "Parameters",
+    ocp2GetName: "Parameters",
     ocp2SetName: "Parameters"
   )
   public var transportTimingParameters: OcaProperty<OcaMediaTransportTimingParameters>
@@ -286,7 +286,7 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, @unchecked Senda
     propertyID: OcaPropertyID("3.9"),
     getMethodID: OcaMethodID("3.20"),
     setMethodID: OcaMethodID("3.14"),
-    ocp2Name: "Limits",
+    ocp2GetName: "Limits",
     ocp2SetName: "Limits"
   )
   public var alignmentLevelLimits: OcaProperty<OcaInterval<OcaDBFS>>.PropertyValue
@@ -306,7 +306,7 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, @unchecked Senda
   @OcaProperty(
     propertyID: OcaPropertyID("3.11"),
     getMethodID: OcaMethodID("3.23"),
-    ocp2Name: "Statuses"
+    ocp2GetName: "Statuses"
   )
   public var endpointStatuses: OcaMapProperty<
     OcaMediaStreamEndpointID,
@@ -401,7 +401,7 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, @unchecked Senda
   @OcaProperty(
     propertyID: OcaPropertyID("3.12"),
     getMethodID: OcaMethodID("3.34"),
-    ocp2Name: "Sets"
+    ocp2GetName: "Sets"
   )
   public var endpointCounterSets: OcaMapProperty<OcaID16, OcaCounterSet>.PropertyValue
 
@@ -470,7 +470,7 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, @unchecked Senda
     propertyID: OcaPropertyID("3.13"),
     getMethodID: OcaMethodID("3.40"),
     setMethodID: OcaMethodID("3.41"),
-    ocp2Name: "ONos",
+    ocp2GetName: "ONos",
     ocp2SetName: "ONos"
   )
   public var transportSessionControlAgentONos: OcaListProperty<OcaONo>.PropertyValue

--- a/Sources/SwiftOCA/OCC/ControlClasses/Networks/NetworkApplication.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Networks/NetworkApplication.swift
@@ -41,7 +41,8 @@ Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("2.3"),
     getMethodID: OcaMethodID("2.5"),
-    setMethodID: OcaMethodID("2.6")
+    setMethodID: OcaMethodID("2.6"),
+    ocp2Name: "Assignments"
   )
   public var networkInterfaceAssignments: OcaListProperty<OcaNetworkInterfaceAssignment>
     .PropertyValue
@@ -49,7 +50,8 @@ Sendable {
   // "OcaOcp1" for OCP.1
   @OcaProperty(
     propertyID: OcaPropertyID("2.4"),
-    getMethodID: OcaMethodID("2.7")
+    getMethodID: OcaMethodID("2.7"),
+    ocp2Name: "Identifier"
   )
   public var adaptationIdentifier: OcaProperty<OcaAdaptationIdentifier>.PropertyValue
 
@@ -57,7 +59,8 @@ Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("2.5"),
     getMethodID: OcaMethodID("2.8"),
-    setMethodID: OcaMethodID("2.9")
+    setMethodID: OcaMethodID("2.9"),
+    ocp2Name: "Data"
   )
   public var adaptationData: OcaProperty<OcaAdaptationData>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Networks/NetworkApplication.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Networks/NetworkApplication.swift
@@ -42,7 +42,7 @@ Sendable {
     propertyID: OcaPropertyID("2.3"),
     getMethodID: OcaMethodID("2.5"),
     setMethodID: OcaMethodID("2.6"),
-    ocp2Name: "Assignments",
+    ocp2GetName: "Assignments",
     ocp2SetName: "Assignments"
   )
   public var networkInterfaceAssignments: OcaListProperty<OcaNetworkInterfaceAssignment>
@@ -52,7 +52,7 @@ Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("2.4"),
     getMethodID: OcaMethodID("2.7"),
-    ocp2Name: "Identifier"
+    ocp2GetName: "Identifier"
   )
   public var adaptationIdentifier: OcaProperty<OcaAdaptationIdentifier>.PropertyValue
 
@@ -61,7 +61,7 @@ Sendable {
     propertyID: OcaPropertyID("2.5"),
     getMethodID: OcaMethodID("2.8"),
     setMethodID: OcaMethodID("2.9"),
-    ocp2Name: "Data",
+    ocp2GetName: "Data",
     ocp2SetName: "Data"
   )
   public var adaptationData: OcaProperty<OcaAdaptationData>.PropertyValue

--- a/Sources/SwiftOCA/OCC/ControlClasses/Networks/NetworkApplication.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Networks/NetworkApplication.swift
@@ -71,7 +71,11 @@ Sendable {
   public var counterSet: OcaProperty<OcaCounterSet>.PropertyValue
 
   public func get(counter id: OcaID16) async throws -> OcaCounter {
-    try await sendCommandRrq(methodID: OcaMethodID("2.11"), parameters: id)
+    try await sendCommandRrq(
+      methodID: OcaMethodID("2.11"),
+      parameters: id,
+      parameterNames: ["CounterID"]
+    )
   }
 
   public func attach(counter id: OcaID16, to oNo: OcaONo) async throws {

--- a/Sources/SwiftOCA/OCC/ControlClasses/Networks/NetworkApplication.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Networks/NetworkApplication.swift
@@ -42,7 +42,8 @@ Sendable {
     propertyID: OcaPropertyID("2.3"),
     getMethodID: OcaMethodID("2.5"),
     setMethodID: OcaMethodID("2.6"),
-    ocp2Name: "Assignments"
+    ocp2Name: "Assignments",
+    ocp2SetName: "Assignments"
   )
   public var networkInterfaceAssignments: OcaListProperty<OcaNetworkInterfaceAssignment>
     .PropertyValue
@@ -60,7 +61,8 @@ Sendable {
     propertyID: OcaPropertyID("2.5"),
     getMethodID: OcaMethodID("2.8"),
     setMethodID: OcaMethodID("2.9"),
-    ocp2Name: "Data"
+    ocp2Name: "Data",
+    ocp2SetName: "Data"
   )
   public var adaptationData: OcaProperty<OcaAdaptationData>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Networks/NetworkInterface.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Networks/NetworkInterface.swift
@@ -60,7 +60,8 @@ Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("2.5"),
     getMethodID: OcaMethodID("2.9"),
-    setMethodID: OcaMethodID("2.10")
+    setMethodID: OcaMethodID("2.10"),
+    ocp2Name: "Id"
   )
   public var groupID: OcaProperty<OcaUint16>.PropertyValue
 
@@ -74,14 +75,16 @@ Sendable {
   /// "OcaIP4" or "OcaIP6"
   @OcaProperty(
     propertyID: OcaPropertyID("2.7"),
-    getMethodID: OcaMethodID("2.13")
+    getMethodID: OcaMethodID("2.13"),
+    ocp2Name: "Identifier"
   )
   public var adaptationIdentifier: OcaProperty<OcaAdaptationIdentifier>.PropertyValue
 
   /// adaptation-specific, e.g. encoded OcaIP4NetworkSettings or MilanNetworkInterfaceAdaptationData
   @OcaProperty(
     propertyID: OcaPropertyID("2.8"),
-    getMethodID: OcaMethodID("2.14")
+    getMethodID: OcaMethodID("2.14"),
+    ocp2Name: "Settings"
   )
   public var currentAdaptationData: OcaProperty<OcaBlob>.PropertyValue
 
@@ -89,14 +92,16 @@ Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("2.9"),
     getMethodID: OcaMethodID("2.15"),
-    setMethodID: OcaMethodID("2.16")
+    setMethodID: OcaMethodID("2.16"),
+    ocp2Name: "Settings"
   )
   public var requestedAdaptationData: OcaProperty<OcaBlob>.PropertyValue
 
   /// adaptation-specific, e.g. encoded OcaIP4NetworkSettings or MilanNetworkInterfaceAdaptationData
   @OcaProperty(
     propertyID: OcaPropertyID("2.10"),
-    getMethodID: OcaMethodID("2.17")
+    getMethodID: OcaMethodID("2.17"),
+    ocp2Name: "Pending"
   )
   public var networkSettingPending: OcaProperty<OcaBoolean>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Networks/NetworkInterface.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Networks/NetworkInterface.swift
@@ -124,7 +124,11 @@ Sendable {
   public var counterSet: OcaProperty<OcaCounterSet>.PropertyValue
 
   public func get(counter id: OcaID16) async throws -> OcaCounter {
-    try await sendCommandRrq(methodID: OcaMethodID("2.21"), parameters: id)
+    try await sendCommandRrq(
+      methodID: OcaMethodID("2.21"),
+      parameters: id,
+      parameterNames: ["CounterID"]
+    )
   }
 
   public func attach(counter id: OcaID16, to oNo: OcaONo) async throws {
@@ -147,7 +151,11 @@ Sendable {
   }
 
   public func apply(command: OcaNetworkInterfaceCommand) async throws {
-    try await sendCommandRrq(methodID: OcaMethodID("2.25"), parameters: command)
+    try await sendCommandRrq(
+      methodID: OcaMethodID("2.25"),
+      parameters: command,
+      parameterNames: ["Command"]
+    )
   }
 }
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Networks/NetworkInterface.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Networks/NetworkInterface.swift
@@ -54,7 +54,7 @@ Sendable {
     propertyID: OcaPropertyID("2.4"),
     getMethodID: OcaMethodID("2.7"),
     setMethodID: OcaMethodID("2.8"),
-    ocp2Name: "Name",
+    ocp2GetName: "Name",
     ocp2SetName: "Identifier"
   )
   public var systemIOInterfaceName: OcaProperty<OcaString>.PropertyValue
@@ -63,7 +63,7 @@ Sendable {
     propertyID: OcaPropertyID("2.5"),
     getMethodID: OcaMethodID("2.9"),
     setMethodID: OcaMethodID("2.10"),
-    ocp2Name: "Id",
+    ocp2GetName: "Id",
     ocp2SetName: "Id"
   )
   public var groupID: OcaProperty<OcaUint16>.PropertyValue
@@ -79,7 +79,7 @@ Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("2.7"),
     getMethodID: OcaMethodID("2.13"),
-    ocp2Name: "Identifier"
+    ocp2GetName: "Identifier"
   )
   public var adaptationIdentifier: OcaProperty<OcaAdaptationIdentifier>.PropertyValue
 
@@ -87,7 +87,7 @@ Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("2.8"),
     getMethodID: OcaMethodID("2.14"),
-    ocp2Name: "Settings"
+    ocp2GetName: "Settings"
   )
   public var currentAdaptationData: OcaProperty<OcaBlob>.PropertyValue
 
@@ -96,7 +96,7 @@ Sendable {
     propertyID: OcaPropertyID("2.9"),
     getMethodID: OcaMethodID("2.15"),
     setMethodID: OcaMethodID("2.16"),
-    ocp2Name: "Settings",
+    ocp2GetName: "Settings",
     ocp2SetName: "Settings"
   )
   public var requestedAdaptationData: OcaProperty<OcaBlob>.PropertyValue
@@ -105,7 +105,7 @@ Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("2.10"),
     getMethodID: OcaMethodID("2.17"),
-    ocp2Name: "Pending"
+    ocp2GetName: "Pending"
   )
   public var networkSettingPending: OcaProperty<OcaBoolean>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Networks/NetworkInterface.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Networks/NetworkInterface.swift
@@ -53,7 +53,9 @@ Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("2.4"),
     getMethodID: OcaMethodID("2.7"),
-    setMethodID: OcaMethodID("2.8")
+    setMethodID: OcaMethodID("2.8"),
+    ocp2Name: "Name",
+    ocp2SetName: "Identifier"
   )
   public var systemIOInterfaceName: OcaProperty<OcaString>.PropertyValue
 
@@ -61,7 +63,8 @@ Sendable {
     propertyID: OcaPropertyID("2.5"),
     getMethodID: OcaMethodID("2.9"),
     setMethodID: OcaMethodID("2.10"),
-    ocp2Name: "Id"
+    ocp2Name: "Id",
+    ocp2SetName: "Id"
   )
   public var groupID: OcaProperty<OcaUint16>.PropertyValue
 
@@ -93,7 +96,8 @@ Sendable {
     propertyID: OcaPropertyID("2.9"),
     getMethodID: OcaMethodID("2.15"),
     setMethodID: OcaMethodID("2.16"),
-    ocp2Name: "Settings"
+    ocp2Name: "Settings",
+    ocp2SetName: "Settings"
   )
   public var requestedAdaptationData: OcaProperty<OcaBlob>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Root+Commands.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Root+Commands.swift
@@ -21,81 +21,116 @@ import Foundation
 #endif
 
 private extension OcaRoot {
+  var _controlProtocol: OcaControlProtocol {
+    connectionDelegate?.controlProtocol ?? .ocp1
+  }
+
   func sendCommand(
     methodID: OcaMethodID,
-    parameterCount: OcaUint8,
-    parameterData: Data
+    parameters: Ocp1Parameters
   ) async throws {
     guard let connectionDelegate else { throw Ocp1Error.noConnectionDelegate }
     let command = Ocp1Command(
       commandSize: 0,
       targetONo: objectNumber,
       methodID: methodID,
-      parameters: Ocp1Parameters(
-        parameterCount: parameterCount,
-        parameterData: parameterData
-      )
+      parameters: parameters
     )
     try await connectionDelegate.sendCommand(command)
   }
 
   func sendCommandRrq(
     methodID: OcaMethodID,
-    parameterCount: OcaUint8,
-    parameterData: Data,
-    responseParameterCount: OcaUint8,
-    responseParameterData: inout Data
-  ) async throws {
-    let response = try await sendCommandRrq(
-      methodID: methodID,
-      parameterCount: parameterCount,
-      parameterData: parameterData
-    )
+    parameters: Ocp1Parameters,
+    responseParameterCount: OcaUint8
+  ) async throws -> Ocp1Parameters {
+    let response = try await sendCommandRrq(methodID: methodID, parameters: parameters)
     guard response.statusCode == .ok else {
       throw Ocp1Error.status(response.statusCode)
     }
-    guard response.parameters.parameterCount == responseParameterCount else {
-      throw Ocp1Error.responseParameterOutOfRange
+    if response.parameters.format == .ocp1 {
+      guard response.parameters.parameterCount == responseParameterCount else {
+        throw Ocp1Error.responseParameterOutOfRange
+      }
     }
-    responseParameterData = response.parameters.parameterData
+    return response.parameters
   }
 
+  /// Encodes `parameters` for the connection's protocol. `parameterNames` names them
+  /// on OCP.2 (see `Ocp2Encoder.encodeParameters`) and is ignored on OCP.1.
   func encodeParameters(
     _ parameters: some Encodable,
+    parameterCount: OcaUint8? = nil,
+    parameterNames: [String]? = nil,
     userInfo: [CodingUserInfoKey: Any]? = nil
-  ) throws -> Data {
-    var encoder = Ocp1Encoder()
-    if let userInfo { encoder.userInfo = userInfo }
-    return try encoder.encode(parameters)
+  ) throws -> Ocp1Parameters {
+    switch _controlProtocol {
+    case .ocp1:
+      var encoder = Ocp1Encoder()
+      if let userInfo { encoder.userInfo = userInfo }
+      return try Ocp1Parameters(
+        parameterCount: parameterCount ?? _ocp1ParameterCount(type: type(of: parameters)),
+        parameterData: encoder.encode(parameters)
+      )
+    #if NonEmbeddedBuild
+    case .ocp2:
+      var encoder = Ocp2Encoder()
+      if let userInfo { encoder.userInfo = userInfo }
+      let object = try encoder.encodeParameters(parameters, parameterNames: parameterNames)
+      return try Ocp1Parameters(
+        ocp2ParameterData: object.isEmpty ? Data() : Ocp2JSON.serialize(object)
+      )
+    #endif
+    }
   }
 
   func decodeResponse<U: Decodable>(
     _ type: U.Type,
-    from data: Data,
+    from parameters: Ocp1Parameters,
+    parameterNames: [String]? = nil,
     userInfo: [CodingUserInfoKey: Any]? = nil
   ) throws -> U {
-    var decoder = Ocp1Decoder()
-    if let userInfo { decoder.userInfo = userInfo }
-    return try decoder.decode(U.self, from: data)
+    switch parameters.format {
+    case .ocp1:
+      var decoder = Ocp1Decoder()
+      if let userInfo { decoder.userInfo = userInfo }
+      return try decoder.decode(U.self, from: parameters.parameterData)
+    case .ocp2:
+      #if NonEmbeddedBuild
+      var decoder = Ocp2Decoder()
+      if let userInfo { decoder.userInfo = userInfo }
+      return try decoder.decodeParameters(
+        U.self,
+        from: parameters.parameterData,
+        parameterNames: parameterNames
+      )
+      #else
+      throw Ocp1Error.unsupportedControlProtocol
+      #endif
+    }
   }
 }
 
 public extension OcaRoot {
-  /// Send a command, not expecting a response
+  /// Send a command, not expecting a response.
+  ///
+  /// `parameterNames` names the parameters on an OCP.2 connection: one name per
+  /// stored property of a parameter record, or a single name for a scalar. Names not
+  /// supplied are derived from the Swift field names (`Ocp2Naming`).
   final func sendCommand<T: Encodable>(
     methodID: OcaMethodID,
     parameterCount: OcaUint8? = nil,
     parameters: T,
+    parameterNames: [String]? = nil,
     userInfo: [CodingUserInfoKey: Any]? = nil
   ) async throws {
-    let parameterCount = parameterCount ?? _ocp1ParameterCount(type: T.self)
-    let parameterData = try encodeParameters(parameters, userInfo: userInfo)
-
-    try await sendCommand(
-      methodID: methodID,
+    let parameters = try encodeParameters(
+      parameters,
       parameterCount: parameterCount,
-      parameterData: parameterData
+      parameterNames: parameterNames,
+      userInfo: userInfo
     )
+    try await sendCommand(methodID: methodID, parameters: parameters)
   }
 }
 
@@ -104,73 +139,89 @@ public extension OcaRoot {
     public init() {}
   }
 
+  /// Send a command and decode its response. `parameterNames` is as for
+  /// `sendCommand`. The response is matched by name, so `responseNames` is needed only
+  /// where the response record's field names differ from the model's (a bounded
+  /// property's `Gain`, `minGain`, `maxGain`).
   final func sendCommandRrq<T: Encodable, U: Decodable>(
     methodID: OcaMethodID,
     parameters: T = Placeholder(),
+    parameterNames: [String]? = nil,
+    responseNames: [String]? = nil,
     userInfo: [CodingUserInfoKey: Any]? = nil
   ) async throws -> U {
-    let parameterData = try encodeParameters(parameters, userInfo: userInfo)
-    var responseParameterData = Data()
-
-    try await sendCommandRrq(
-      methodID: methodID,
-      parameterCount: _ocp1ParameterCount(type: T.self),
-      parameterData: parameterData,
-      responseParameterCount: _ocp1ParameterCount(type: U.self),
-      responseParameterData: &responseParameterData
+    let parameters = try encodeParameters(
+      parameters,
+      parameterNames: parameterNames,
+      userInfo: userInfo
     )
-    return try decodeResponse(U.self, from: responseParameterData, userInfo: userInfo)
+    let response = try await sendCommandRrq(
+      methodID: methodID,
+      parameters: parameters,
+      responseParameterCount: _ocp1ParameterCount(type: U.self)
+    )
+    return try decodeResponse(U.self, from: response, parameterNames: responseNames, userInfo: userInfo)
   }
 
   final func sendCommandRrq<T: Encodable>(
     methodID: OcaMethodID,
     parameters: T,
+    parameterNames: [String]? = nil,
     userInfo: [CodingUserInfoKey: Any]? = nil
   ) async throws {
-    let parameterData = try encodeParameters(parameters, userInfo: userInfo)
-    var responseParameterData = Data()
-
-    try await sendCommandRrq(
+    let parameters = try encodeParameters(
+      parameters,
+      parameterNames: parameterNames,
+      userInfo: userInfo
+    )
+    _ = try await sendCommandRrq(
       methodID: methodID,
-      parameterCount: _ocp1ParameterCount(type: T.self),
-      parameterData: parameterData,
-      responseParameterCount: 0,
-      responseParameterData: &responseParameterData
+      parameters: parameters,
+      responseParameterCount: 0
     )
   }
 
   final func sendCommandRrq(
     methodID: OcaMethodID
   ) async throws {
-    var responseParameterData = Data()
-    try await sendCommandRrq(
+    _ = try await sendCommandRrq(
       methodID: methodID,
-      parameterCount: 0,
-      parameterData: Data(),
-      responseParameterCount: 0,
-      responseParameterData: &responseParameterData
+      parameters: Ocp1Parameters(),
+      responseParameterCount: 0
     )
   }
 }
 
 public extension OcaRoot {
-  // public for FlutterSwiftOCA to use
+  /// Send pre-encoded parameters; they must be in the connection's format.
   final func sendCommandRrq(
     methodID: OcaMethodID,
-    parameterCount: OcaUint8,
-    parameterData: Data
+    parameters: Ocp1Parameters
   ) async throws -> Ocp1Response {
     guard let connectionDelegate else { throw Ocp1Error.noConnectionDelegate }
+    guard parameters.isEmpty || parameters.format == connectionDelegate.controlProtocol.parameterFormat
+    else {
+      throw Ocp1Error.unsupportedControlProtocol
+    }
 
     let command = Ocp1Command(
       commandSize: 0,
       targetONo: objectNumber,
       methodID: methodID,
-      parameters: Ocp1Parameters(
-        parameterCount: parameterCount,
-        parameterData: parameterData
-      )
+      parameters: parameters
     )
     return try await connectionDelegate.sendCommandRrq(command)
+  }
+
+  // public for FlutterSwiftOCA to use; OCP.1-encoded parameters only
+  final func sendCommandRrq(
+    methodID: OcaMethodID,
+    parameterCount: OcaUint8,
+    parameterData: Data
+  ) async throws -> Ocp1Response {
+    try await sendCommandRrq(
+      methodID: methodID,
+      parameters: Ocp1Parameters(parameterCount: parameterCount, parameterData: parameterData)
+    )
   }
 }

--- a/Sources/SwiftOCA/OCC/ControlClasses/Root+Commands.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Root+Commands.swift
@@ -76,9 +76,8 @@ private extension OcaRoot {
     case .ocp2:
       var encoder = Ocp2Encoder()
       if let userInfo { encoder.userInfo = userInfo }
-      let object = try encoder.encodeParameters(parameters, parameterNames: parameterNames)
       return try Ocp1Parameters(
-        ocp2ParameterData: object.isEmpty ? Data() : Ocp2JSON.serialize(object)
+        ocp2Parameters: encoder.encodeParameters(parameters, parameterNames: parameterNames)
       )
     #endif
     }
@@ -101,7 +100,7 @@ private extension OcaRoot {
       if let userInfo { decoder.userInfo = userInfo }
       return try decoder.decodeParameters(
         U.self,
-        from: parameters.parameterData,
+        from: parameters.ocp2Parameters,
         parameterNames: parameterNames
       )
       #else

--- a/Sources/SwiftOCA/OCC/ControlClasses/Root+JSON.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Root+JSON.swift
@@ -83,7 +83,4 @@ package func reencodeAsValidJSONObject(_ value: some Codable) throws -> any Send
     .value as! any Sendable
 }
 
-enum OcaJSONPropertyKeys: String {
-  case type
-}
 #endif

--- a/Sources/SwiftOCA/OCC/ControlClasses/Root.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Root.swift
@@ -88,7 +88,7 @@ open class OcaRoot: CustomStringConvertible, @unchecked Sendable, _OcaObjectKeyP
   @OcaProperty(
     propertyID: OcaPropertyID("1.6"),
     getMethodID: OcaMethodID("1.7"),
-    ocp2Name: "State"
+    ocp2GetName: "State"
   )
   public var lockState: OcaProperty<OcaLockState>.PropertyValue
 
@@ -350,12 +350,12 @@ public extension OcaRoot {
       nil
     }
 
-    func _ocp2WireName(_ object: OcaRoot) -> String? {
+    func _ocp2GetName(_ object: OcaRoot) -> String? {
       object._jsonPropertyName(for: propertyIDs[0])
     }
 
     func _ocp2ResponseNames(_ object: OcaRoot) -> [String]? {
-      _ocp2WireName(object).map { [$0] }
+      _ocp2GetName(object).map { [$0] }
     }
 
     var propertyIDs: [OcaPropertyID]
@@ -393,7 +393,7 @@ public extension OcaRoot {
       keyPath: AnyKeyPath,
       flags: OcaPropertyResolutionFlags = .defaultFlags
     ) async throws -> [String: any Sendable] {
-      let name = _ocp2WireName(object) ?? propertyIDs[0].description
+      let name = _ocp2GetName(object) ?? propertyIDs[0].description
       return try [name: Ocp2JSON.sendable(Ocp2Encoder().encodeValue(value))]
     }
     #endif

--- a/Sources/SwiftOCA/OCC/ControlClasses/Root.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Root.swift
@@ -87,7 +87,8 @@ open class OcaRoot: CustomStringConvertible, @unchecked Sendable, _OcaObjectKeyP
 
   @OcaProperty(
     propertyID: OcaPropertyID("1.6"),
-    getMethodID: OcaMethodID("1.7")
+    getMethodID: OcaMethodID("1.7"),
+    ocp2Name: "State"
   )
   public var lockState: OcaProperty<OcaLockState>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Root.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Root.swift
@@ -262,18 +262,16 @@ public extension OcaRoot {
   }
 
   @OcaConnection
-  private func onPropertyEvent(event: OcaEvent, eventData data: Data) {
-    // event data arrives in the connection's format
-    let format = connectionDelegate?.controlProtocol.parameterFormat ?? .ocp1
+  private func onPropertyEvent(event: OcaEvent, eventData: OcaEncodedEventData) {
     // the property with this ID from the class's key paths, worked out once, rather than
     // reading every property of the object in turn, computed ones included, and casting
     // each to find it
-    guard let propertyID = try? OcaEventDataCoding.propertyID(from: data, format: format),
+    guard let propertyID = try? OcaEventDataCoding.propertyID(from: eventData),
       let keyPath = OcaPropertyKeyPathCache.shared.lookupProperty(byID: propertyID, for: self),
       let value = self[keyPath: keyPath] as? (any OcaPropertyChangeEventNotifiable)
     else { return }
 
-    try? value.onEvent(self, event: event, eventData: data, format: format)
+    try? value.onEvent(self, event: event, eventData: eventData)
   }
 
   @OcaConnection
@@ -289,11 +287,11 @@ public extension OcaRoot {
       // per-object label: aliased proxies for the same ONo (e.g. a resolved
       // subclass alongside a connection's built-in manager) must each register
       // their own callback, or the loser's property subjects never see events
-      subscriptionCancellable = try await connectionDelegate.addSubscription(
+      subscriptionCancellable = try await connectionDelegate.addEventDataSubscription(
         label: "com.padl.SwiftOCA.OcaRoot.\(ObjectIdentifier(self))",
         event: event
-      ) { [weak self] event, data in
-        await self?.onPropertyEvent(event: event, eventData: data)
+      ) { [weak self] event, eventData in
+        await self?.onPropertyEvent(event: event, eventData: eventData)
       }
     } catch Ocp1Error.alreadySubscribedToEvent(_) {
     } catch Ocp1Error.status(.invalidRequest) {

--- a/Sources/SwiftOCA/OCC/ControlClasses/Root.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Root.swift
@@ -62,9 +62,10 @@ open class OcaRoot: CustomStringConvertible, @unchecked Sendable, _OcaObjectKeyP
   }
 
   // 1.3
+  private static let _objectNumberPropertyID = OcaPropertyID("1.3")
   public let objectNumber: OcaONo
   private var _objectNumber: StaticProperty<OcaONo> {
-    StaticProperty<OcaONo>(propertyIDs: [OcaPropertyID("1.3")], value: objectNumber)
+    StaticProperty<OcaONo>(propertyIDs: [Self._objectNumberPropertyID], value: objectNumber)
   }
 
   @OcaProperty(
@@ -143,6 +144,9 @@ open class OcaRoot: CustomStringConvertible, @unchecked Sendable, _OcaObjectKeyP
   }
 
   #if NonEmbeddedBuild
+  /// The object's properties as OCP.2 JSON: each property under its wire name with
+  /// its AES70-4 marshaled value, the same encoding the protocol carries. Every member
+  /// is a property; the class is identified by `ClassID` and `ClassVersion`.
   open func getJsonValue(
     flags: OcaPropertyResolutionFlags = .defaultFlags
   ) async -> [String: any Sendable] {
@@ -173,11 +177,21 @@ open class OcaRoot: CustomStringConvertible, @unchecked Sendable, _OcaObjectKeyP
           return dict
         }
       }
-      let type = String(describing: type(of: self))
       return await taskGroup.collect()
         .reduce(into: [String: Sendable]()) { $0.merge($1) { $1 } }
-        .merging([OcaJSONPropertyKeys.type.rawValue: type], uniquingKeysWith: { $1 })
     }
+  }
+
+  /// The OCP.2 wire name of a property for the JSON export, derived from its Swift
+  /// name with no exceptions: the object number resolves to `ObjectNumber`, which is
+  /// what AES70-2 calls that property (`ONo` is the model's name for object-number
+  /// *parameters* and struct fields, not for this). A property the reflected table
+  /// does not know falls back to its property ID.
+  func _jsonPropertyName(for propertyID: OcaPropertyID) -> String {
+    guard let name = propertyName(for: propertyID) else {
+      return propertyID.description
+    }
+    return Ocp2Naming.wireName(name)
   }
 
   public var jsonObject: [String: any Sendable] {
@@ -193,6 +207,12 @@ open class OcaRoot: CustomStringConvertible, @unchecked Sendable, _OcaObjectKeyP
 
   public func propertyKeyPath(for name: String) -> AnyKeyPath? {
     OcaPropertyKeyPathCache.shared.lookupProperty(byName: name, for: self)
+  }
+
+  /// The Swift name of the property with `propertyID`, from which its OCP.2 wire name
+  /// is derived.
+  public func propertyName(for propertyID: OcaPropertyID) -> String? {
+    OcaPropertyKeyPathCache.shared.lookupPropertyName(byID: propertyID, for: self)
   }
 }
 
@@ -242,19 +262,17 @@ public extension OcaRoot {
 
   @OcaConnection
   private func onPropertyEvent(event: OcaEvent, eventData data: Data) {
-    let decoder = Ocp1Decoder()
+    // event data arrives in the connection's format
+    let format = connectionDelegate?.controlProtocol.parameterFormat ?? .ocp1
     // the property with this ID from the class's key paths, worked out once, rather than
     // reading every property of the object in turn, computed ones included, and casting
     // each to find it
-    guard let propertyID = try? decoder.decode(
-      OcaPropertyID.self,
-      from: data
-    ),
+    guard let propertyID = try? OcaEventDataCoding.propertyID(from: data, format: format),
       let keyPath = OcaPropertyKeyPathCache.shared.lookupProperty(byID: propertyID, for: self),
       let value = self[keyPath: keyPath] as? (any OcaPropertyChangeEventNotifiable)
     else { return }
 
-    try? value.onEvent(self, event: event, eventData: data)
+    try? value.onEvent(self, event: event, eventData: data, format: format)
   }
 
   @OcaConnection
@@ -325,8 +343,20 @@ public extension OcaRoot {
 
     typealias Value = T
 
+    var getMethodID: OcaMethodID? {
+      nil
+    }
+
     var setMethodID: OcaMethodID? {
       nil
+    }
+
+    func _ocp2WireName(_ object: OcaRoot) -> String? {
+      object._jsonPropertyName(for: propertyIDs[0])
+    }
+
+    func _ocp2ResponseNames(_ object: OcaRoot) -> [String]? {
+      _ocp2WireName(object).map { [$0] }
     }
 
     var propertyIDs: [OcaPropertyID]
@@ -364,12 +394,8 @@ public extension OcaRoot {
       keyPath: AnyKeyPath,
       flags: OcaPropertyResolutionFlags = .defaultFlags
     ) async throws -> [String: any Sendable] {
-      let jsonValue: any Sendable = if JSONSerialization.isValidJSONObject(value) {
-        value
-      } else {
-        try reencodeAsValidJSONObject(value)
-      }
-      return try [keyPath.jsonKey: jsonValue]
+      let name = _ocp2WireName(object) ?? propertyIDs[0].description
+      return try [name: Ocp2JSON.sendable(Ocp2Encoder().encodeValue(value))]
     }
     #endif
 
@@ -393,6 +419,7 @@ private final class OcaPropertyKeyPathCache: Sendable {
     let keyPaths: [String: AnyKeyPath]
     let propertiesByID: [OcaPropertyID: AnyKeyPath]
     let propertiesByName: [String: AnyKeyPath]
+    let propertyNamesByID: [OcaPropertyID: String]
 
     private init(keyPaths: [String: AnyKeyPath], object: some OcaRoot) {
       self.keyPaths = keyPaths
@@ -403,6 +430,15 @@ private final class OcaPropertyKeyPathCache: Sendable {
 
         for propertyID in value.propertyIDs {
           $0[propertyID] = $1.value
+        }
+      }
+      propertyNamesByID = keyPaths.reduce(into: [:]) {
+        guard let value = object[keyPath: $1.value] as? any OcaPropertySubjectRepresentable else {
+          return
+        }
+
+        for propertyID in value.propertyIDs {
+          $0[propertyID] = $1.key
         }
       }
       propertiesByName = keyPaths.reduce(into: [:]) {
@@ -456,6 +492,13 @@ private final class OcaPropertyKeyPathCache: Sendable {
     for object: some OcaRoot
   ) -> AnyKeyPath? {
     cacheEntry(for: object).propertiesByName[name]
+  }
+
+  fileprivate func lookupPropertyName(
+    byID propertyID: OcaPropertyID,
+    for object: some OcaRoot
+  ) -> String? {
+    cacheEntry(for: object).propertyNamesByID[propertyID]
   }
 }
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/Delay.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/Delay.swift
@@ -19,10 +19,14 @@ open class OcaDelay: OcaActuator, @unchecked Sendable {
   override open class var classVersion: OcaClassVersionNumber { 3 }
 
   /// delay in seconds
+  // the model names the setter's parameter `delayTime` where its getter says `Time`;
+  // OcaDelayExtended is self-consistent, so the difference is with the committee
   @OcaBoundedProperty(
     propertyID: OcaPropertyID("4.1"),
     getMethodID: OcaMethodID("4.1"),
-    setMethodID: OcaMethodID("4.2")
+    setMethodID: OcaMethodID("4.2"),
+    ocp2Name: "Time",
+    ocp2SetName: "Time"
   )
   public var delayTime: OcaBoundedProperty<OcaTimeInterval>.PropertyValue
 }
@@ -36,7 +40,8 @@ open class OcaDelayExtended: OcaDelay, @unchecked Sendable {
     propertyID: OcaPropertyID("5.1"),
     getMethodID: OcaMethodID("5.1"),
     setMethodID: OcaMethodID("5.2"),
-    ocp2Name: "Value"
+    ocp2Name: "Value",
+    ocp2SetName: "Value"
   )
   public var delayValue: OcaBoundedProperty<OcaDelayValue>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/Delay.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/Delay.swift
@@ -44,7 +44,8 @@ open class OcaDelayExtended: OcaDelay, @unchecked Sendable {
   {
     try await sendCommandRrq(
       methodID: OcaMethodID("5.3"),
-      parameters: unitOfMeasure
+      parameters: unitOfMeasure,
+      parameterNames: ["UoM"]
     )
   }
 }

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/Delay.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/Delay.swift
@@ -25,7 +25,7 @@ open class OcaDelay: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.1"),
     getMethodID: OcaMethodID("4.1"),
     setMethodID: OcaMethodID("4.2"),
-    ocp2Name: "Time",
+    ocp2GetName: "Time",
     ocp2SetName: "Time"
   )
   public var delayTime: OcaBoundedProperty<OcaTimeInterval>.PropertyValue
@@ -40,7 +40,7 @@ open class OcaDelayExtended: OcaDelay, @unchecked Sendable {
     propertyID: OcaPropertyID("5.1"),
     getMethodID: OcaMethodID("5.1"),
     setMethodID: OcaMethodID("5.2"),
-    ocp2Name: "Value",
+    ocp2GetName: "Value",
     ocp2SetName: "Value"
   )
   public var delayValue: OcaBoundedProperty<OcaDelayValue>.PropertyValue

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/Delay.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/Delay.swift
@@ -35,7 +35,8 @@ open class OcaDelayExtended: OcaDelay, @unchecked Sendable {
   @OcaBoundedProperty(
     propertyID: OcaPropertyID("5.1"),
     getMethodID: OcaMethodID("5.1"),
-    setMethodID: OcaMethodID("5.2")
+    setMethodID: OcaMethodID("5.2"),
+    ocp2Name: "Value"
   )
   public var delayValue: OcaBoundedProperty<OcaDelayValue>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/Dynamics.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/Dynamics.swift
@@ -373,7 +373,10 @@ open class OcaDynamicsCurve: OcaActuator, @unchecked Sendable {
     )
   {
     let parameters: GetFloat32ListParameters =
-      try await sendCommandRrq(methodID: OcaMethodID("4.5"))
+      try await sendCommandRrq(
+        methodID: OcaMethodID("4.5"),
+        responseNames: ["Slopes", "MinSlope", "MaxSlope"]
+      )
     return (parameters.values, parameters.minValues, parameters.maxValues)
   }
 
@@ -385,7 +388,10 @@ open class OcaDynamicsCurve: OcaActuator, @unchecked Sendable {
     )
   {
     let parameters: GetFloat32ListParameters =
-      try await sendCommandRrq(methodID: OcaMethodID("4.7"))
+      try await sendCommandRrq(
+        methodID: OcaMethodID("4.7"),
+        responseNames: ["Parameters", "MinParameter", "MaxParameter"]
+      )
     return (parameters.values, parameters.minValues, parameters.maxValues)
   }
 
@@ -438,7 +444,16 @@ open class OcaDynamicsCurve: OcaActuator, @unchecked Sendable {
         kneeParameters: kneeParameters,
         dynamicGainFloor: dynamicGainFloor,
         dynamicGainCeiling: dynamicGainCeiling
-      )
+      ),
+      parameterNames: [
+        "Mask",
+        "NSegments",
+        "Thresholds",
+        "Slope",
+        "KneeParameter",
+        "DynamicGainFloor",
+        "DynamicGainCeiling",
+      ]
     )
   }
 }

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/Dynamics.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/Dynamics.swift
@@ -29,7 +29,7 @@ open class OcaDynamics: OcaActuator, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.2"),
-    ocp2Name: "Gain"
+    ocp2GetName: "Gain"
   )
   public var dynamicGain: OcaProperty<OcaDB>.PropertyValue
 
@@ -37,7 +37,7 @@ open class OcaDynamics: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.3"),
     setMethodID: OcaMethodID("4.4"),
-    ocp2Name: "Func",
+    ocp2GetName: "Func",
     ocp2SetName: "Func"
   )
   public var function: OcaProperty<OcaDynamicsFunction>.PropertyValue
@@ -61,7 +61,7 @@ open class OcaDynamics: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.6"),
     getMethodID: OcaMethodID("4.9"),
     setMethodID: OcaMethodID("4.10"),
-    ocp2Name: "Units",
+    ocp2GetName: "Units",
     ocp2SetName: "Units"
   )
   public var thresholdPresentationUnits: OcaProperty<OcaPresentationUnit>.PropertyValue
@@ -70,7 +70,7 @@ open class OcaDynamics: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.7"),
     getMethodID: OcaMethodID("4.11"),
     setMethodID: OcaMethodID("4.12"),
-    ocp2Name: "Law",
+    ocp2GetName: "Law",
     ocp2SetName: "Law"
   )
   public var detectorLaw: OcaProperty<OcaLevelDetectionLaw>.PropertyValue
@@ -79,7 +79,7 @@ open class OcaDynamics: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.8"),
     getMethodID: OcaMethodID("4.13"),
     setMethodID: OcaMethodID("4.14"),
-    ocp2Name: "Time",
+    ocp2GetName: "Time",
     ocp2SetName: "Time"
   )
   public var attackTime: OcaBoundedProperty<OcaTimeInterval>.PropertyValue
@@ -88,7 +88,7 @@ open class OcaDynamics: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.9"),
     getMethodID: OcaMethodID("4.15"),
     setMethodID: OcaMethodID("4.16"),
-    ocp2Name: "Time",
+    ocp2GetName: "Time",
     ocp2SetName: "Time"
   )
   public var releaseTime: OcaBoundedProperty<OcaTimeInterval>.PropertyValue
@@ -97,7 +97,7 @@ open class OcaDynamics: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.10"),
     getMethodID: OcaMethodID("4.17"),
     setMethodID: OcaMethodID("4.18"),
-    ocp2Name: "Time",
+    ocp2GetName: "Time",
     ocp2SetName: "Time"
   )
   public var holdTime: OcaBoundedProperty<OcaTimeInterval>.PropertyValue
@@ -106,7 +106,7 @@ open class OcaDynamics: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.11"),
     getMethodID: OcaMethodID("4.21"),
     setMethodID: OcaMethodID("4.22"),
-    ocp2Name: "Limit",
+    ocp2GetName: "Limit",
     ocp2SetName: "Limit"
   )
   public var dynamicGainCeiling: OcaBoundedProperty<OcaDB>.PropertyValue
@@ -115,7 +115,7 @@ open class OcaDynamics: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.12"),
     getMethodID: OcaMethodID("4.19"),
     setMethodID: OcaMethodID("4.20"),
-    ocp2Name: "Limit",
+    ocp2GetName: "Limit",
     ocp2SetName: "Limit"
   )
   public var dynamicGainFloor: OcaBoundedProperty<OcaDB>.PropertyValue
@@ -125,7 +125,7 @@ open class OcaDynamics: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.13"),
     getMethodID: OcaMethodID("4.23"),
     setMethodID: OcaMethodID("4.24"),
-    ocp2Name: "Parameter",
+    ocp2GetName: "Parameter",
     ocp2SetName: "Parameter"
   )
   public var kneeParameter: OcaBoundedProperty<OcaFloat32>.PropertyValue
@@ -232,7 +232,7 @@ open class OcaDynamicsDetector: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.3"),
     setMethodID: OcaMethodID("4.4"),
-    ocp2Name: "Time",
+    ocp2GetName: "Time",
     ocp2SetName: "Time"
   )
   public var attackTime: OcaBoundedProperty<OcaTimeInterval>.PropertyValue
@@ -241,7 +241,7 @@ open class OcaDynamicsDetector: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.5"),
     setMethodID: OcaMethodID("4.6"),
-    ocp2Name: "Time",
+    ocp2GetName: "Time",
     ocp2SetName: "Time"
   )
   public var releaseTime: OcaBoundedProperty<OcaTimeInterval>.PropertyValue
@@ -250,7 +250,7 @@ open class OcaDynamicsDetector: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.4"),
     getMethodID: OcaMethodID("4.7"),
     setMethodID: OcaMethodID("4.8"),
-    ocp2Name: "Time",
+    ocp2GetName: "Time",
     ocp2SetName: "Time"
   )
   public var holdTime: OcaBoundedProperty<OcaTimeInterval>.PropertyValue
@@ -310,7 +310,7 @@ open class OcaDynamicsCurve: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.1"),
     getMethodID: OcaMethodID("4.1"),
     setMethodID: OcaMethodID("4.2"),
-    ocp2Name: "NSegments",
+    ocp2GetName: "NSegments",
     ocp2SetName: "NSegments"
   )
   public var nSegments: OcaBoundedProperty<OcaUint8>.PropertyValue
@@ -320,7 +320,7 @@ open class OcaDynamicsCurve: OcaActuator, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("4.2"),
     setMethodID: OcaMethodID("4.4"),
-    ocp2Name: "Threshold",
+    ocp2GetName: "Threshold",
     ocp2SetName: "Threshold"
   )
   public var thresholds: OcaProperty<OcaList<OcaDBr>>.PropertyValue
@@ -329,7 +329,7 @@ open class OcaDynamicsCurve: OcaActuator, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("4.3"),
     setMethodID: OcaMethodID("4.6"),
-    ocp2Name: "Slope",
+    ocp2GetName: "Slope",
     ocp2SetName: "Slope"
   )
   public var slopes: OcaProperty<OcaList<OcaFloat32>>.PropertyValue
@@ -339,7 +339,7 @@ open class OcaDynamicsCurve: OcaActuator, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("4.4"),
     setMethodID: OcaMethodID("4.8"),
-    ocp2Name: "Parameters",
+    ocp2GetName: "Parameters",
     ocp2SetName: "Parameters"
   )
   public var kneeParameters: OcaProperty<OcaList<OcaFloat32>>.PropertyValue
@@ -348,7 +348,7 @@ open class OcaDynamicsCurve: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.5"),
     getMethodID: OcaMethodID("4.11"),
     setMethodID: OcaMethodID("4.12"),
-    ocp2Name: "Gain",
+    ocp2GetName: "Gain",
     ocp2SetName: "Gain"
   )
   public var dynamicGainFloor: OcaBoundedProperty<OcaDB>.PropertyValue
@@ -357,7 +357,7 @@ open class OcaDynamicsCurve: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.6"),
     getMethodID: OcaMethodID("4.9"),
     setMethodID: OcaMethodID("4.10"),
-    ocp2Name: "Gain",
+    ocp2GetName: "Gain",
     ocp2SetName: "Gain"
   )
   public var dynamicGainCeiling: OcaBoundedProperty<OcaDB>.PropertyValue

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/Dynamics.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/Dynamics.swift
@@ -28,14 +28,16 @@ open class OcaDynamics: OcaActuator, @unchecked Sendable {
   /// the instantaneous gain of the dynamics element
   @OcaProperty(
     propertyID: OcaPropertyID("4.2"),
-    getMethodID: OcaMethodID("4.2")
+    getMethodID: OcaMethodID("4.2"),
+    ocp2Name: "Gain"
   )
   public var dynamicGain: OcaProperty<OcaDB>.PropertyValue
 
   @OcaProperty(
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.3"),
-    setMethodID: OcaMethodID("4.4")
+    setMethodID: OcaMethodID("4.4"),
+    ocp2Name: "Func"
   )
   public var function: OcaProperty<OcaDynamicsFunction>.PropertyValue
 
@@ -57,49 +59,56 @@ open class OcaDynamics: OcaActuator, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("4.6"),
     getMethodID: OcaMethodID("4.9"),
-    setMethodID: OcaMethodID("4.10")
+    setMethodID: OcaMethodID("4.10"),
+    ocp2Name: "Units"
   )
   public var thresholdPresentationUnits: OcaProperty<OcaPresentationUnit>.PropertyValue
 
   @OcaProperty(
     propertyID: OcaPropertyID("4.7"),
     getMethodID: OcaMethodID("4.11"),
-    setMethodID: OcaMethodID("4.12")
+    setMethodID: OcaMethodID("4.12"),
+    ocp2Name: "Law"
   )
   public var detectorLaw: OcaProperty<OcaLevelDetectionLaw>.PropertyValue
 
   @OcaBoundedProperty(
     propertyID: OcaPropertyID("4.8"),
     getMethodID: OcaMethodID("4.13"),
-    setMethodID: OcaMethodID("4.14")
+    setMethodID: OcaMethodID("4.14"),
+    ocp2Name: "Time"
   )
   public var attackTime: OcaBoundedProperty<OcaTimeInterval>.PropertyValue
 
   @OcaBoundedProperty(
     propertyID: OcaPropertyID("4.9"),
     getMethodID: OcaMethodID("4.15"),
-    setMethodID: OcaMethodID("4.16")
+    setMethodID: OcaMethodID("4.16"),
+    ocp2Name: "Time"
   )
   public var releaseTime: OcaBoundedProperty<OcaTimeInterval>.PropertyValue
 
   @OcaBoundedProperty(
     propertyID: OcaPropertyID("4.10"),
     getMethodID: OcaMethodID("4.17"),
-    setMethodID: OcaMethodID("4.18")
+    setMethodID: OcaMethodID("4.18"),
+    ocp2Name: "Time"
   )
   public var holdTime: OcaBoundedProperty<OcaTimeInterval>.PropertyValue
 
   @OcaBoundedProperty(
     propertyID: OcaPropertyID("4.11"),
     getMethodID: OcaMethodID("4.21"),
-    setMethodID: OcaMethodID("4.22")
+    setMethodID: OcaMethodID("4.22"),
+    ocp2Name: "Limit"
   )
   public var dynamicGainCeiling: OcaBoundedProperty<OcaDB>.PropertyValue
 
   @OcaBoundedProperty(
     propertyID: OcaPropertyID("4.12"),
     getMethodID: OcaMethodID("4.19"),
-    setMethodID: OcaMethodID("4.20")
+    setMethodID: OcaMethodID("4.20"),
+    ocp2Name: "Limit"
   )
   public var dynamicGainFloor: OcaBoundedProperty<OcaDB>.PropertyValue
 
@@ -107,7 +116,8 @@ open class OcaDynamics: OcaActuator, @unchecked Sendable {
   @OcaBoundedProperty(
     propertyID: OcaPropertyID("4.13"),
     getMethodID: OcaMethodID("4.23"),
-    setMethodID: OcaMethodID("4.24")
+    setMethodID: OcaMethodID("4.24"),
+    ocp2Name: "Parameter"
   )
   public var kneeParameter: OcaBoundedProperty<OcaFloat32>.PropertyValue
 
@@ -212,21 +222,24 @@ open class OcaDynamicsDetector: OcaActuator, @unchecked Sendable {
   @OcaBoundedProperty(
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.3"),
-    setMethodID: OcaMethodID("4.4")
+    setMethodID: OcaMethodID("4.4"),
+    ocp2Name: "Time"
   )
   public var attackTime: OcaBoundedProperty<OcaTimeInterval>.PropertyValue
 
   @OcaBoundedProperty(
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.5"),
-    setMethodID: OcaMethodID("4.6")
+    setMethodID: OcaMethodID("4.6"),
+    ocp2Name: "Time"
   )
   public var releaseTime: OcaBoundedProperty<OcaTimeInterval>.PropertyValue
 
   @OcaBoundedProperty(
     propertyID: OcaPropertyID("4.4"),
     getMethodID: OcaMethodID("4.7"),
-    setMethodID: OcaMethodID("4.8")
+    setMethodID: OcaMethodID("4.8"),
+    ocp2Name: "Time"
   )
   public var holdTime: OcaBoundedProperty<OcaTimeInterval>.PropertyValue
 
@@ -290,14 +303,16 @@ open class OcaDynamicsCurve: OcaActuator, @unchecked Sendable {
   /// retrieved with ``getThresholds()`` rather than by property accessor
   @OcaProperty(
     propertyID: OcaPropertyID("4.2"),
-    setMethodID: OcaMethodID("4.4")
+    setMethodID: OcaMethodID("4.4"),
+    ocp2Name: "Threshold"
   )
   public var thresholds: OcaProperty<OcaList<OcaDBr>>.PropertyValue
 
   /// segment slopes; retrieved with ``getSlopes()``, which returns per-element limits
   @OcaProperty(
     propertyID: OcaPropertyID("4.3"),
-    setMethodID: OcaMethodID("4.6")
+    setMethodID: OcaMethodID("4.6"),
+    ocp2Name: "Slope"
   )
   public var slopes: OcaProperty<OcaList<OcaFloat32>>.PropertyValue
 
@@ -305,21 +320,24 @@ open class OcaDynamicsCurve: OcaActuator, @unchecked Sendable {
   /// limits
   @OcaProperty(
     propertyID: OcaPropertyID("4.4"),
-    setMethodID: OcaMethodID("4.8")
+    setMethodID: OcaMethodID("4.8"),
+    ocp2Name: "Parameters"
   )
   public var kneeParameters: OcaProperty<OcaList<OcaFloat32>>.PropertyValue
 
   @OcaBoundedProperty(
     propertyID: OcaPropertyID("4.5"),
     getMethodID: OcaMethodID("4.11"),
-    setMethodID: OcaMethodID("4.12")
+    setMethodID: OcaMethodID("4.12"),
+    ocp2Name: "Gain"
   )
   public var dynamicGainFloor: OcaBoundedProperty<OcaDB>.PropertyValue
 
   @OcaBoundedProperty(
     propertyID: OcaPropertyID("4.6"),
     getMethodID: OcaMethodID("4.9"),
-    setMethodID: OcaMethodID("4.10")
+    setMethodID: OcaMethodID("4.10"),
+    ocp2Name: "Gain"
   )
   public var dynamicGainCeiling: OcaBoundedProperty<OcaDB>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/Dynamics.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/Dynamics.swift
@@ -37,7 +37,8 @@ open class OcaDynamics: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.3"),
     setMethodID: OcaMethodID("4.4"),
-    ocp2Name: "Func"
+    ocp2Name: "Func",
+    ocp2SetName: "Func"
   )
   public var function: OcaProperty<OcaDynamicsFunction>.PropertyValue
 
@@ -60,7 +61,8 @@ open class OcaDynamics: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.6"),
     getMethodID: OcaMethodID("4.9"),
     setMethodID: OcaMethodID("4.10"),
-    ocp2Name: "Units"
+    ocp2Name: "Units",
+    ocp2SetName: "Units"
   )
   public var thresholdPresentationUnits: OcaProperty<OcaPresentationUnit>.PropertyValue
 
@@ -68,7 +70,8 @@ open class OcaDynamics: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.7"),
     getMethodID: OcaMethodID("4.11"),
     setMethodID: OcaMethodID("4.12"),
-    ocp2Name: "Law"
+    ocp2Name: "Law",
+    ocp2SetName: "Law"
   )
   public var detectorLaw: OcaProperty<OcaLevelDetectionLaw>.PropertyValue
 
@@ -76,7 +79,8 @@ open class OcaDynamics: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.8"),
     getMethodID: OcaMethodID("4.13"),
     setMethodID: OcaMethodID("4.14"),
-    ocp2Name: "Time"
+    ocp2Name: "Time",
+    ocp2SetName: "Time"
   )
   public var attackTime: OcaBoundedProperty<OcaTimeInterval>.PropertyValue
 
@@ -84,7 +88,8 @@ open class OcaDynamics: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.9"),
     getMethodID: OcaMethodID("4.15"),
     setMethodID: OcaMethodID("4.16"),
-    ocp2Name: "Time"
+    ocp2Name: "Time",
+    ocp2SetName: "Time"
   )
   public var releaseTime: OcaBoundedProperty<OcaTimeInterval>.PropertyValue
 
@@ -92,7 +97,8 @@ open class OcaDynamics: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.10"),
     getMethodID: OcaMethodID("4.17"),
     setMethodID: OcaMethodID("4.18"),
-    ocp2Name: "Time"
+    ocp2Name: "Time",
+    ocp2SetName: "Time"
   )
   public var holdTime: OcaBoundedProperty<OcaTimeInterval>.PropertyValue
 
@@ -100,7 +106,8 @@ open class OcaDynamics: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.11"),
     getMethodID: OcaMethodID("4.21"),
     setMethodID: OcaMethodID("4.22"),
-    ocp2Name: "Limit"
+    ocp2Name: "Limit",
+    ocp2SetName: "Limit"
   )
   public var dynamicGainCeiling: OcaBoundedProperty<OcaDB>.PropertyValue
 
@@ -108,7 +115,8 @@ open class OcaDynamics: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.12"),
     getMethodID: OcaMethodID("4.19"),
     setMethodID: OcaMethodID("4.20"),
-    ocp2Name: "Limit"
+    ocp2Name: "Limit",
+    ocp2SetName: "Limit"
   )
   public var dynamicGainFloor: OcaBoundedProperty<OcaDB>.PropertyValue
 
@@ -117,7 +125,8 @@ open class OcaDynamics: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.13"),
     getMethodID: OcaMethodID("4.23"),
     setMethodID: OcaMethodID("4.24"),
-    ocp2Name: "Parameter"
+    ocp2Name: "Parameter",
+    ocp2SetName: "Parameter"
   )
   public var kneeParameter: OcaBoundedProperty<OcaFloat32>.PropertyValue
 
@@ -223,7 +232,8 @@ open class OcaDynamicsDetector: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.3"),
     setMethodID: OcaMethodID("4.4"),
-    ocp2Name: "Time"
+    ocp2Name: "Time",
+    ocp2SetName: "Time"
   )
   public var attackTime: OcaBoundedProperty<OcaTimeInterval>.PropertyValue
 
@@ -231,7 +241,8 @@ open class OcaDynamicsDetector: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.5"),
     setMethodID: OcaMethodID("4.6"),
-    ocp2Name: "Time"
+    ocp2Name: "Time",
+    ocp2SetName: "Time"
   )
   public var releaseTime: OcaBoundedProperty<OcaTimeInterval>.PropertyValue
 
@@ -239,7 +250,8 @@ open class OcaDynamicsDetector: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.4"),
     getMethodID: OcaMethodID("4.7"),
     setMethodID: OcaMethodID("4.8"),
-    ocp2Name: "Time"
+    ocp2Name: "Time",
+    ocp2SetName: "Time"
   )
   public var holdTime: OcaBoundedProperty<OcaTimeInterval>.PropertyValue
 
@@ -292,10 +304,14 @@ open class OcaDynamicsCurve: OcaActuator, @unchecked Sendable {
   override open class var classVersion: OcaClassVersionNumber { 3 }
 
   /// the curve is composed of (n + 1) straight line segments joined by (n) knees
+  // the model names this setter's parameter `Slope`, copied from the slope methods,
+  // and the getter's bounds `minN`/`maxN`; both are with the committee
   @OcaBoundedProperty(
     propertyID: OcaPropertyID("4.1"),
     getMethodID: OcaMethodID("4.1"),
-    setMethodID: OcaMethodID("4.2")
+    setMethodID: OcaMethodID("4.2"),
+    ocp2Name: "NSegments",
+    ocp2SetName: "NSegments"
   )
   public var nSegments: OcaBoundedProperty<OcaUint8>.PropertyValue
 
@@ -304,7 +320,8 @@ open class OcaDynamicsCurve: OcaActuator, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("4.2"),
     setMethodID: OcaMethodID("4.4"),
-    ocp2Name: "Threshold"
+    ocp2Name: "Threshold",
+    ocp2SetName: "Threshold"
   )
   public var thresholds: OcaProperty<OcaList<OcaDBr>>.PropertyValue
 
@@ -312,7 +329,8 @@ open class OcaDynamicsCurve: OcaActuator, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("4.3"),
     setMethodID: OcaMethodID("4.6"),
-    ocp2Name: "Slope"
+    ocp2Name: "Slope",
+    ocp2SetName: "Slope"
   )
   public var slopes: OcaProperty<OcaList<OcaFloat32>>.PropertyValue
 
@@ -321,7 +339,8 @@ open class OcaDynamicsCurve: OcaActuator, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("4.4"),
     setMethodID: OcaMethodID("4.8"),
-    ocp2Name: "Parameters"
+    ocp2Name: "Parameters",
+    ocp2SetName: "Parameters"
   )
   public var kneeParameters: OcaProperty<OcaList<OcaFloat32>>.PropertyValue
 
@@ -329,7 +348,8 @@ open class OcaDynamicsCurve: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.5"),
     getMethodID: OcaMethodID("4.11"),
     setMethodID: OcaMethodID("4.12"),
-    ocp2Name: "Gain"
+    ocp2Name: "Gain",
+    ocp2SetName: "Gain"
   )
   public var dynamicGainFloor: OcaBoundedProperty<OcaDB>.PropertyValue
 
@@ -337,7 +357,8 @@ open class OcaDynamicsCurve: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.6"),
     getMethodID: OcaMethodID("4.9"),
     setMethodID: OcaMethodID("4.10"),
-    ocp2Name: "Gain"
+    ocp2Name: "Gain",
+    ocp2SetName: "Gain"
   )
   public var dynamicGainCeiling: OcaBoundedProperty<OcaDB>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/Filters.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/Filters.swift
@@ -118,7 +118,8 @@ open class OcaFilterParametric: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.3"),
     setMethodID: OcaMethodID("4.4"),
-    ocp2Name: "Type"
+    ocp2Name: "Type",
+    ocp2SetName: "Type"
   )
   public var shape: OcaProperty<OcaParametricEQShape>.PropertyValue
 
@@ -127,7 +128,8 @@ open class OcaFilterParametric: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.5"),
     setMethodID: OcaMethodID("4.6"),
-    ocp2Name: "Width"
+    ocp2Name: "Width",
+    ocp2SetName: "Width"
   )
   public var widthParameter: OcaBoundedProperty<OcaFloat32>.PropertyValue
 
@@ -135,7 +137,8 @@ open class OcaFilterParametric: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.4"),
     getMethodID: OcaMethodID("4.7"),
     setMethodID: OcaMethodID("4.8"),
-    ocp2Name: "Gain"
+    ocp2Name: "Gain",
+    ocp2SetName: "Gain"
   )
   public var inBandGain: OcaBoundedProperty<OcaDB>.PropertyValue
 
@@ -144,7 +147,8 @@ open class OcaFilterParametric: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.5"),
     getMethodID: OcaMethodID("4.9"),
     setMethodID: OcaMethodID("4.10"),
-    ocp2Name: "Shape"
+    ocp2Name: "Shape",
+    ocp2SetName: "Shape"
   )
   public var shapeParameter: OcaBoundedProperty<OcaFloat32>.PropertyValue
 
@@ -218,7 +222,8 @@ open class OcaFilterPolynomial: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.3"),
     setMethodID: OcaMethodID("4.4"),
-    ocp2Name: "Rate"
+    ocp2Name: "Rate",
+    ocp2SetName: "Rate"
   )
   public var sampleRate: OcaBoundedProperty<OcaFrequency>.PropertyValue
 
@@ -280,7 +285,8 @@ open class OcaFilterFIR: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.4"),
     setMethodID: OcaMethodID("4.5"),
-    ocp2Name: "Rate"
+    ocp2Name: "Rate",
+    ocp2SetName: "Rate"
   )
   public var sampleRate: OcaBoundedProperty<OcaFrequency>.PropertyValue
 }
@@ -320,7 +326,8 @@ open class OcaFilterArbitraryCurve: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.3"),
     setMethodID: OcaMethodID("4.4"),
-    ocp2Name: "Rate"
+    ocp2Name: "Rate",
+    ocp2SetName: "Rate"
   )
   public var sampleRate: OcaBoundedProperty<OcaFrequency>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/Filters.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/Filters.swift
@@ -118,7 +118,7 @@ open class OcaFilterParametric: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.3"),
     setMethodID: OcaMethodID("4.4"),
-    ocp2Name: "Type",
+    ocp2GetName: "Type",
     ocp2SetName: "Type"
   )
   public var shape: OcaProperty<OcaParametricEQShape>.PropertyValue
@@ -128,7 +128,7 @@ open class OcaFilterParametric: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.5"),
     setMethodID: OcaMethodID("4.6"),
-    ocp2Name: "Width",
+    ocp2GetName: "Width",
     ocp2SetName: "Width"
   )
   public var widthParameter: OcaBoundedProperty<OcaFloat32>.PropertyValue
@@ -137,7 +137,7 @@ open class OcaFilterParametric: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.4"),
     getMethodID: OcaMethodID("4.7"),
     setMethodID: OcaMethodID("4.8"),
-    ocp2Name: "Gain",
+    ocp2GetName: "Gain",
     ocp2SetName: "Gain"
   )
   public var inBandGain: OcaBoundedProperty<OcaDB>.PropertyValue
@@ -147,7 +147,7 @@ open class OcaFilterParametric: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.5"),
     getMethodID: OcaMethodID("4.9"),
     setMethodID: OcaMethodID("4.10"),
-    ocp2Name: "Shape",
+    ocp2GetName: "Shape",
     ocp2SetName: "Shape"
   )
   public var shapeParameter: OcaBoundedProperty<OcaFloat32>.PropertyValue
@@ -222,7 +222,7 @@ open class OcaFilterPolynomial: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.3"),
     setMethodID: OcaMethodID("4.4"),
-    ocp2Name: "Rate",
+    ocp2GetName: "Rate",
     ocp2SetName: "Rate"
   )
   public var sampleRate: OcaBoundedProperty<OcaFrequency>.PropertyValue
@@ -231,7 +231,7 @@ open class OcaFilterPolynomial: OcaActuator, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("4.4"),
     getMethodID: OcaMethodID("4.5"),
-    ocp2Name: "Order"
+    ocp2GetName: "Order"
   )
   public var maxOrder: OcaProperty<OcaUint8>.PropertyValue
 
@@ -285,7 +285,7 @@ open class OcaFilterFIR: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.4"),
     setMethodID: OcaMethodID("4.5"),
-    ocp2Name: "Rate",
+    ocp2GetName: "Rate",
     ocp2SetName: "Rate"
   )
   public var sampleRate: OcaBoundedProperty<OcaFrequency>.PropertyValue
@@ -326,7 +326,7 @@ open class OcaFilterArbitraryCurve: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.3"),
     setMethodID: OcaMethodID("4.4"),
-    ocp2Name: "Rate",
+    ocp2GetName: "Rate",
     ocp2SetName: "Rate"
   )
   public var sampleRate: OcaBoundedProperty<OcaFrequency>.PropertyValue
@@ -335,7 +335,7 @@ open class OcaFilterArbitraryCurve: OcaActuator, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.5"),
-    ocp2Name: "Min"
+    ocp2GetName: "Min"
   )
   public var tfMinLength: OcaProperty<OcaUint16>.PropertyValue
 
@@ -343,7 +343,7 @@ open class OcaFilterArbitraryCurve: OcaActuator, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("4.4"),
     getMethodID: OcaMethodID("4.6"),
-    ocp2Name: "Max"
+    ocp2GetName: "Max"
   )
   public var tfMaxLength: OcaProperty<OcaUint16>.PropertyValue
 }

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/Filters.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/Filters.swift
@@ -117,7 +117,8 @@ open class OcaFilterParametric: OcaActuator, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.3"),
-    setMethodID: OcaMethodID("4.4")
+    setMethodID: OcaMethodID("4.4"),
+    ocp2Name: "Type"
   )
   public var shape: OcaProperty<OcaParametricEQShape>.PropertyValue
 
@@ -125,14 +126,16 @@ open class OcaFilterParametric: OcaActuator, @unchecked Sendable {
   @OcaBoundedProperty(
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.5"),
-    setMethodID: OcaMethodID("4.6")
+    setMethodID: OcaMethodID("4.6"),
+    ocp2Name: "Width"
   )
   public var widthParameter: OcaBoundedProperty<OcaFloat32>.PropertyValue
 
   @OcaBoundedProperty(
     propertyID: OcaPropertyID("4.4"),
     getMethodID: OcaMethodID("4.7"),
-    setMethodID: OcaMethodID("4.8")
+    setMethodID: OcaMethodID("4.8"),
+    ocp2Name: "Gain"
   )
   public var inBandGain: OcaBoundedProperty<OcaDB>.PropertyValue
 
@@ -140,7 +143,8 @@ open class OcaFilterParametric: OcaActuator, @unchecked Sendable {
   @OcaBoundedProperty(
     propertyID: OcaPropertyID("4.5"),
     getMethodID: OcaMethodID("4.9"),
-    setMethodID: OcaMethodID("4.10")
+    setMethodID: OcaMethodID("4.10"),
+    ocp2Name: "Shape"
   )
   public var shapeParameter: OcaBoundedProperty<OcaFloat32>.PropertyValue
 
@@ -213,14 +217,16 @@ open class OcaFilterPolynomial: OcaActuator, @unchecked Sendable {
   @OcaBoundedProperty(
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.3"),
-    setMethodID: OcaMethodID("4.4")
+    setMethodID: OcaMethodID("4.4"),
+    ocp2Name: "Rate"
   )
   public var sampleRate: OcaBoundedProperty<OcaFrequency>.PropertyValue
 
   /// the maximum number of elements of ``a`` and ``b``
   @OcaProperty(
     propertyID: OcaPropertyID("4.4"),
-    getMethodID: OcaMethodID("4.5")
+    getMethodID: OcaMethodID("4.5"),
+    ocp2Name: "Order"
   )
   public var maxOrder: OcaProperty<OcaUint8>.PropertyValue
 
@@ -273,7 +279,8 @@ open class OcaFilterFIR: OcaActuator, @unchecked Sendable {
   @OcaBoundedProperty(
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.4"),
-    setMethodID: OcaMethodID("4.5")
+    setMethodID: OcaMethodID("4.5"),
+    ocp2Name: "Rate"
   )
   public var sampleRate: OcaBoundedProperty<OcaFrequency>.PropertyValue
 }
@@ -312,21 +319,24 @@ open class OcaFilterArbitraryCurve: OcaActuator, @unchecked Sendable {
   @OcaBoundedProperty(
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.3"),
-    setMethodID: OcaMethodID("4.4")
+    setMethodID: OcaMethodID("4.4"),
+    ocp2Name: "Rate"
   )
   public var sampleRate: OcaBoundedProperty<OcaFrequency>.PropertyValue
 
   /// minimum number of points the transfer function must specify
   @OcaProperty(
     propertyID: OcaPropertyID("4.3"),
-    getMethodID: OcaMethodID("4.5")
+    getMethodID: OcaMethodID("4.5"),
+    ocp2Name: "Min"
   )
   public var tfMinLength: OcaProperty<OcaUint16>.PropertyValue
 
   /// maximum number of points the transfer function may specify
   @OcaProperty(
     propertyID: OcaPropertyID("4.4"),
-    getMethodID: OcaMethodID("4.6")
+    getMethodID: OcaMethodID("4.6"),
+    ocp2Name: "Max"
   )
   public var tfMaxLength: OcaProperty<OcaUint16>.PropertyValue
 }

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/PanBalance.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/PanBalance.swift
@@ -28,7 +28,7 @@ open class OcaPanBalance: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.3"),
     setMethodID: OcaMethodID("4.4"),
-    ocp2Name: "Gain",
+    ocp2GetName: "Gain",
     ocp2SetName: "Gain"
   )
   public var midpointGain: OcaBoundedProperty<OcaDB>.PropertyValue

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/PanBalance.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/PanBalance.swift
@@ -27,7 +27,8 @@ open class OcaPanBalance: OcaActuator, @unchecked Sendable {
   @OcaBoundedProperty(
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.3"),
-    setMethodID: OcaMethodID("4.4")
+    setMethodID: OcaMethodID("4.4"),
+    ocp2Name: "Gain"
   )
   public var midpointGain: OcaBoundedProperty<OcaDB>.PropertyValue
 }

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/PanBalance.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/PanBalance.swift
@@ -28,7 +28,8 @@ open class OcaPanBalance: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.3"),
     setMethodID: OcaMethodID("4.4"),
-    ocp2Name: "Gain"
+    ocp2Name: "Gain",
+    ocp2SetName: "Gain"
   )
   public var midpointGain: OcaBoundedProperty<OcaDB>.PropertyValue
 }

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/SamplingRateConverter.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/SamplingRateConverter.swift
@@ -21,7 +21,7 @@ open class OcaSamplingRateConverter: OcaActuator, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("4.1"),
     getMethodID: OcaMethodID("4.1"),
-    ocp2Name: "SrcType"
+    ocp2GetName: "SrcType"
   )
   public var type: OcaProperty<OcaSamplingRateConverterType>.PropertyValue
 }

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/SamplingRateConverter.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/SamplingRateConverter.swift
@@ -20,7 +20,8 @@ open class OcaSamplingRateConverter: OcaActuator, @unchecked Sendable {
 
   @OcaProperty(
     propertyID: OcaPropertyID("4.1"),
-    getMethodID: OcaMethodID("4.1")
+    getMethodID: OcaMethodID("4.1"),
+    ocp2Name: "SrcType"
   )
   public var type: OcaProperty<OcaSamplingRateConverterType>.PropertyValue
 }

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/SignalGenerator.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/SignalGenerator.swift
@@ -23,7 +23,7 @@ open class OcaSignalGenerator: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.1"),
     getMethodID: OcaMethodID("4.1"),
     setMethodID: OcaMethodID("4.2"),
-    ocp2Name: "Frequency",
+    ocp2GetName: "Frequency",
     ocp2SetName: "Frequency"
   )
   public var frequency1: OcaBoundedProperty<OcaFrequency>.PropertyValue
@@ -33,7 +33,7 @@ open class OcaSignalGenerator: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.3"),
     setMethodID: OcaMethodID("4.4"),
-    ocp2Name: "Frequency",
+    ocp2GetName: "Frequency",
     ocp2SetName: "Frequency"
   )
   public var frequency2: OcaBoundedProperty<OcaFrequency>.PropertyValue

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/SignalGenerator.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/SignalGenerator.swift
@@ -23,7 +23,8 @@ open class OcaSignalGenerator: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.1"),
     getMethodID: OcaMethodID("4.1"),
     setMethodID: OcaMethodID("4.2"),
-    ocp2Name: "Frequency"
+    ocp2Name: "Frequency",
+    ocp2SetName: "Frequency"
   )
   public var frequency1: OcaBoundedProperty<OcaFrequency>.PropertyValue
 
@@ -32,7 +33,8 @@ open class OcaSignalGenerator: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.3"),
     setMethodID: OcaMethodID("4.4"),
-    ocp2Name: "Frequency"
+    ocp2Name: "Frequency",
+    ocp2SetName: "Frequency"
   )
   public var frequency2: OcaBoundedProperty<OcaFrequency>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/SignalGenerator.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/SignalGenerator.swift
@@ -22,7 +22,8 @@ open class OcaSignalGenerator: OcaActuator, @unchecked Sendable {
   @OcaBoundedProperty(
     propertyID: OcaPropertyID("4.1"),
     getMethodID: OcaMethodID("4.1"),
-    setMethodID: OcaMethodID("4.2")
+    setMethodID: OcaMethodID("4.2"),
+    ocp2Name: "Frequency"
   )
   public var frequency1: OcaBoundedProperty<OcaFrequency>.PropertyValue
 
@@ -30,7 +31,8 @@ open class OcaSignalGenerator: OcaActuator, @unchecked Sendable {
   @OcaBoundedProperty(
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.3"),
-    setMethodID: OcaMethodID("4.4")
+    setMethodID: OcaMethodID("4.4"),
+    ocp2Name: "Frequency"
   )
   public var frequency2: OcaBoundedProperty<OcaFrequency>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/Switch.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/Switch.swift
@@ -28,7 +28,7 @@ open class OcaSwitch: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.5"),
     setMethodID: OcaMethodID("4.6"),
-    ocp2Name: "Names",
+    ocp2GetName: "Names",
     ocp2SetName: "Names"
   )
   public var positionNames: OcaListProperty<OcaString>.PropertyValue
@@ -37,7 +37,7 @@ open class OcaSwitch: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.9"),
     setMethodID: OcaMethodID("4.10"),
-    ocp2Name: "Flags",
+    ocp2GetName: "Flags",
     ocp2SetName: "Flags"
   )
   public var positionEnableds: OcaListProperty<OcaBoolean>.PropertyValue

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/Switch.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/Switch.swift
@@ -27,14 +27,16 @@ open class OcaSwitch: OcaActuator, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.5"),
-    setMethodID: OcaMethodID("4.6")
+    setMethodID: OcaMethodID("4.6"),
+    ocp2Name: "Names"
   )
   public var positionNames: OcaListProperty<OcaString>.PropertyValue
 
   @OcaProperty(
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.9"),
-    setMethodID: OcaMethodID("4.10")
+    setMethodID: OcaMethodID("4.10"),
+    ocp2Name: "Flags"
   )
   public var positionEnableds: OcaListProperty<OcaBoolean>.PropertyValue
 }

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/Switch.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Actuators/Switch.swift
@@ -28,7 +28,8 @@ open class OcaSwitch: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.5"),
     setMethodID: OcaMethodID("4.6"),
-    ocp2Name: "Names"
+    ocp2Name: "Names",
+    ocp2SetName: "Names"
   )
   public var positionNames: OcaListProperty<OcaString>.PropertyValue
 
@@ -36,7 +37,8 @@ open class OcaSwitch: OcaActuator, @unchecked Sendable {
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.9"),
     setMethodID: OcaMethodID("4.10"),
-    ocp2Name: "Flags"
+    ocp2Name: "Flags",
+    ocp2SetName: "Flags"
   )
   public var positionEnableds: OcaListProperty<OcaBoolean>.PropertyValue
 }

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/BlocksAndMatrices/Block.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/BlocksAndMatrices/Block.swift
@@ -117,6 +117,16 @@ Sendable {
   )
   public var mostRecentParamDatasetONo: OcaProperty<OcaONo>.PropertyValue
 
+  public struct ConstructActionObjectParameters: Ocp1ParametersReflectable {
+    public let classID: OcaClassID
+    public let constructionParameters: [OcaConstructionParameter]
+
+    public init(classID: OcaClassID, constructionParameters: [OcaConstructionParameter]) {
+      self.classID = classID
+      self.constructionParameters = constructionParameters
+    }
+  }
+
   // 3.2
   public func constructActionObject(
     classID: OcaClassID,
@@ -124,8 +134,11 @@ Sendable {
   ) async throws -> OcaONo {
     try await sendCommandRrq(
       methodID: OcaMethodID("3.2"),
-      parameters: constructionParameters,
-      parameterNames: ["ConstructionParameters"]
+      parameters: ConstructActionObjectParameters(
+        classID: classID,
+        constructionParameters: constructionParameters
+      ),
+      parameterNames: ["ClassID", "ConstructionParameters"]
     )
   }
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/BlocksAndMatrices/Block.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/BlocksAndMatrices/Block.swift
@@ -124,21 +124,24 @@ Sendable {
   ) async throws -> OcaONo {
     try await sendCommandRrq(
       methodID: OcaMethodID("3.2"),
-      parameters: constructionParameters
+      parameters: constructionParameters,
+      parameterNames: ["ConstructionParameters"]
     )
   }
 
   public func constructActionObject(factory factoryONo: OcaONo) async throws -> OcaONo {
     try await sendCommandRrq(
       methodID: OcaMethodID("3.3"),
-      parameters: factoryONo
+      parameters: factoryONo,
+      parameterNames: ["FactoryONo"]
     )
   }
 
   public func delete(actionObject objectNumber: OcaONo) async throws {
     try await sendCommandRrq(
       methodID: OcaMethodID("3.4"),
-      parameters: objectNumber
+      parameters: objectNumber,
+      parameterNames: ["ObjectNumber"]
     )
   }
 
@@ -189,14 +192,16 @@ Sendable {
   public func add(signalPath path: OcaSignalPath) async throws -> OcaUint16 {
     try await sendCommandRrq(
       methodID: OcaMethodID("3.7"),
-      parameters: path
+      parameters: path,
+      parameterNames: ["Path"]
     )
   }
 
   public func delete(signalPath index: OcaUint16) async throws {
     try await sendCommandRrq(
       methodID: OcaMethodID("3.8"),
-      parameters: index
+      parameters: index,
+      parameterNames: ["Index"]
     )
   }
 
@@ -207,7 +212,8 @@ Sendable {
   public func apply(paramSet identifier: OcaLibVolIdentifier) async throws {
     try await sendCommandRrq(
       methodID: OcaMethodID("3.12"),
-      parameters: identifier
+      parameters: identifier,
+      parameterNames: ["Identifier"]
     )
   }
 
@@ -218,7 +224,8 @@ Sendable {
   public func store(currentParamSet identifier: OcaLibVolIdentifier) async throws {
     try await sendCommandRrq(
       methodID: OcaMethodID("3.14"),
-      parameters: identifier
+      parameters: identifier,
+      parameterNames: ["Identifier"]
     )
   }
 
@@ -360,11 +367,19 @@ Sendable {
   }
 
   public func apply(paramDataset: OcaONo) async throws {
-    try await sendCommandRrq(methodID: OcaMethodID("3.23"), parameters: paramDataset)
+    try await sendCommandRrq(
+      methodID: OcaMethodID("3.23"),
+      parameters: paramDataset,
+      parameterNames: ["ONo"]
+    )
   }
 
   public func store(currentParameterData: OcaONo) async throws {
-    try await sendCommandRrq(methodID: OcaMethodID("3.24"), parameters: currentParameterData)
+    try await sendCommandRrq(
+      methodID: OcaMethodID("3.24"),
+      parameters: currentParameterData,
+      parameterNames: ["ONo"]
+    )
   }
 
   public func fetchCurrentParameterData() async throws -> OcaLongBlob {
@@ -372,7 +387,11 @@ Sendable {
   }
 
   public func apply(parameterData: OcaLongBlob) async throws {
-    try await sendCommandRrq(methodID: OcaMethodID("3.26"), parameters: parameterData)
+    try await sendCommandRrq(
+      methodID: OcaMethodID("3.26"),
+      parameters: parameterData,
+      parameterNames: ["Data"]
+    )
   }
 
   @_spi(SwiftOCAPrivate)
@@ -514,7 +533,8 @@ Sendable {
     var jsonObject = await super.getJsonValue(flags: flags)
     // the property carries object identifications; the dump carries the objects
     // themselves, under that same property's name
-    jsonObject["ActionObjects"] = try? await resolveActionObjects()
+    jsonObject[_jsonPropertyName(for: $actionObjects.propertyID)] =
+      try? await resolveActionObjects()
       .asyncMap { await $0.getJsonValue(flags: flags) }
     return jsonObject
   }

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/BlocksAndMatrices/Block.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/BlocksAndMatrices/Block.swift
@@ -71,19 +71,22 @@ Sendable {
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.2"),
-    getMethodID: OcaMethodID("3.5")
+    getMethodID: OcaMethodID("3.5"),
+    ocp2Name: "Objects"
   )
   public var actionObjects: OcaListProperty<OcaObjectIdentification>.PropertyValue
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.3"),
-    getMethodID: OcaMethodID("3.9")
+    getMethodID: OcaMethodID("3.9"),
+    ocp2Name: "Members"
   )
   public var signalPaths: OcaMapProperty<OcaUint16, OcaSignalPath>.PropertyValue
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.4"),
-    getMethodID: OcaMethodID("3.11")
+    getMethodID: OcaMethodID("3.11"),
+    ocp2Name: "Identifier"
   )
   public var mostRecentParamSetIdentifier: OcaProperty<OcaLibVolIdentifier>.PropertyValue
 
@@ -101,7 +104,8 @@ Sendable {
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.7"),
-    getMethodID: OcaMethodID("3.29")
+    getMethodID: OcaMethodID("3.29"),
+    ocp2Name: "Objects"
   )
   public var datasetObjects: OcaProperty<[OcaObjectIdentification]>.PropertyValue
 
@@ -113,7 +117,8 @@ Sendable {
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.9"),
-    getMethodID: OcaMethodID("3.22")
+    getMethodID: OcaMethodID("3.22"),
+    ocp2Name: "ONo"
   )
   public var mostRecentParamDatasetONo: OcaProperty<OcaONo>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/BlocksAndMatrices/Block.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/BlocksAndMatrices/Block.swift
@@ -72,21 +72,21 @@ Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("3.2"),
     getMethodID: OcaMethodID("3.5"),
-    ocp2Name: "Objects"
+    ocp2GetName: "Objects"
   )
   public var actionObjects: OcaListProperty<OcaObjectIdentification>.PropertyValue
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.3"),
     getMethodID: OcaMethodID("3.9"),
-    ocp2Name: "Members"
+    ocp2GetName: "Members"
   )
   public var signalPaths: OcaMapProperty<OcaUint16, OcaSignalPath>.PropertyValue
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.4"),
     getMethodID: OcaMethodID("3.11"),
-    ocp2Name: "Identifier"
+    ocp2GetName: "Identifier"
   )
   public var mostRecentParamSetIdentifier: OcaProperty<OcaLibVolIdentifier>.PropertyValue
 
@@ -105,7 +105,7 @@ Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("3.7"),
     getMethodID: OcaMethodID("3.29"),
-    ocp2Name: "Objects"
+    ocp2GetName: "Objects"
   )
   public var datasetObjects: OcaProperty<[OcaObjectIdentification]>.PropertyValue
 
@@ -118,7 +118,7 @@ Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("3.9"),
     getMethodID: OcaMethodID("3.22"),
-    ocp2Name: "ONo"
+    ocp2GetName: "ONo"
   )
   public var mostRecentParamDatasetONo: OcaProperty<OcaONo>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/BlocksAndMatrices/Matrix.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/BlocksAndMatrices/Matrix.swift
@@ -54,7 +54,8 @@ Sendable {
     propertyID: OcaPropertyID("3.6"),
     getMethodID: OcaMethodID("3.9"),
     setMethodID: OcaMethodID("3.10"),
-    ocp2Name: "ONo"
+    ocp2Name: "ONo",
+    ocp2SetName: "ONo"
   )
   public var proxy: OcaProperty<OcaONo>.PropertyValue
 
@@ -62,7 +63,8 @@ Sendable {
     propertyID: OcaPropertyID("3.7"),
     getMethodID: OcaMethodID("3.11"),
     setMethodID: OcaMethodID("3.12"),
-    ocp2Name: "Ports"
+    ocp2Name: "Ports",
+    ocp2SetName: "Ports"
   )
   public var portsPerRow: OcaProperty<OcaUint8>.PropertyValue
 
@@ -70,7 +72,8 @@ Sendable {
     propertyID: OcaPropertyID("3.8"),
     getMethodID: OcaMethodID("3.13"),
     setMethodID: OcaMethodID("3.14"),
-    ocp2Name: "Ports"
+    ocp2Name: "Ports",
+    ocp2SetName: "Ports"
   )
   public var portsPerColumn: OcaProperty<OcaUint8>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/BlocksAndMatrices/Matrix.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/BlocksAndMatrices/Matrix.swift
@@ -109,7 +109,8 @@ Sendable {
   ) async -> [String: any Sendable] {
     var jsonObject = await super.getJsonValue(flags: flags)
     let membersJson = try? await resolveMembers().map(defaultValue: nil, \.?.objectNumber)
-    jsonObject["Members"] = try? reencodeAsValidJSONObject(membersJson)
+    jsonObject[_jsonPropertyName(for: $members.propertyID)] =
+      (try? Ocp2Encoder().encodeValue(membersJson)).map { Ocp2JSON.sendable($0) }
     return jsonObject
   }
   #endif

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/BlocksAndMatrices/Matrix.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/BlocksAndMatrices/Matrix.swift
@@ -53,21 +53,24 @@ Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("3.6"),
     getMethodID: OcaMethodID("3.9"),
-    setMethodID: OcaMethodID("3.10")
+    setMethodID: OcaMethodID("3.10"),
+    ocp2Name: "ONo"
   )
   public var proxy: OcaProperty<OcaONo>.PropertyValue
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.7"),
     getMethodID: OcaMethodID("3.11"),
-    setMethodID: OcaMethodID("3.12")
+    setMethodID: OcaMethodID("3.12"),
+    ocp2Name: "Ports"
   )
   public var portsPerRow: OcaProperty<OcaUint8>.PropertyValue
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.8"),
     getMethodID: OcaMethodID("3.13"),
-    setMethodID: OcaMethodID("3.14")
+    setMethodID: OcaMethodID("3.14"),
+    ocp2Name: "Ports"
   )
   public var portsPerColumn: OcaProperty<OcaUint8>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/BlocksAndMatrices/Matrix.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/BlocksAndMatrices/Matrix.swift
@@ -54,7 +54,7 @@ Sendable {
     propertyID: OcaPropertyID("3.6"),
     getMethodID: OcaMethodID("3.9"),
     setMethodID: OcaMethodID("3.10"),
-    ocp2Name: "ONo",
+    ocp2GetName: "ONo",
     ocp2SetName: "ONo"
   )
   public var proxy: OcaProperty<OcaONo>.PropertyValue
@@ -63,7 +63,7 @@ Sendable {
     propertyID: OcaPropertyID("3.7"),
     getMethodID: OcaMethodID("3.11"),
     setMethodID: OcaMethodID("3.12"),
-    ocp2Name: "Ports",
+    ocp2GetName: "Ports",
     ocp2SetName: "Ports"
   )
   public var portsPerRow: OcaProperty<OcaUint8>.PropertyValue
@@ -72,7 +72,7 @@ Sendable {
     propertyID: OcaPropertyID("3.8"),
     getMethodID: OcaMethodID("3.13"),
     setMethodID: OcaMethodID("3.14"),
-    ocp2Name: "Ports",
+    ocp2GetName: "Ports",
     ocp2SetName: "Ports"
   )
   public var portsPerColumn: OcaProperty<OcaUint8>.PropertyValue

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/DataSets/DataSetWorker.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/DataSets/DataSetWorker.swift
@@ -20,7 +20,8 @@ open class OcaDatasetWorker: OcaWorker, @unchecked Sendable {
 
   @OcaProperty(
     propertyID: OcaPropertyID("3.1"),
-    getMethodID: OcaMethodID("3.1")
+    getMethodID: OcaMethodID("3.1"),
+    ocp2Name: "ONo"
   )
   public var datasetONo: OcaProperty<OcaONo>.PropertyValue
 }

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/DataSets/DataSetWorker.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/DataSets/DataSetWorker.swift
@@ -21,7 +21,7 @@ open class OcaDatasetWorker: OcaWorker, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("3.1"),
     getMethodID: OcaMethodID("3.1"),
-    ocp2Name: "ONo"
+    ocp2GetName: "ONo"
   )
   public var datasetONo: OcaProperty<OcaONo>.PropertyValue
 }

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/DataSets/MediaRecorderPlayer.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/DataSets/MediaRecorderPlayer.swift
@@ -34,14 +34,16 @@ open class OcaMediaRecorderPlayer: OcaDatasetWorker, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.10"),
-    setMethodID: OcaMethodID("4.11")
+    setMethodID: OcaMethodID("4.11"),
+    ocp2Name: "Functions"
   )
   public var trackFunctions: OcaProperty<[OcaMediaTrackFunction]>.PropertyValue
 
   @OcaProperty(
     propertyID: OcaPropertyID("4.4"),
     getMethodID: OcaMethodID("4.12"),
-    setMethodID: OcaMethodID("4.13")
+    setMethodID: OcaMethodID("4.13"),
+    ocp2Name: "Option"
   )
   public var playOption: OcaProperty<OcaMediaPlayOption>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/DataSets/MediaRecorderPlayer.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/DataSets/MediaRecorderPlayer.swift
@@ -35,7 +35,8 @@ open class OcaMediaRecorderPlayer: OcaDatasetWorker, @unchecked Sendable {
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.10"),
     setMethodID: OcaMethodID("4.11"),
-    ocp2Name: "Functions"
+    ocp2Name: "Functions",
+    ocp2SetName: "Functions"
   )
   public var trackFunctions: OcaProperty<[OcaMediaTrackFunction]>.PropertyValue
 
@@ -43,7 +44,8 @@ open class OcaMediaRecorderPlayer: OcaDatasetWorker, @unchecked Sendable {
     propertyID: OcaPropertyID("4.4"),
     getMethodID: OcaMethodID("4.12"),
     setMethodID: OcaMethodID("4.13"),
-    ocp2Name: "Option"
+    ocp2Name: "Option",
+    ocp2SetName: "Option"
   )
   public var playOption: OcaProperty<OcaMediaPlayOption>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/DataSets/MediaRecorderPlayer.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/DataSets/MediaRecorderPlayer.swift
@@ -35,7 +35,7 @@ open class OcaMediaRecorderPlayer: OcaDatasetWorker, @unchecked Sendable {
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.10"),
     setMethodID: OcaMethodID("4.11"),
-    ocp2Name: "Functions",
+    ocp2GetName: "Functions",
     ocp2SetName: "Functions"
   )
   public var trackFunctions: OcaProperty<[OcaMediaTrackFunction]>.PropertyValue
@@ -44,7 +44,7 @@ open class OcaMediaRecorderPlayer: OcaDatasetWorker, @unchecked Sendable {
     propertyID: OcaPropertyID("4.4"),
     getMethodID: OcaMethodID("4.12"),
     setMethodID: OcaMethodID("4.13"),
-    ocp2Name: "Option",
+    ocp2GetName: "Option",
     ocp2SetName: "Option"
   )
   public var playOption: OcaProperty<OcaMediaPlayOption>.PropertyValue

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Sensors/StateSensor.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Sensors/StateSensor.swift
@@ -34,7 +34,8 @@ open class OcaStateSensor: OcaSensor, @unchecked Sendable {
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.2"),
     setMethodID: OcaMethodID("4.3"),
-    ocp2Name: "Names"
+    ocp2Name: "Names",
+    ocp2SetName: "Names"
   )
   public var stateNames: OcaProperty<OcaList<OcaString>>.PropertyValue
 }

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Sensors/StateSensor.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Sensors/StateSensor.swift
@@ -23,7 +23,8 @@ open class OcaStateSensor: OcaSensor, @unchecked Sendable {
   /// value of this property inclusive
   @OcaBoundedProperty(
     propertyID: OcaPropertyID("4.1"),
-    getMethodID: OcaMethodID("4.1")
+    getMethodID: OcaMethodID("4.1"),
+    ocp2Name: "State"
   )
   public var reading: OcaBoundedProperty<OcaUint16>.PropertyValue
 
@@ -32,7 +33,8 @@ open class OcaStateSensor: OcaSensor, @unchecked Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.2"),
-    setMethodID: OcaMethodID("4.3")
+    setMethodID: OcaMethodID("4.3"),
+    ocp2Name: "Names"
   )
   public var stateNames: OcaProperty<OcaList<OcaString>>.PropertyValue
 }

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Sensors/StateSensor.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Sensors/StateSensor.swift
@@ -24,7 +24,7 @@ open class OcaStateSensor: OcaSensor, @unchecked Sendable {
   @OcaBoundedProperty(
     propertyID: OcaPropertyID("4.1"),
     getMethodID: OcaMethodID("4.1"),
-    ocp2Name: "State"
+    ocp2GetName: "State"
   )
   public var reading: OcaBoundedProperty<OcaUint16>.PropertyValue
 
@@ -34,7 +34,7 @@ open class OcaStateSensor: OcaSensor, @unchecked Sendable {
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.2"),
     setMethodID: OcaMethodID("4.3"),
-    ocp2Name: "Names",
+    ocp2GetName: "Names",
     ocp2SetName: "Names"
   )
   public var stateNames: OcaProperty<OcaList<OcaString>>.PropertyValue

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Worker.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Worker.swift
@@ -33,7 +33,8 @@ Sendable {
 
   @OcaProperty(
     propertyID: OcaPropertyID("2.2"),
-    getMethodID: OcaMethodID("2.5")
+    getMethodID: OcaMethodID("2.5"),
+    ocp2Name: "OcaPorts"
   )
   public var ports: OcaListProperty<OcaPort>.PropertyValue
 
@@ -62,7 +63,8 @@ Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("2.6"),
     getMethodID: OcaMethodID("2.14"),
-    setMethodID: OcaMethodID("2.15")
+    setMethodID: OcaMethodID("2.15"),
+    ocp2Name: "Map"
   )
   public var portClockMap: OcaMapProperty<OcaPortID, OcaPortClockMapEntry>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Worker.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Worker.swift
@@ -34,7 +34,7 @@ Sendable {
   @OcaProperty(
     propertyID: OcaPropertyID("2.2"),
     getMethodID: OcaMethodID("2.5"),
-    ocp2Name: "OcaPorts"
+    ocp2GetName: "OcaPorts"
   )
   public var ports: OcaListProperty<OcaPort>.PropertyValue
 
@@ -64,7 +64,7 @@ Sendable {
     propertyID: OcaPropertyID("2.6"),
     getMethodID: OcaMethodID("2.14"),
     setMethodID: OcaMethodID("2.15"),
-    ocp2Name: "Map",
+    ocp2GetName: "Map",
     ocp2SetName: "Map"
   )
   public var portClockMap: OcaMapProperty<OcaPortID, OcaPortClockMapEntry>.PropertyValue

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Worker.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Worker.swift
@@ -64,7 +64,8 @@ Sendable {
     propertyID: OcaPropertyID("2.6"),
     getMethodID: OcaMethodID("2.14"),
     setMethodID: OcaMethodID("2.15"),
-    ocp2Name: "Map"
+    ocp2Name: "Map",
+    ocp2SetName: "Map"
   )
   public var portClockMap: OcaMapProperty<OcaPortID, OcaPortClockMapEntry>.PropertyValue
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Workers/Worker.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Workers/Worker.swift
@@ -86,7 +86,8 @@ Sendable {
   public func delete(portID id: OcaPortID) async throws {
     try await sendCommandRrq(
       methodID: OcaMethodID("2.4"),
-      parameters: id
+      parameters: id,
+      parameterNames: ["ID"]
     )
   }
 
@@ -129,7 +130,8 @@ Sendable {
   public func get(portID: OcaPortID) async throws -> OcaPortClockMapEntry {
     try await sendCommandRrq(
       methodID: OcaMethodID("2.16"),
-      parameters: portID
+      parameters: portID,
+      parameterNames: ["ID"]
     )
   }
 
@@ -146,7 +148,8 @@ Sendable {
   public func deletePortClockMapEntry(portID: OcaPortID) async throws {
     try await sendCommandRrq(
       methodID: OcaMethodID("2.18"),
-      parameters: portID
+      parameters: portID,
+      parameterNames: ["ID"]
     )
   }
 }

--- a/Sources/SwiftOCA/OCC/ControlDataTypes/ApplicationNetworkDataTypes.swift
+++ b/Sources/SwiftOCA/OCC/ControlDataTypes/ApplicationNetworkDataTypes.swift
@@ -37,7 +37,7 @@ public enum OcaApplicationNetworkState: OcaUint8, Codable, Sendable, CaseIterabl
 
 public typealias OcaApplicationNetworkServiceID = OcaBlob
 
-public enum OcaProtocolVersion: OcaUint16, Codable, Sendable {
+public enum OcaProtocolVersion: OcaUint16, Codable, Sendable, CaseIterable {
   // Original standard (AES70-2015)
   case aes70_2015 = 1
   // 2018 revision

--- a/Sources/SwiftOCA/OCC/ControlDataTypes/BaseDataTypes.swift
+++ b/Sources/SwiftOCA/OCC/ControlDataTypes/BaseDataTypes.swift
@@ -168,21 +168,21 @@ public struct OcaPropertyID: Codable, Hashable, Equatable, Comparable, Sendable,
     }
   }
 
-  // SPI visibility for SwiftOCADevice and FlutterSwiftOCA
+  /// SPI visibility for SwiftOCADevice and FlutterSwiftOCA
   @_spi(SwiftOCAPrivate)
   public init(parsing input: inout ParserSpan) throws {
     defLevel = try OcaUint16(parsingBigEndian: &input)
     propertyIndex = try OcaUint16(parsingBigEndian: &input)
   }
 
-  // SPI visibility for SwiftOCADevice and FlutterSwiftOCA, which decode a
-  // property ID from a standalone buffer rather than mid-PDU
+  /// SPI visibility for SwiftOCADevice and FlutterSwiftOCA, which decode a
+  /// property ID from a standalone buffer rather than mid-PDU
   @_spi(SwiftOCAPrivate)
   public init(bytes: borrowing Data) throws {
     try self.init(decodingOcp1Bytes: bytes)
   }
 
-  // SPI visibility for SwiftOCADevice and FlutterSwiftOCA
+  /// SPI visibility for SwiftOCADevice and FlutterSwiftOCA
   @_spi(SwiftOCAPrivate)
   public func encode(into bytes: inout [UInt8]) {
     withUnsafeBytes(of: defLevel.bigEndian) { bytes += $0 }
@@ -678,3 +678,74 @@ public struct OcaOPath: Codable, Sendable {
     self.oNo = oNo
   }
 }
+
+#if NonEmbeddedBuild
+/// The OCP.2 forms of the identifier datatypes (AES70-4 8.11.1), applied by the
+/// OCP.2 coder rather than by the types' `Codable` conformances, which stay as the
+/// OCP.1 coder expects them.
+package extension OcaClassID {
+  /// A JSON array of class indices; a nonstandard class embeds its authority as
+  /// `[65535, "<6 hex digits>"]` in place of the three authority fields.
+  var ocp2JSON: [Any] {
+    var json = [Any]()
+    var index = 0
+    while index < fields.count {
+      let field = fields[index]
+      if field == Self.ProprietaryClassField, index + 2 < fields.count {
+        let authority = OcaOrganizationID((
+          OcaUint8(truncatingIfNeeded: fields[index + 1]),
+          OcaUint8(fields[index + 2] >> 8),
+          OcaUint8(fields[index + 2] & 0xFF)
+        ))
+        json.append([Int(field), authority.description] as [Any])
+        index += 3
+      } else {
+        json.append(Int(field))
+        index += 1
+      }
+    }
+    return json
+  }
+
+  init(ocp2JSON json: Any) throws {
+    guard let elements = json as? [Any] else { throw Ocp1Error.status(.badFormat) }
+    var fields = [OcaUint16]()
+    for element in elements {
+      if let authority = element as? [Any] {
+        guard authority.count == 2,
+              try Ocp2JSON.integer(OcaUint16.self, from: authority[0]) == Self
+              .ProprietaryClassField,
+              let hex = authority[1] as? String
+        else {
+          throw Ocp1Error.status(.badFormat)
+        }
+        let organization = try OcaOrganizationID(hex)
+        fields += [
+          Self.ProprietaryClassField,
+          OcaUint16(organization.id.0),
+          (OcaUint16(organization.id.1) << 8) | OcaUint16(organization.id.2),
+        ]
+      } else {
+        try fields.append(Ocp2JSON.integer(OcaUint16.self, from: element))
+      }
+    }
+    self.init(fields)
+  }
+}
+
+/// `[DefLevel, Index]`, optionally followed by the element's name, which has no
+/// programmatic effect (AES70-4 8.11.1.5).
+package func _ocp2ElementID(_ defLevel: OcaUint16, _ index: OcaUint16) -> [Int] {
+  [Int(defLevel), Int(index)]
+}
+
+package func _ocp2ElementID(from json: Any) throws -> (OcaUint16, OcaUint16) {
+  guard let array = json as? [Any], array.count == 2 || array.count == 3 else {
+    throw Ocp1Error.status(.badFormat)
+  }
+  return try (
+    Ocp2JSON.integer(OcaUint16.self, from: array[0]),
+    Ocp2JSON.integer(OcaUint16.self, from: array[1])
+  )
+}
+#endif

--- a/Sources/SwiftOCA/OCC/ControlDataTypes/EventDataTypes.swift
+++ b/Sources/SwiftOCA/OCC/ControlDataTypes/EventDataTypes.swift
@@ -99,7 +99,7 @@ public struct OcaEvent: Codable, Hashable, Equatable, Sendable, CustomStringConv
   }
 }
 
-public enum OcaPropertyChangeType: OcaUint8, Codable, Equatable, Sendable {
+public enum OcaPropertyChangeType: OcaUint8, Codable, Equatable, Sendable, CaseIterable {
   case currentChanged = 1
   case minChanged = 2
   case maxChanged = 3

--- a/Sources/SwiftOCA/OCC/ControlDataTypes/MediaDataTypes.swift
+++ b/Sources/SwiftOCA/OCC/ControlDataTypes/MediaDataTypes.swift
@@ -171,13 +171,13 @@ public struct OcaMediaSourceConnector: Codable, Sendable {
   }
 }
 
-public enum OcaMediaPlayOption: OcaUint8, Codable, Sendable {
+public enum OcaMediaPlayOption: OcaUint8, Codable, Sendable, CaseIterable {
   case normal = 0
   case autoclose = 1
   case repeatInterval = 2
 }
 
-public enum OcaMediaRecorderPlayerState: OcaUint8, Codable, Sendable {
+public enum OcaMediaRecorderPlayerState: OcaUint8, Codable, Sendable, CaseIterable {
   case idle = 0
   case stopped = 1
   case seeking = 2
@@ -185,7 +185,7 @@ public enum OcaMediaRecorderPlayerState: OcaUint8, Codable, Sendable {
   case playing = 4
 }
 
-public enum OcaMediaAccessMode: OcaUint8, Codable, Sendable {
+public enum OcaMediaAccessMode: OcaUint8, Codable, Sendable, CaseIterable {
   case none = 0
   case play = 1
   case record = 2
@@ -193,7 +193,7 @@ public enum OcaMediaAccessMode: OcaUint8, Codable, Sendable {
 
 public typealias OcaMediaTrackFunction = OcaBitSet16
 
-public enum OcaMediaVolumePositionType: OcaUint16, Codable, Sendable {
+public enum OcaMediaVolumePositionType: OcaUint16, Codable, Sendable, CaseIterable {
   case samples = 0
   case seconds = 1
 }

--- a/Sources/SwiftOCA/OCC/ControlDataTypes/ModelDataTypes.swift
+++ b/Sources/SwiftOCA/OCC/ControlDataTypes/ModelDataTypes.swift
@@ -14,6 +14,12 @@
 // limitations under the License.
 //
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
 public struct OcaModelDescription: Codable, Sendable, CustomStringConvertible {
   public let manufacturer: OcaString
   public let name: OcaString
@@ -101,6 +107,17 @@ public struct OcaModelGUID: Hashable, Codable, Sendable, CustomStringConvertible
     reserved = try container.decode(OcaUint8.self, forKey: .reserved)
     mfrCode = try container.decode(OcaOrganizationID.self, forKey: .mfrCode)
 
+    #if NonEmbeddedBuild
+    if decoder._isOcp2Decoder {
+      // OcaBlobFixedLen<4>: base64
+      let bytes = try container.decode(Data.self, forKey: .modelCode)
+      guard bytes.count == 4 else { throw Ocp1Error.status(.badFormat) }
+      modelCode = (bytes[bytes.startIndex], bytes[bytes.startIndex + 1],
+                   bytes[bytes.startIndex + 2], bytes[bytes.startIndex + 3])
+      return
+    }
+    #endif
+
     var modelCodeContainer = try container.nestedUnkeyedContainer(forKey: .modelCode)
     modelCode = try (
       modelCodeContainer.decode(OcaUint8.self),
@@ -114,6 +131,16 @@ public struct OcaModelGUID: Hashable, Codable, Sendable, CustomStringConvertible
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(reserved, forKey: .reserved)
     try container.encode(mfrCode, forKey: .mfrCode)
+
+    #if NonEmbeddedBuild
+    if encoder._isOcp2Encoder {
+      try container.encode(
+        Data([modelCode.0, modelCode.1, modelCode.2, modelCode.3]),
+        forKey: .modelCode
+      )
+      return
+    }
+    #endif
 
     var modelCodeContainer = container.nestedUnkeyedContainer(forKey: .modelCode)
     try modelCodeContainer.encode(modelCode.0)

--- a/Sources/SwiftOCA/OCC/ControlDataTypes/NetworkApplicationDataTypes.swift
+++ b/Sources/SwiftOCA/OCC/ControlDataTypes/NetworkApplicationDataTypes.swift
@@ -43,11 +43,17 @@ public enum OcaNetworkAdvertisingService: OcaUint8, Codable, Sendable, CaseItera
 
 public enum OcaNetworkAdvertisingServiceType: String, Sendable, CaseIterable {
   case none = ""
+  // OCP.1 (AES70-3)
   case tcp = "_oca._tcp."
   case tcpSecure = "_ocasec._tcp."
   case udp = "_oca._udp."
   case udpSecure = "_ocasec._udp."
   case tcpWebSocket = "_ocaws._tcp."
+  // OCP.2 (AES70-4 Table 4)
+  case tcpJson = "_ocajson._tcp."
+  case tcpSecureJson = "_ocajsonsec._tcp."
+  case udpJson = "_ocajson._udp."
+  case tcpWebSocketJson = "_ocajsonws._tcp."
 
   public var shortDescription: String {
     switch self {
@@ -63,6 +69,54 @@ public enum OcaNetworkAdvertisingServiceType: String, Sendable, CaseIterable {
       "DTLS"
     case .tcpWebSocket:
       "WS"
+    case .tcpJson:
+      "TCP/JSON"
+    case .tcpSecureJson:
+      "TLS/JSON"
+    case .udpJson:
+      "UDP/JSON"
+    case .tcpWebSocketJson:
+      "WS/JSON"
+    }
+  }
+
+  /// The control protocol the service speaks.
+  public var controlProtocol: OcaControlProtocol {
+    switch self {
+    case .none, .tcp, .tcpSecure, .udp, .udpSecure, .tcpWebSocket:
+      .ocp1
+    case .tcpJson, .tcpSecureJson, .udpJson, .tcpWebSocketJson:
+      #if NonEmbeddedBuild
+      .ocp2
+      #else
+      .ocp1
+      #endif
+    }
+  }
+
+  /// The OCP.1 service type for the same transport.
+  public var transport: OcaNetworkAdvertisingServiceType {
+    switch self {
+    case .tcpJson: .tcp
+    case .tcpSecureJson: .tcpSecure
+    case .udpJson: .udp
+    case .tcpWebSocketJson: .tcpWebSocket
+    default: self
+    }
+  }
+
+  /// The service type for this transport and `controlProtocol`.
+  public func withControlProtocol(_ controlProtocol: OcaControlProtocol) -> Self {
+    switch (transport, controlProtocol) {
+    case (_, .ocp1):
+      return transport
+    #if NonEmbeddedBuild
+    case (.tcp, .ocp2): return .tcpJson
+    case (.tcpSecure, .ocp2): return .tcpSecureJson
+    case (.udp, .ocp2): return .udpJson
+    case (.tcpWebSocket, .ocp2): return .tcpWebSocketJson
+    case (_, .ocp2): return transport
+    #endif
     }
   }
 
@@ -98,15 +152,15 @@ public struct OcaNetworkAdvertisingMechanism: Codable, Sendable, Equatable {
 }
 
 public struct OcaNetworkInterfaceAssignment: Codable, Sendable, Equatable {
-  // internal ID
+  /// internal ID
   public let id: OcaID16
-  // ONo of network interface
+  /// ONo of network interface
   public let networkInterfaceONo: OcaONo
-  // assignment-specific, e.g. IP port as encoded UInt16
+  /// assignment-specific, e.g. IP port as encoded UInt16
   public let networkBindingParameters: OcaBlob
-  // zero or more PSK identifies that apply to the IP port
+  /// zero or more PSK identifies that apply to the IP port
   public let securityKeyIdentities: [OcaString]
-  // list of advertising mechanisms
+  /// list of advertising mechanisms
   public let advertisingMechanisms: [OcaNetworkAdvertisingMechanism]
 
   public init(

--- a/Sources/SwiftOCA/OCC/ControlDataTypes/ProgrammingDataTypes.swift
+++ b/Sources/SwiftOCA/OCC/ControlDataTypes/ProgrammingDataTypes.swift
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-public enum OcaRelationalOperator: OcaUint8, Codable, Sendable {
+public enum OcaRelationalOperator: OcaUint8, Codable, Sendable, CaseIterable {
   case none = 0
   case equality = 1
   case inequality = 2

--- a/Sources/SwiftOCA/OCC/PropertyTypes/BoundedProperty.swift
+++ b/Sources/SwiftOCA/OCC/PropertyTypes/BoundedProperty.swift
@@ -218,9 +218,9 @@ public struct OcaBoundedProperty<
     flags: OcaPropertyResolutionFlags = .defaultFlags
   ) async throws -> [String: any Sendable] {
     let value = try await _getValue(object, flags: flags)
-    // the shape of the property's OCP.2 getter response: Gain, minGain, maxGain
-    let names = _ocp2ResponseNames(object)
-      ?? Ocp2Naming.boundedWireNames(propertyIDs[0].description)
+    // the shape of the getter response (Gain, MinGain, MaxGain) under the property's
+    // own name, as accessor parameter names repeat within a class
+    let names = Ocp2Naming.boundedWireNames(object._jsonPropertyName(for: propertyIDs[0]))
     let encoder = Ocp2Encoder()
     return [
       names[0]: Ocp2JSON.sendable(try encoder.encodeValue(value.value)),

--- a/Sources/SwiftOCA/OCC/PropertyTypes/BoundedProperty.swift
+++ b/Sources/SwiftOCA/OCC/PropertyTypes/BoundedProperty.swift
@@ -169,15 +169,13 @@ public struct OcaBoundedProperty<
   func onEvent(
     _ object: OcaRoot,
     event: OcaEvent,
-    eventData data: Data,
-    format: OcaParameterFormat
+    eventData encodedEventData: OcaEncodedEventData
   ) throws {
     precondition(event.eventID == OcaPropertyChangedEventID)
 
     let eventData = try OcaEventDataCoding.decode(
       OcaPropertyChangedEventData<Value>.self,
-      from: data,
-      format: format
+      from: encodedEventData
     )
     precondition(propertyIDs.contains(eventData.propertyID))
 

--- a/Sources/SwiftOCA/OCC/PropertyTypes/BoundedProperty.swift
+++ b/Sources/SwiftOCA/OCC/PropertyTypes/BoundedProperty.swift
@@ -128,19 +128,25 @@ public struct OcaBoundedProperty<
     propertyID: OcaPropertyID,
     getMethodID: OcaMethodID,
     setMethodID: OcaMethodID? = nil,
-    ocp2Name: String? = nil
+    ocp2Name: String? = nil,
+    ocp2SetName: String? = nil
   ) {
     _storage = OcaProperty(
       propertyID: propertyID,
       getMethodID: getMethodID,
       setMethodID: setMethodID,
       ocp2Name: ocp2Name,
+      ocp2SetName: ocp2SetName,
       setValueTransformer: { $1.value }
     )
   }
 
   public func _ocp2WireName(_ object: OcaRoot) -> String? {
     _storage._ocp2WireName(object)
+  }
+
+  public func _ocp2SetName(_ object: OcaRoot) -> String? {
+    _storage._ocp2SetName(object)
   }
 
   public func _ocp2ResponseNames(_ object: OcaRoot) -> [String]? {

--- a/Sources/SwiftOCA/OCC/PropertyTypes/BoundedProperty.swift
+++ b/Sources/SwiftOCA/OCC/PropertyTypes/BoundedProperty.swift
@@ -128,21 +128,21 @@ public struct OcaBoundedProperty<
     propertyID: OcaPropertyID,
     getMethodID: OcaMethodID,
     setMethodID: OcaMethodID? = nil,
-    ocp2Name: String? = nil,
+    ocp2GetName: String? = nil,
     ocp2SetName: String? = nil
   ) {
     _storage = OcaProperty(
       propertyID: propertyID,
       getMethodID: getMethodID,
       setMethodID: setMethodID,
-      ocp2Name: ocp2Name,
+      ocp2GetName: ocp2GetName,
       ocp2SetName: ocp2SetName,
       setValueTransformer: { $1.value }
     )
   }
 
-  public func _ocp2WireName(_ object: OcaRoot) -> String? {
-    _storage._ocp2WireName(object)
+  public func _ocp2GetName(_ object: OcaRoot) -> String? {
+    _storage._ocp2GetName(object)
   }
 
   public func _ocp2SetName(_ object: OcaRoot) -> String? {

--- a/Sources/SwiftOCA/OCC/PropertyTypes/BoundedProperty.swift
+++ b/Sources/SwiftOCA/OCC/PropertyTypes/BoundedProperty.swift
@@ -21,10 +21,14 @@ import FoundationEssentials
 import Foundation
 #endif
 
+/// Marks a bounded property value, whose OCP.2 response is named after the property
+/// (`Gain`, `minGain`, `maxGain`) rather than after its fields.
+public protocol OcaBoundedPropertyValueRepresentable {}
+
 public struct OcaBoundedPropertyValue<
   Value: Codable & Comparable &
     Sendable
->: Ocp1ParametersReflectable, Codable, Equatable, Sendable {
+>: Ocp1ParametersReflectable, Codable, Equatable, Sendable, OcaBoundedPropertyValueRepresentable {
   public var value: Value
   public var minValue: Value
   public var maxValue: Value
@@ -82,6 +86,7 @@ public struct OcaBoundedProperty<
     [_storage.propertyID]
   }
 
+  public var getMethodID: OcaMethodID? { _storage.getMethodID }
   public var setMethodID: OcaMethodID? { _storage.setMethodID }
 
   fileprivate var _storage: Property
@@ -122,14 +127,24 @@ public struct OcaBoundedProperty<
   public init(
     propertyID: OcaPropertyID,
     getMethodID: OcaMethodID,
-    setMethodID: OcaMethodID? = nil
+    setMethodID: OcaMethodID? = nil,
+    ocp2Name: String? = nil
   ) {
     _storage = OcaProperty(
       propertyID: propertyID,
       getMethodID: getMethodID,
       setMethodID: setMethodID,
+      ocp2Name: ocp2Name,
       setValueTransformer: { $1.value }
     )
+  }
+
+  public func _ocp2WireName(_ object: OcaRoot) -> String? {
+    _storage._ocp2WireName(object)
+  }
+
+  public func _ocp2ResponseNames(_ object: OcaRoot) -> [String]? {
+    _storage._ocp2ResponseNames(object)
   }
 
   public static subscript<T: OcaRoot>(
@@ -151,13 +166,18 @@ public struct OcaBoundedProperty<
     }
   }
 
-  func onEvent(_ object: OcaRoot, event: OcaEvent, eventData data: Data) throws {
+  func onEvent(
+    _ object: OcaRoot,
+    event: OcaEvent,
+    eventData data: Data,
+    format: OcaParameterFormat
+  ) throws {
     precondition(event.eventID == OcaPropertyChangedEventID)
 
-    let decoder = Ocp1Decoder()
-    let eventData = try decoder.decode(
+    let eventData = try OcaEventDataCoding.decode(
       OcaPropertyChangedEventData<Value>.self,
-      from: data
+      from: data,
+      format: format
     )
     precondition(propertyIDs.contains(eventData.propertyID))
 
@@ -198,12 +218,14 @@ public struct OcaBoundedProperty<
     flags: OcaPropertyResolutionFlags = .defaultFlags
   ) async throws -> [String: any Sendable] {
     let value = try await _getValue(object, flags: flags)
-    let jsonKey = try keyPath.jsonKey
-    // a gain's range is commonly bounded by -inf dB, which JSON cannot encode
+    // the shape of the property's OCP.2 getter response: Gain, minGain, maxGain
+    let names = _ocp2ResponseNames(object)
+      ?? Ocp2Naming.boundedWireNames(propertyIDs[0].description)
+    let encoder = Ocp2Encoder()
     return [
-      "Min\(jsonKey)": _jsonNonFiniteSafe(value.minValue),
-      "Max\(jsonKey)": _jsonNonFiniteSafe(value.maxValue),
-      "\(jsonKey)": _jsonNonFiniteSafe(value.value),
+      names[0]: Ocp2JSON.sendable(try encoder.encodeValue(value.value)),
+      names[1]: Ocp2JSON.sendable(try encoder.encodeValue(value.minValue)),
+      names[2]: Ocp2JSON.sendable(try encoder.encodeValue(value.maxValue)),
     ]
   }
   #endif

--- a/Sources/SwiftOCA/OCC/PropertyTypes/Property.swift
+++ b/Sources/SwiftOCA/OCC/PropertyTypes/Property.swift
@@ -81,7 +81,16 @@ public extension OcaPropertyRepresentable {
 /// line tool which manages its own cache but shouldn't be used by applications generally
 @_spi(SwiftOCAPrivate)
 public protocol OcaPropertySubjectRepresentable: OcaPropertyRepresentable {
+  var getMethodID: OcaMethodID? { get }
   var setMethodID: OcaMethodID? { get }
+
+  /// The property's OCP.2 wire name: an explicit `ocp2Name`, else derived from its
+  /// Swift name (`Ocp2Naming.wireName`).
+  func _ocp2WireName(_ object: OcaRoot) -> String?
+
+  /// The OCP.2 names of the getter's response parameters (a bounded property's
+  /// `Gain`, `minGain`, `maxGain`).
+  func _ocp2ResponseNames(_ object: OcaRoot) -> [String]?
 
   var subject: AsyncCurrentValueSubject<PropertyValue> { get }
 
@@ -122,7 +131,9 @@ extension OcaPropertySubjectRepresentable {
 public struct OcaProperty<Value: Codable & Sendable>: Codable, Sendable,
   OcaPropertyChangeEventNotifiable
 {
-  public var valueType: Any.Type { Value.self }
+  public var valueType: Any.Type {
+    Value.self
+  }
 
   /// All property IDs supported by this property
   public var propertyIDs: [OcaPropertyID] {
@@ -203,9 +214,9 @@ public struct OcaProperty<Value: Codable & Sendable>: Codable, Sendable,
     subject.value
   }
 
-  /// It's not possible to wrap `subscript(_enclosingInstance:wrapped:storage:)` because we can't
-  /// cast struct key paths to `ReferenceWritableKeyPath`. For property wrapper wrappers, use
-  /// these internal get/set functions.
+  // It's not possible to wrap `subscript(_enclosingInstance:wrapped:storage:)` because we can't
+  // cast struct key paths to `ReferenceWritableKeyPath`. For property wrapper wrappers, use
+  // these internal get/set functions.
 
   func _get(
     _enclosingInstance object: OcaRoot
@@ -270,15 +281,21 @@ public struct OcaProperty<Value: Codable & Sendable>: Codable, Sendable,
   typealias SetValueTransformer = @Sendable (OcaRoot, Value) async throws -> Encodable
   private let setValueTransformer: SetValueTransformer?
 
+  /// The AES70-2A name of the property's accessor parameter, where it differs from
+  /// the Swift property name upper-cased (the model's `Name` for `deviceName`).
+  public let ocp2Name: String?
+
   init(
     propertyID: OcaPropertyID,
     getMethodID: OcaMethodID?,
     setMethodID: OcaMethodID?,
+    ocp2Name: String? = nil,
     setValueTransformer: SetValueTransformer?
   ) {
     self.propertyID = propertyID
     self.getMethodID = getMethodID
     self.setMethodID = setMethodID
+    self.ocp2Name = ocp2Name
     subject = AsyncCurrentValueSubject(PropertyValue.initial)
     self.setValueTransformer = setValueTransformer
   }
@@ -286,12 +303,14 @@ public struct OcaProperty<Value: Codable & Sendable>: Codable, Sendable,
   public init(
     propertyID: OcaPropertyID,
     getMethodID: OcaMethodID? = nil,
-    setMethodID: OcaMethodID? = nil
+    setMethodID: OcaMethodID? = nil,
+    ocp2Name: String? = nil
   ) {
     self.init(
       propertyID: propertyID,
       getMethodID: getMethodID,
       setMethodID: setMethodID,
+      ocp2Name: ocp2Name,
       setValueTransformer: nil
     )
   }
@@ -327,7 +346,10 @@ public struct OcaProperty<Value: Codable & Sendable>: Codable, Sendable,
         }
       }
 
-      let returnValue: Value = try await object.sendCommandRrq(methodID: getMethodID)
+      let returnValue: Value = try await object.sendCommandRrq(
+        methodID: getMethodID,
+        responseNames: _ocp2ResponseNamesIfNeeded(object)
+      )
       if flags.contains(.cacheValue) {
         _send(object, .success(returnValue))
       }
@@ -350,6 +372,36 @@ public struct OcaProperty<Value: Codable & Sendable>: Codable, Sendable,
     }
   }
 
+  /// Names are only looked up (an actor hop into the key-path cache) on an OCP.2
+  /// connection; OCP.1 never needs them.
+  private func _ocp2WireNameIfNeeded(_ object: OcaRoot) -> String? {
+    guard object.connectionDelegate?.controlProtocol != .ocp1 else { return nil }
+    return _ocp2WireName(object)
+  }
+
+  private func _ocp2ResponseNamesIfNeeded(_ object: OcaRoot) -> [String]? {
+    guard object.connectionDelegate?.controlProtocol != .ocp1 else { return nil }
+    return _ocp2ResponseNames(object)
+  }
+
+  public func _ocp2WireName(_ object: OcaRoot) -> String? {
+    if let ocp2Name {
+      return ocp2Name
+    }
+    guard let name = object.propertyName(for: propertyID) else { return nil }
+    return Ocp2Naming.wireName(name)
+  }
+
+  /// OCP.2 names for the getter's response: the property's wire name, or for a
+  /// bounded value the `Gain`, `minGain`, `maxGain` triple.
+  public func _ocp2ResponseNames(_ object: OcaRoot) -> [String]? {
+    guard let wireName = _ocp2WireName(object) else { return nil }
+    if Value.self is any OcaBoundedPropertyValueRepresentable.Type {
+      return Ocp2Naming.boundedWireNames(wireName)
+    }
+    return [wireName]
+  }
+
   func setValueIfMutable(
     _ object: OcaRoot,
     _ value: Value
@@ -364,17 +416,22 @@ public struct OcaProperty<Value: Codable & Sendable>: Codable, Sendable,
       value
     }
 
+    // on OCP.2 the parameter is named after the property
+    let parameterNames = _ocp2WireNameIfNeeded(object).map { [$0] }
+
     // setters need to support variable parameter counts
     if try await object.isSubscribed {
       // we'll get a notification (hoepfully) so, don't require a reply
       try await object.sendCommand(
         methodID: setMethodID!,
-        parameters: newValue
+        parameters: newValue,
+        parameterNames: parameterNames
       )
     } else {
       try await object.sendCommandRrq(
         methodID: setMethodID!,
-        parameters: newValue
+        parameters: newValue,
+        parameterNames: parameterNames
       )
 
       // if we're not expecting an event, then be sure to update it here
@@ -390,12 +447,18 @@ public struct OcaProperty<Value: Codable & Sendable>: Codable, Sendable,
     _send(object, .initial)
   }
 
-  func onEvent(_ object: OcaRoot, event: OcaEvent, eventData data: Data) throws {
+  func onEvent(
+    _ object: OcaRoot,
+    event: OcaEvent,
+    eventData data: Data,
+    format: OcaParameterFormat
+  ) throws {
     precondition(event.eventID == OcaPropertyChangedEventID)
 
-    let eventData = try Ocp1Decoder().decode(
+    let eventData = try OcaEventDataCoding.decode(
       OcaPropertyChangedEventData<Value>.self,
-      from: data
+      from: data,
+      format: format
     )
     precondition(propertyIDs.contains(eventData.propertyID))
 
@@ -443,26 +506,15 @@ public struct OcaProperty<Value: Codable & Sendable>: Codable, Sendable,
   }
 
   #if NonEmbeddedBuild
+  /// The property as OCP.2 JSON: its wire name and its AES70-4 marshaled value.
   public func getJsonValue(
     _ object: OcaRoot,
     keyPath: AnyKeyPath,
     flags: OcaPropertyResolutionFlags = .defaultFlags
   ) async throws -> [String: any Sendable] {
     let value = try await _getValue(object, flags: flags)
-    let jsonValue: any Sendable = if isNil(value) {
-      #if canImport(Foundation) && !canImport(FoundationEssentials)
-      NSNull()
-      #else
-      (any Sendable)?.none
-      #endif
-
-    } else if JSONSerialization.isValidJSONObject(value) {
-      value
-    } else {
-      try reencodeAsValidJSONObject(value)
-    }
-
-    return try [keyPath.jsonKey: jsonValue]
+    let name = _ocp2WireName(object) ?? propertyID.description
+    return try [name: Ocp2JSON.sendable(Ocp2Encoder().encodeValue(value))]
   }
   #endif
 
@@ -502,34 +554,3 @@ extension OcaProperty.PropertyValue: Hashable where Value: Hashable & Codable {
     }
   }
 }
-
-#if NonEmbeddedBuild
-extension AnyKeyPath {
-  // NOTE: This relies on the String(describing:) format of AnyKeyPath which is
-  // not part of Swift's public API. It has been stable in practice but could
-  // break in future Swift versions. A more robust approach would use a reverse
-  // lookup through the property cache.
-  var jsonKey: String {
-    get throws {
-      let fullString = String(describing: self)
-
-      // Find the last dot to separate the type from the property
-      guard let lastDotIndex = fullString.lastIndex(of: ".") else {
-        throw Ocp1Error.status(.badFormat)
-      }
-
-      let propertyPart = String(fullString[fullString.index(after: lastDotIndex)...])
-
-      // Remove leading underscore if present
-      guard propertyPart.hasPrefix("_") else {
-        throw Ocp1Error.status(.badFormat)
-      }
-
-      let withoutUnderscore = String(propertyPart.dropFirst())
-
-      // Capitalize first letter
-      return withoutUnderscore.prefix(1).uppercased() + withoutUnderscore.dropFirst()
-    }
-  }
-}
-#endif

--- a/Sources/SwiftOCA/OCC/PropertyTypes/Property.swift
+++ b/Sources/SwiftOCA/OCC/PropertyTypes/Property.swift
@@ -92,6 +92,10 @@ public protocol OcaPropertySubjectRepresentable: OcaPropertyRepresentable {
   /// `Gain`, `minGain`, `maxGain`).
   func _ocp2ResponseNames(_ object: OcaRoot) -> [String]?
 
+  /// The OCP.2 name of the setter's parameter, which the model sometimes spells
+  /// differently from the getter's response (`Message` out, `Text` in).
+  func _ocp2SetName(_ object: OcaRoot) -> String?
+
   var subject: AsyncCurrentValueSubject<PropertyValue> { get }
 
   func _setValue(_ object: OcaRoot, _ anyValue: Any) async throws
@@ -100,6 +104,11 @@ public protocol OcaPropertySubjectRepresentable: OcaPropertyRepresentable {
 }
 
 extension OcaPropertySubjectRepresentable {
+  /// Unless a property states one, the setter's parameter is named as the getter's.
+  public func _ocp2SetName(_ object: OcaRoot) -> String? {
+    _ocp2WireName(object)
+  }
+
   public var async: AnyAsyncSequence<Result<any Sendable, Error>> {
     subject.compactMap { value in
       switch value {
@@ -285,17 +294,23 @@ public struct OcaProperty<Value: Codable & Sendable>: Codable, Sendable,
   /// the Swift property name upper-cased (the model's `Name` for `deviceName`).
   public let ocp2Name: String?
 
+  /// The AES70-2A name of the setter's parameter, where the model names it differently
+  /// from the getter's response (`Message` out, `Text` in); `nil` uses `ocp2Name`.
+  public let ocp2SetName: String?
+
   init(
     propertyID: OcaPropertyID,
     getMethodID: OcaMethodID?,
     setMethodID: OcaMethodID?,
     ocp2Name: String? = nil,
+    ocp2SetName: String? = nil,
     setValueTransformer: SetValueTransformer?
   ) {
     self.propertyID = propertyID
     self.getMethodID = getMethodID
     self.setMethodID = setMethodID
     self.ocp2Name = ocp2Name
+    self.ocp2SetName = ocp2SetName
     subject = AsyncCurrentValueSubject(PropertyValue.initial)
     self.setValueTransformer = setValueTransformer
   }
@@ -304,13 +319,15 @@ public struct OcaProperty<Value: Codable & Sendable>: Codable, Sendable,
     propertyID: OcaPropertyID,
     getMethodID: OcaMethodID? = nil,
     setMethodID: OcaMethodID? = nil,
-    ocp2Name: String? = nil
+    ocp2Name: String? = nil,
+    ocp2SetName: String? = nil
   ) {
     self.init(
       propertyID: propertyID,
       getMethodID: getMethodID,
       setMethodID: setMethodID,
       ocp2Name: ocp2Name,
+      ocp2SetName: ocp2SetName,
       setValueTransformer: nil
     )
   }
@@ -374,9 +391,9 @@ public struct OcaProperty<Value: Codable & Sendable>: Codable, Sendable,
 
   /// Names are only looked up (an actor hop into the key-path cache) on an OCP.2
   /// connection; OCP.1 never needs them.
-  private func _ocp2WireNameIfNeeded(_ object: OcaRoot) -> String? {
+  private func _ocp2SetNameIfNeeded(_ object: OcaRoot) -> String? {
     guard object.connectionDelegate?.controlProtocol != .ocp1 else { return nil }
-    return _ocp2WireName(object)
+    return _ocp2SetName(object)
   }
 
   private func _ocp2ResponseNamesIfNeeded(_ object: OcaRoot) -> [String]? {
@@ -390,6 +407,13 @@ public struct OcaProperty<Value: Codable & Sendable>: Codable, Sendable,
     }
     guard let name = object.propertyName(for: propertyID) else { return nil }
     return Ocp2Naming.wireName(name)
+  }
+
+  public func _ocp2SetName(_ object: OcaRoot) -> String? {
+    if let ocp2SetName {
+      return ocp2SetName
+    }
+    return _ocp2WireName(object)
   }
 
   /// OCP.2 names for the getter's response: the property's wire name, or for a
@@ -416,8 +440,8 @@ public struct OcaProperty<Value: Codable & Sendable>: Codable, Sendable,
       value
     }
 
-    // on OCP.2 the parameter is named after the property
-    let parameterNames = _ocp2WireNameIfNeeded(object).map { [$0] }
+    // on OCP.2 the parameter carries the setter's model name
+    let parameterNames = _ocp2SetNameIfNeeded(object).map { [$0] }
 
     // setters need to support variable parameter counts
     if try await object.isSubscribed {

--- a/Sources/SwiftOCA/OCC/PropertyTypes/Property.swift
+++ b/Sources/SwiftOCA/OCC/PropertyTypes/Property.swift
@@ -84,9 +84,9 @@ public protocol OcaPropertySubjectRepresentable: OcaPropertyRepresentable {
   var getMethodID: OcaMethodID? { get }
   var setMethodID: OcaMethodID? { get }
 
-  /// The property's OCP.2 wire name: an explicit `ocp2Name`, else derived from its
-  /// Swift name (`Ocp2Naming.wireName`).
-  func _ocp2WireName(_ object: OcaRoot) -> String?
+  /// The property's OCP.2 getter name: an explicit `ocp2GetName`, else derived from
+  /// its Swift name (`Ocp2Naming.wireName`).
+  func _ocp2GetName(_ object: OcaRoot) -> String?
 
   /// The OCP.2 names of the getter's response parameters (a bounded property's
   /// `Gain`, `minGain`, `maxGain`).
@@ -106,7 +106,7 @@ public protocol OcaPropertySubjectRepresentable: OcaPropertyRepresentable {
 extension OcaPropertySubjectRepresentable {
   /// Unless a property states one, the setter's parameter is named as the getter's.
   public func _ocp2SetName(_ object: OcaRoot) -> String? {
-    _ocp2WireName(object)
+    _ocp2GetName(object)
   }
 
   public var async: AnyAsyncSequence<Result<any Sendable, Error>> {
@@ -292,24 +292,24 @@ public struct OcaProperty<Value: Codable & Sendable>: Codable, Sendable,
 
   /// The AES70-2A name of the property's accessor parameter, where it differs from
   /// the Swift property name upper-cased (the model's `Name` for `deviceName`).
-  public let ocp2Name: String?
+  public let ocp2GetName: String?
 
   /// The AES70-2A name of the setter's parameter, where the model names it differently
-  /// from the getter's response (`Message` out, `Text` in); `nil` uses `ocp2Name`.
+  /// from the getter's response (`Message` out, `Text` in); `nil` uses `ocp2GetName`.
   public let ocp2SetName: String?
 
   init(
     propertyID: OcaPropertyID,
     getMethodID: OcaMethodID?,
     setMethodID: OcaMethodID?,
-    ocp2Name: String? = nil,
+    ocp2GetName: String? = nil,
     ocp2SetName: String? = nil,
     setValueTransformer: SetValueTransformer?
   ) {
     self.propertyID = propertyID
     self.getMethodID = getMethodID
     self.setMethodID = setMethodID
-    self.ocp2Name = ocp2Name
+    self.ocp2GetName = ocp2GetName
     self.ocp2SetName = ocp2SetName
     subject = AsyncCurrentValueSubject(PropertyValue.initial)
     self.setValueTransformer = setValueTransformer
@@ -319,14 +319,14 @@ public struct OcaProperty<Value: Codable & Sendable>: Codable, Sendable,
     propertyID: OcaPropertyID,
     getMethodID: OcaMethodID? = nil,
     setMethodID: OcaMethodID? = nil,
-    ocp2Name: String? = nil,
+    ocp2GetName: String? = nil,
     ocp2SetName: String? = nil
   ) {
     self.init(
       propertyID: propertyID,
       getMethodID: getMethodID,
       setMethodID: setMethodID,
-      ocp2Name: ocp2Name,
+      ocp2GetName: ocp2GetName,
       ocp2SetName: ocp2SetName,
       setValueTransformer: nil
     )
@@ -401,9 +401,9 @@ public struct OcaProperty<Value: Codable & Sendable>: Codable, Sendable,
     return _ocp2ResponseNames(object)
   }
 
-  public func _ocp2WireName(_ object: OcaRoot) -> String? {
-    if let ocp2Name {
-      return ocp2Name
+  public func _ocp2GetName(_ object: OcaRoot) -> String? {
+    if let ocp2GetName {
+      return ocp2GetName
     }
     guard let name = object.propertyName(for: propertyID) else { return nil }
     return Ocp2Naming.wireName(name)
@@ -413,17 +413,17 @@ public struct OcaProperty<Value: Codable & Sendable>: Codable, Sendable,
     if let ocp2SetName {
       return ocp2SetName
     }
-    return _ocp2WireName(object)
+    return _ocp2GetName(object)
   }
 
-  /// OCP.2 names for the getter's response: the property's wire name, or for a
+  /// OCP.2 names for the getter's response: the property's getter name, or for a
   /// bounded value the `Gain`, `minGain`, `maxGain` triple.
   public func _ocp2ResponseNames(_ object: OcaRoot) -> [String]? {
-    guard let wireName = _ocp2WireName(object) else { return nil }
+    guard let getName = _ocp2GetName(object) else { return nil }
     if Value.self is any OcaBoundedPropertyValueRepresentable.Type {
-      return Ocp2Naming.boundedWireNames(wireName)
+      return Ocp2Naming.boundedWireNames(getName)
     }
-    return [wireName]
+    return [getName]
   }
 
   func setValueIfMutable(

--- a/Sources/SwiftOCA/OCC/PropertyTypes/Property.swift
+++ b/Sources/SwiftOCA/OCC/PropertyTypes/Property.swift
@@ -450,15 +450,13 @@ public struct OcaProperty<Value: Codable & Sendable>: Codable, Sendable,
   func onEvent(
     _ object: OcaRoot,
     event: OcaEvent,
-    eventData data: Data,
-    format: OcaParameterFormat
+    eventData encodedEventData: OcaEncodedEventData
   ) throws {
     precondition(event.eventID == OcaPropertyChangedEventID)
 
     let eventData = try OcaEventDataCoding.decode(
       OcaPropertyChangedEventData<Value>.self,
-      from: data,
-      format: format
+      from: encodedEventData
     )
     precondition(propertyIDs.contains(eventData.propertyID))
 

--- a/Sources/SwiftOCA/OCC/PropertyTypes/Property.swift
+++ b/Sources/SwiftOCA/OCC/PropertyTypes/Property.swift
@@ -513,7 +513,9 @@ public struct OcaProperty<Value: Codable & Sendable>: Codable, Sendable,
     flags: OcaPropertyResolutionFlags = .defaultFlags
   ) async throws -> [String: any Sendable] {
     let value = try await _getValue(object, flags: flags)
-    let name = _ocp2WireName(object) ?? propertyID.description
+    // keyed by the property, not its accessor parameter: the model reuses parameter
+    // names (`Time`) across a class's properties
+    let name = object._jsonPropertyName(for: propertyID)
     return try [name: Ocp2JSON.sendable(Ocp2Encoder().encodeValue(value))]
   }
   #endif

--- a/Sources/SwiftOCA/OCC/PropertyTypes/VectorProperty.swift
+++ b/Sources/SwiftOCA/OCC/PropertyTypes/VectorProperty.swift
@@ -76,7 +76,7 @@ public struct OcaVectorProperty<
 
   public let xPropertyID: OcaPropertyID
   public let yPropertyID: OcaPropertyID
-  public let getMethodID: OcaMethodID
+  public let getMethodID: OcaMethodID?
   public let setMethodID: OcaMethodID?
 
   public init(from decoder: Decoder) throws {
@@ -116,17 +116,35 @@ public struct OcaVectorProperty<
     xPropertyID: OcaPropertyID,
     yPropertyID: OcaPropertyID,
     getMethodID: OcaMethodID,
-    setMethodID: OcaMethodID? = nil
+    setMethodID: OcaMethodID? = nil,
+    ocp2Name: String? = nil
   ) {
     self.xPropertyID = xPropertyID
     self.yPropertyID = yPropertyID
     self.getMethodID = getMethodID
     self.setMethodID = setMethodID
+    // The storage stands in for a pair of properties, so it has no property ID of
+    // its own and must not borrow one: an ID that resolves (1.1 is OcaRoot's
+    // `classID`) would name the OCP.2 parameters after that property. Leaving both
+    // the ID unresolvable and `ocp2Name` unset keeps `_ocp2WireName` nil, so the
+    // encoder names the parameters after the vector record's own fields (`X`, `Y`),
+    // which is what the model specifies. `ocp2Name` still applies to the JSON export
+    // through this wrapper's own `_ocp2WireName`.
     _storage = OcaProperty(
-      propertyID: OcaPropertyID("1.1"),
+      propertyID: OcaPropertyID("0.0"),
       getMethodID: getMethodID,
       setMethodID: setMethodID
     )
+  }
+
+  public func _ocp2WireName(_ object: OcaRoot) -> String? {
+    if let ocp2Name = _storage.ocp2Name { return ocp2Name }
+    guard let name = object.propertyName(for: xPropertyID) else { return nil }
+    return Ocp2Naming.wireName(name)
+  }
+
+  public func _ocp2ResponseNames(_ object: OcaRoot) -> [String]? {
+    _ocp2WireName(object).map { [$0] }
   }
 
   public static subscript<T: OcaRoot>(
@@ -143,13 +161,18 @@ public struct OcaVectorProperty<
     }
   }
 
-  func onEvent(_ object: OcaRoot, event: OcaEvent, eventData data: Data) throws {
+  func onEvent(
+    _ object: OcaRoot,
+    event: OcaEvent,
+    eventData data: Data,
+    format: OcaParameterFormat
+  ) throws {
     precondition(event.eventID == OcaPropertyChangedEventID)
 
-    let decoder = Ocp1Decoder()
-    let eventData = try decoder.decode(
+    let eventData = try OcaEventDataCoding.decode(
       OcaPropertyChangedEventData<Value>.self,
-      from: data
+      from: data,
+      format: format
     )
     precondition(propertyIDs.contains(eventData.propertyID))
 
@@ -195,7 +218,8 @@ public struct OcaVectorProperty<
     flags: OcaPropertyResolutionFlags = .defaultFlags
   ) async throws -> [String: any Sendable] {
     let value = try await _getValue(object, flags: flags)
-    return try [keyPath.jsonKey: [value.x, value.y]]
+    let name = _ocp2WireName(object) ?? xPropertyID.description
+    return [name: Ocp2JSON.sendable(try Ocp2Encoder().encodeValue(value))]
   }
   #endif
 

--- a/Sources/SwiftOCA/OCC/PropertyTypes/VectorProperty.swift
+++ b/Sources/SwiftOCA/OCC/PropertyTypes/VectorProperty.swift
@@ -164,15 +164,13 @@ public struct OcaVectorProperty<
   func onEvent(
     _ object: OcaRoot,
     event: OcaEvent,
-    eventData data: Data,
-    format: OcaParameterFormat
+    eventData encodedEventData: OcaEncodedEventData
   ) throws {
     precondition(event.eventID == OcaPropertyChangedEventID)
 
     let eventData = try OcaEventDataCoding.decode(
       OcaPropertyChangedEventData<Value>.self,
-      from: data,
-      format: format
+      from: encodedEventData
     )
     precondition(propertyIDs.contains(eventData.propertyID))
 

--- a/Sources/SwiftOCA/OCC/PropertyTypes/VectorProperty.swift
+++ b/Sources/SwiftOCA/OCC/PropertyTypes/VectorProperty.swift
@@ -253,7 +253,7 @@ public struct OcaBoundedVectorProperty<
 
   public let xPropertyID: OcaPropertyID
   public let yPropertyID: OcaPropertyID
-  public let getMethodID: OcaMethodID
+  public let getMethodID: OcaMethodID?
   public let setMethodID: OcaMethodID?
 
   public init(from decoder: Decoder) throws {
@@ -308,6 +308,16 @@ public struct OcaBoundedVectorProperty<
     )
   }
 
+  /// AES70-2 names the size parameters, and the device answers with those names; the
+  /// record's own fields would derive `X` and `MinX`, which no conforming peer sends.
+  public func _ocp2ResponseNames(_ object: OcaRoot) -> [String]? {
+    ["xSize", "ySize", "minXSize", "maxXSize", "minYSize", "maxYSize"]
+  }
+
+  public func _ocp2GetName(_ object: OcaRoot) -> String? {
+    _ocp2ResponseNames(object)?.first
+  }
+
   public static subscript<T: OcaRoot>(
     _enclosingInstance object: T,
     wrapped wrappedKeyPath: ReferenceWritableKeyPath<T, PropertyValue>,
@@ -322,12 +332,16 @@ public struct OcaBoundedVectorProperty<
     }
   }
 
-  func onEvent(_ object: OcaRoot, event: OcaEvent, eventData data: Data) throws {
+  func onEvent(
+    _ object: OcaRoot,
+    event: OcaEvent,
+    eventData encodedEventData: OcaEncodedEventData
+  ) throws {
     precondition(event.eventID == OcaPropertyChangedEventID)
 
-    let eventData = try Ocp1Decoder().decode(
+    let eventData = try OcaEventDataCoding.decode(
       OcaPropertyChangedEventData<Value>.self,
-      from: data
+      from: encodedEventData
     )
     precondition(propertyIDs.contains(eventData.propertyID))
 
@@ -368,7 +382,8 @@ public struct OcaBoundedVectorProperty<
     flags: OcaPropertyResolutionFlags = .defaultFlags
   ) async throws -> [String: any Sendable] {
     let value = try await _getValue(object, flags: flags)
-    return try [keyPath.jsonKey: [value.x, value.y]]
+    let name = object._jsonPropertyName(for: xPropertyID)
+    return [name: Ocp2JSON.sendable(try Ocp2Encoder().encodeValue(value))]
   }
   #endif
 

--- a/Sources/SwiftOCA/OCC/PropertyTypes/VectorProperty.swift
+++ b/Sources/SwiftOCA/OCC/PropertyTypes/VectorProperty.swift
@@ -117,7 +117,7 @@ public struct OcaVectorProperty<
     yPropertyID: OcaPropertyID,
     getMethodID: OcaMethodID,
     setMethodID: OcaMethodID? = nil,
-    ocp2Name: String? = nil
+    ocp2GetName: String? = nil
   ) {
     self.xPropertyID = xPropertyID
     self.yPropertyID = yPropertyID
@@ -126,10 +126,10 @@ public struct OcaVectorProperty<
     // The storage stands in for a pair of properties, so it has no property ID of
     // its own and must not borrow one: an ID that resolves (1.1 is OcaRoot's
     // `classID`) would name the OCP.2 parameters after that property. Leaving both
-    // the ID unresolvable and `ocp2Name` unset keeps `_ocp2WireName` nil, so the
+    // the ID unresolvable and `ocp2GetName` unset keeps `_ocp2GetName` nil, so the
     // encoder names the parameters after the vector record's own fields (`X`, `Y`),
-    // which is what the model specifies. `ocp2Name` still applies to the JSON export
-    // through this wrapper's own `_ocp2WireName`.
+    // which is what the model specifies. `ocp2GetName` still applies to the JSON export
+    // through this wrapper's own `_ocp2GetName`.
     _storage = OcaProperty(
       propertyID: OcaPropertyID("0.0"),
       getMethodID: getMethodID,
@@ -137,14 +137,14 @@ public struct OcaVectorProperty<
     )
   }
 
-  public func _ocp2WireName(_ object: OcaRoot) -> String? {
-    if let ocp2Name = _storage.ocp2Name { return ocp2Name }
+  public func _ocp2GetName(_ object: OcaRoot) -> String? {
+    if let ocp2GetName = _storage.ocp2GetName { return ocp2GetName }
     guard let name = object.propertyName(for: xPropertyID) else { return nil }
     return Ocp2Naming.wireName(name)
   }
 
   public func _ocp2ResponseNames(_ object: OcaRoot) -> [String]? {
-    _ocp2WireName(object).map { [$0] }
+    _ocp2GetName(object).map { [$0] }
   }
 
   public static subscript<T: OcaRoot>(
@@ -216,7 +216,7 @@ public struct OcaVectorProperty<
     flags: OcaPropertyResolutionFlags = .defaultFlags
   ) async throws -> [String: any Sendable] {
     let value = try await _getValue(object, flags: flags)
-    let name = _ocp2WireName(object) ?? xPropertyID.description
+    let name = _ocp2GetName(object) ?? xPropertyID.description
     return [name: Ocp2JSON.sendable(try Ocp2Encoder().encodeValue(value))]
   }
   #endif

--- a/Sources/SwiftOCA/OCF/Messages/Command.swift
+++ b/Sources/SwiftOCA/OCF/Messages/Command.swift
@@ -21,22 +21,58 @@ import FoundationEssentials
 import Foundation
 #endif
 
+/// Method parameters as carried on the wire. For OCP.1, `parameterCount` positional
+/// values encoded in `parameterData`; for OCP.2, `parameterData` is the serialised JSON
+/// `Parameters` object and `parameterCount` is unused.
 public struct Ocp1Parameters: Codable, Sendable {
   public let parameterCount: OcaUint8
   public let parameterData: Data
+  public let format: OcaParameterFormat
 
   public init(parameterCount: OcaUint8, parameterData: Data) {
     self.parameterCount = parameterCount
     self.parameterData = parameterData
+    format = .ocp1
+  }
+
+  /// OCP.2 parameters: `parameterData` is a serialised JSON object.
+  public init(ocp2ParameterData parameterData: Data) {
+    parameterCount = 0
+    self.parameterData = parameterData
+    format = .ocp2
   }
 
   public init() {
     self.init(parameterCount: 0, parameterData: Data())
   }
 
-  /// `true` when no parameters are carried.
+  /// `true` when no parameters are carried, in either format.
   public var isEmpty: Bool {
-    parameterCount == 0 && parameterData.isEmpty
+    switch format {
+    case .ocp1:
+      parameterCount == 0 && parameterData.isEmpty
+    case .ocp2:
+      parameterData.isEmpty
+    }
+  }
+
+  enum CodingKeys: CodingKey {
+    case parameterCount
+    case parameterData
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.init(
+      parameterCount: try container.decode(OcaUint8.self, forKey: .parameterCount),
+      parameterData: try container.decode(Data.self, forKey: .parameterData)
+    )
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(parameterCount, forKey: .parameterCount)
+    try container.encode(parameterData, forKey: .parameterData)
   }
 }
 

--- a/Sources/SwiftOCA/OCF/Messages/Command.swift
+++ b/Sources/SwiftOCA/OCF/Messages/Command.swift
@@ -22,25 +22,63 @@ import Foundation
 #endif
 
 /// Method parameters as carried on the wire. For OCP.1, `parameterCount` positional
-/// values encoded in `parameterData`; for OCP.2, `parameterData` is the serialised JSON
-/// `Parameters` object and `parameterCount` is unused.
+/// values encoded in `parameterData`; for OCP.2, the parsed JSON `Parameters` object,
+/// which `parameterData` serialises on demand, and `parameterCount` is unused.
 public struct Ocp1Parameters: Codable, Sendable {
   public let parameterCount: OcaUint8
-  public let parameterData: Data
   public let format: OcaParameterFormat
+  private let _ocp1Data: Data
+  #if NonEmbeddedBuild
+  private let _ocp2Object: [String: any Sendable]
+  #endif
+
+  public var parameterData: Data {
+    switch format {
+    case .ocp1:
+      return _ocp1Data
+    case .ocp2:
+      #if NonEmbeddedBuild
+      // the object was parsed or encoded as valid JSON, so serialising cannot fail
+      return _ocp2Object.isEmpty ? Data() : (try? Ocp2JSON.serialize(_ocp2Object)) ?? Data()
+      #else
+      return Data()
+      #endif
+    }
+  }
+
+  /// The OCP.2 `Parameters` object, or `nil` on OCP.1.
+  public var ocp2Parameters: [String: Any]? {
+    #if NonEmbeddedBuild
+    guard format == .ocp2 else { return nil }
+    return _ocp2Object
+    #else
+    return nil
+    #endif
+  }
 
   public init(parameterCount: OcaUint8, parameterData: Data) {
     self.parameterCount = parameterCount
-    self.parameterData = parameterData
+    _ocp1Data = parameterData
     format = .ocp1
+    #if NonEmbeddedBuild
+    _ocp2Object = [:]
+    #endif
   }
 
-  /// OCP.2 parameters: `parameterData` is a serialised JSON object.
-  public init(ocp2ParameterData parameterData: Data) {
+  #if NonEmbeddedBuild
+  /// OCP.2 parameters from the parsed `Parameters` object.
+  public init(ocp2Parameters object: [String: Any]) {
     parameterCount = 0
-    self.parameterData = parameterData
+    _ocp1Data = Data()
+    _ocp2Object = Ocp2JSON.sendableObject(object)
     format = .ocp2
   }
+
+  /// OCP.2 parameters from a serialised JSON object; empty data is no parameters.
+  public init(ocp2ParameterData parameterData: Data) throws {
+    self.init(ocp2Parameters: parameterData.isEmpty ? [:] : try Ocp2JSON.parseObject(parameterData))
+  }
+  #endif
 
   public init() {
     self.init(parameterCount: 0, parameterData: Data())
@@ -50,9 +88,13 @@ public struct Ocp1Parameters: Codable, Sendable {
   public var isEmpty: Bool {
     switch format {
     case .ocp1:
-      parameterCount == 0 && parameterData.isEmpty
+      return parameterCount == 0 && _ocp1Data.isEmpty
     case .ocp2:
-      parameterData.isEmpty
+      #if NonEmbeddedBuild
+      return _ocp2Object.isEmpty
+      #else
+      return true
+      #endif
     }
   }
 

--- a/Sources/SwiftOCA/OCF/Messages/Notification2.swift
+++ b/Sources/SwiftOCA/OCF/Messages/Notification2.swift
@@ -53,14 +53,41 @@ public struct Ocp1Notification2: _Ocp1MessageCodable, Sendable {
   let notificationSize: OcaUint32
   let event: OcaEvent
   let notificationType: Ocp1Notification2Type
-  /// Event data (`.event`) or an OCP.1-encoded `Ocp1Notification2ExceptionData`
-  /// (`.exception`). Event data is in `dataFormat`.
-  let data: Data
-  /// The marshaling of `data` for an `.event` notification. Exception data is always
-  /// OCP.1-encoded, whatever the framing, so `throwIfException` works for both.
+  /// OCP.1 event data (`.event`) or an OCP.1-encoded `Ocp1Notification2ExceptionData`
+  /// (`.exception`). Exception data is always OCP.1-encoded, whatever the framing,
+  /// so `throwIfException` works for both.
+  private let _data: Data
+  #if NonEmbeddedBuild
+  /// OCP.2 event data, held as parsed and serialised only if `data` is asked for.
+  private let _ocp2Value: (any Sendable)?
+  #endif
+  /// The marshaling of the event data for an `.event` notification.
   package let dataFormat: OcaParameterFormat
 
   public var messageSize: OcaUint32 { notificationSize }
+
+  /// The event data as wire bytes.
+  var data: Data {
+    switch dataFormat {
+    case .ocp1:
+      return _data
+    case .ocp2:
+      // parsed or encoded as valid JSON, so serialising cannot fail
+      return (try? eventData.data) ?? Data()
+    }
+  }
+
+  /// The event data as it was received or encoded.
+  package var eventData: OcaEncodedEventData {
+    #if NonEmbeddedBuild
+    switch dataFormat {
+    case .ocp1: .ocp1(_data)
+    case .ocp2: .ocp2(_ocp2Value)
+    }
+    #else
+    .ocp1(_data)
+    #endif
+  }
 
   public init(
     notificationSize: OcaUint32 = 0,
@@ -72,8 +99,7 @@ public struct Ocp1Notification2: _Ocp1MessageCodable, Sendable {
       notificationSize: notificationSize,
       event: event,
       notificationType: notificationType,
-      data: data,
-      dataFormat: .ocp1
+      eventData: .ocp1(data)
     )
   }
 
@@ -81,14 +107,25 @@ public struct Ocp1Notification2: _Ocp1MessageCodable, Sendable {
     notificationSize: OcaUint32 = 0,
     event: OcaEvent,
     notificationType: Ocp1Notification2Type,
-    data: Data,
-    dataFormat: OcaParameterFormat
+    eventData: OcaEncodedEventData
   ) {
     self.notificationSize = notificationSize
     self.event = event
     self.notificationType = notificationType
-    self.data = data
-    self.dataFormat = dataFormat
+    switch eventData {
+    case let .ocp1(data):
+      _data = data
+      dataFormat = .ocp1
+      #if NonEmbeddedBuild
+      _ocp2Value = nil
+      #endif
+    #if NonEmbeddedBuild
+    case let .ocp2(value):
+      _data = Data()
+      _ocp2Value = value
+      dataFormat = .ocp2
+    #endif
+    }
   }
 
   enum CodingKeys: CodingKey {
@@ -136,8 +173,11 @@ public struct Ocp1Notification2: _Ocp1MessageCodable, Sendable {
     notificationSize = try OcaUint32(parsingBigEndian: &input)
     event = try OcaEvent(parsing: &input)
     notificationType = try Ocp1Notification2Type(parsing: &input)
-    data = Data(parsingRemainingBytes: &input)
+    _data = Data(parsingRemainingBytes: &input)
     dataFormat = .ocp1
+    #if NonEmbeddedBuild
+    _ocp2Value = nil
+    #endif
   }
 
   func encode(into bytes: inout [UInt8]) {

--- a/Sources/SwiftOCA/OCF/Messages/Notification2.swift
+++ b/Sources/SwiftOCA/OCF/Messages/Notification2.swift
@@ -53,7 +53,12 @@ public struct Ocp1Notification2: _Ocp1MessageCodable, Sendable {
   let notificationSize: OcaUint32
   let event: OcaEvent
   let notificationType: Ocp1Notification2Type
+  /// Event data (`.event`) or an OCP.1-encoded `Ocp1Notification2ExceptionData`
+  /// (`.exception`). Event data is in `dataFormat`.
   let data: Data
+  /// The marshaling of `data` for an `.event` notification. Exception data is always
+  /// OCP.1-encoded, whatever the framing, so `throwIfException` works for both.
+  package let dataFormat: OcaParameterFormat
 
   public var messageSize: OcaUint32 { notificationSize }
 
@@ -63,10 +68,52 @@ public struct Ocp1Notification2: _Ocp1MessageCodable, Sendable {
     notificationType: Ocp1Notification2Type,
     data: Data
   ) {
+    self.init(
+      notificationSize: notificationSize,
+      event: event,
+      notificationType: notificationType,
+      data: data,
+      dataFormat: .ocp1
+    )
+  }
+
+  package init(
+    notificationSize: OcaUint32 = 0,
+    event: OcaEvent,
+    notificationType: Ocp1Notification2Type,
+    data: Data,
+    dataFormat: OcaParameterFormat
+  ) {
     self.notificationSize = notificationSize
     self.event = event
     self.notificationType = notificationType
     self.data = data
+    self.dataFormat = dataFormat
+  }
+
+  enum CodingKeys: CodingKey {
+    case notificationSize
+    case event
+    case notificationType
+    case data
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.init(
+      notificationSize: try container.decode(OcaUint32.self, forKey: .notificationSize),
+      event: try container.decode(OcaEvent.self, forKey: .event),
+      notificationType: try container.decode(Ocp1Notification2Type.self, forKey: .notificationType),
+      data: try container.decode(Data.self, forKey: .data)
+    )
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(notificationSize, forKey: .notificationSize)
+    try container.encode(event, forKey: .event)
+    try container.encode(notificationType, forKey: .notificationType)
+    try container.encode(data, forKey: .data)
   }
 
   func throwIfException() throws {
@@ -90,6 +137,7 @@ public struct Ocp1Notification2: _Ocp1MessageCodable, Sendable {
     event = try OcaEvent(parsing: &input)
     notificationType = try Ocp1Notification2Type(parsing: &input)
     data = Data(parsingRemainingBytes: &input)
+    dataFormat = .ocp1
   }
 
   func encode(into bytes: inout [UInt8]) {

--- a/Sources/SwiftOCA/OCF/OcaWireFormat.swift
+++ b/Sources/SwiftOCA/OCF/OcaWireFormat.swift
@@ -1,0 +1,178 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+/// The AES70 control protocol spoken on a connection.
+///
+/// Both protocols carry the same in-memory message model (`Ocp1Command`,
+/// `Ocp1Response`, `Ocp1Notification2`, keep-alives); they differ only in how a
+/// PDU is framed and how method parameters are marshaled. The `Ocp1*` message
+/// types are therefore the protocol-neutral model, despite their names.
+public enum OcaControlProtocol: String, Codable, Sendable, CaseIterable {
+  /// AES70-3: binary PDUs, positional parameters
+  case ocp1
+  #if NonEmbeddedBuild
+  /// AES70-4: newline-delimited JSON PDUs, named parameters
+  case ocp2
+  #endif
+}
+
+/// The marshaling of `Ocp1Parameters.parameterData`.
+public enum OcaParameterFormat: Sendable, Hashable {
+  /// positional OCP.1 bytes, counted by `parameterCount`
+  case ocp1
+  /// a serialised OCP.2 JSON `Parameters` object
+  case ocp2
+}
+
+/// Reads one PDU at a time from a transport. Owned by exactly one receive loop
+/// and not `Sendable`: it buffers bytes between PDUs on stream transports.
+///
+/// `read(n, awaitingAllRead)` returns exactly `n` bytes when `awaitingAllRead`, else
+/// between 1 and `n` as soon as any are available; a message-oriented transport
+/// returns one whole message either way, ignoring `n`. It throws on EOF.
+package protocol OcaPduReader: AnyObject {
+  func nextPdu(
+    read: (_ count: Int, _ awaitingAllRead: Bool) async throws -> Data
+  ) async throws -> Data
+}
+
+public extension OcaControlProtocol {
+  /// Default maximum PDU size accepted from the peer.
+  static let defaultMaximumPduSize = 16 * 1024 * 1024
+}
+
+/// Framing, as a switch on the protocol rather than a witness table: the two
+/// framings are a closed set and hold no state (per-connection reader state lives
+/// in the `OcaPduReader` they vend), so an existential would buy nothing and cost a
+/// dynamic dispatch — and, for a message passed as `any Ocp1Message`, a heap box on
+/// every send, since the message types are larger than an existential's inline
+/// buffer.
+package extension OcaControlProtocol {
+  /// Encode a whole PDU.
+  func encodePdu(_ messages: [Ocp1Message], type messageType: OcaMessageType) throws -> Data {
+    switch self {
+    case .ocp1:
+      try Ocp1Connection.encodeOcp1MessagePdu(messages, type: messageType)
+    #if NonEmbeddedBuild
+    case .ocp2:
+      try Ocp2Message.encodePdu(messages, type: messageType)
+    #endif
+    }
+  }
+
+  /// Decode a whole PDU into its message type and messages.
+  func decodePdu(_ data: Data) throws -> (OcaMessageType, [Ocp1Message]) {
+    switch self {
+    case .ocp1:
+      try Ocp1Connection.decodeOcp1MessagePdu(from: data)
+    #if NonEmbeddedBuild
+    case .ocp2:
+      try Ocp2Message.decodePdu(data)
+    #endif
+    }
+  }
+
+  /// Batching support: encode one message; `assemblePdu` later combines any
+  /// number of same-type encoded messages into one PDU. Generic, so a message
+  /// reaches the encoder without being boxed; `internal` because
+  /// `_Ocp1MessageCodable` is, and only the batcher (in this module) sends one
+  /// message at a time.
+  internal func encodeMessage(
+    _ message: some _Ocp1MessageCodable,
+    type messageType: OcaMessageType
+  ) throws -> [UInt8] {
+    switch self {
+    case .ocp1:
+      var bytes = [UInt8]()
+      try message.encode(type: messageType, into: &bytes)
+      return bytes
+    #if NonEmbeddedBuild
+    case .ocp2:
+      return try Ocp2Message.encodeMessage(message, type: messageType)
+    #endif
+    }
+  }
+
+  func assemblePdu(
+    type messageType: OcaMessageType,
+    encodedMessages: [[UInt8]]
+  ) throws -> [UInt8] {
+    switch self {
+    case .ocp1:
+      try Ocp1Connection.encodeOcp1MessagePduData(type: messageType, encodedPdus: encodedMessages)
+    #if NonEmbeddedBuild
+    case .ocp2:
+      try Ocp2Message.assemblePdu(type: messageType, encodedMessages: encodedMessages)
+    #endif
+    }
+  }
+
+  /// Bytes a PDU carrying `messageCount` messages adds beyond the messages
+  /// themselves, for batch size accounting.
+  func pduOverhead(messageCount: Int) -> Int {
+    switch self {
+    case .ocp1:
+      Ocp1Connection.MinimumPduSize
+    #if NonEmbeddedBuild
+    case .ocp2:
+      Ocp2Message.pduOverhead(messageCount: messageCount)
+    #endif
+    }
+  }
+
+  /// A reader for one receive loop. `isMessageOriented` transports deliver a whole
+  /// PDU per read.
+  func makeReader(isMessageOriented: Bool, maximumPduSize: Int) -> any OcaPduReader {
+    switch self {
+    case .ocp1:
+      Ocp1PduReader(maximumPduSize: maximumPduSize)
+    #if NonEmbeddedBuild
+    case .ocp2:
+      Ocp2PduReader(isMessageOriented: isMessageOriented, maximumPduSize: maximumPduSize)
+    #endif
+    }
+  }
+
+  /// WebSocket subprotocol to offer/accept, or `nil` for none.
+  var webSocketSubprotocol: String? {
+    switch self {
+    case .ocp1:
+      nil
+    #if NonEmbeddedBuild
+    case .ocp2:
+      "AES70-OCP.2"
+    #endif
+    }
+  }
+
+  /// Whether WebSocket frames carry text (OCP.2) or binary (OCP.1).
+  var webSocketUsesTextFrames: Bool {
+    switch self {
+    case .ocp1:
+      false
+    #if NonEmbeddedBuild
+    case .ocp2:
+      true
+    #endif
+    }
+  }
+}

--- a/Sources/SwiftOCA/OCF/OcaWireFormat.swift
+++ b/Sources/SwiftOCA/OCF/OcaWireFormat.swift
@@ -152,6 +152,16 @@ package extension OcaControlProtocol {
     }
   }
 
+  /// The connection prefix for the protocol in use: `ocp1` on OCP.1, `ocp2` on OCP.2.
+  func connectionPrefix(ocp1: String, ocp2: String) -> String {
+    switch self {
+    case .ocp1: ocp1
+    #if NonEmbeddedBuild
+    case .ocp2: ocp2
+    #endif
+    }
+  }
+
   /// WebSocket subprotocol to offer/accept, or `nil` for none.
   var webSocketSubprotocol: String? {
     switch self {

--- a/Sources/SwiftOCA/OCP.1/Backend/Ocp1CFSocketConnection.swift
+++ b/Sources/SwiftOCA/OCP.1/Backend/Ocp1CFSocketConnection.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023-2024 PADL Software Pty Ltd
+// Copyright (c) 2023-2026 PADL Software Pty Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.
@@ -300,6 +300,22 @@ Sendable, CustomStringConvertible, Hashable {
     }
   }
 
+  /// Between 1 and `maxLength` bytes, as soon as any are buffered or arrive.
+  public func readSome(atMost maxLength: Int) async throws -> Data {
+    precondition(!isDatagram)
+
+    if receivedData.isEmpty {
+      try await drainChannel(atLeast: 1)
+      guard !receivedData.isEmpty else {
+        throw Ocp1Error.notConnected
+      }
+    }
+
+    let data = Data(receivedData.prefix(maxLength))
+    receivedData = receivedData.dropFirst(data.count)
+    return data
+  }
+
   public func read(count: Int) async throws -> Data {
     precondition(!isDatagram)
 
@@ -478,12 +494,13 @@ public final class Ocp1CFSocketUDPConnection: Ocp1CFSocketConnection {
   }
 
   override public var connectionPrefix: String {
-    "\(OcaUdpConnectionPrefix)/\(_currentPresentationAddress)"
+    let prefix = _connectionPrefix(ocp1: OcaUdpConnectionPrefix, ocp2: OcaJsonUdpConnectionPrefix)
+    return "\(prefix)/\(_currentPresentationAddress)"
   }
 
   override public var isDatagram: Bool { true }
 
-  override public func read(_ length: Int) async throws -> Data {
+  override public func read(_ length: Int, awaitingAllRead: Bool) async throws -> Data {
     guard let _socket else { throw Ocp1Error.notConnected }
     var iterator = _socket.receivedMessages.makeAsyncIterator()
     guard let data = try await iterator.next()?.1 else {
@@ -505,14 +522,18 @@ public final class Ocp1CFSocketTCPConnection: Ocp1CFSocketConnection {
   }
 
   override public var connectionPrefix: String {
-    "\(OcaTcpConnectionPrefix)/\(_currentPresentationAddress)"
+    let prefix = _connectionPrefix(ocp1: OcaTcpConnectionPrefix, ocp2: OcaJsonTcpConnectionPrefix)
+    return "\(prefix)/\(_currentPresentationAddress)"
   }
 
   override public var isDatagram: Bool { false }
 
-  override public func read(_ length: Int) async throws -> Data {
+  override public func read(_ length: Int, awaitingAllRead: Bool) async throws -> Data {
     guard let _socket else { throw Ocp1Error.notConnected }
-    return try await _socket.read(count: length)
+    if awaitingAllRead {
+      return try await _socket.read(count: length)
+    }
+    return try await _socket.readSome(atMost: length)
   }
 
   override public func write(_ data: Data) async throws -> Int {

--- a/Sources/SwiftOCA/OCP.1/Backend/Ocp1FlyingFoxConnection.swift
+++ b/Sources/SwiftOCA/OCP.1/Backend/Ocp1FlyingFoxConnection.swift
@@ -22,10 +22,12 @@ import FoundationEssentials
 import Foundation
 #endif
 
-/// A client-side OCP.1 connection over WebSockets.
+/// A client-side OCP.1 or OCP.2 connection over WebSockets.
 ///
-/// WebSocket ping/pong frames handle connection liveness, so no OCP.1 keepalive
-/// (heartbeat) messages are required. `heartbeatTime` is `.zero`.
+/// WebSocket ping/pong frames handle connection liveness, so no keepalive
+/// (heartbeat) messages are required by default; `heartbeatTime` is `.zero` unless
+/// the options override it. OCP.1 travels in binary frames, OCP.2 in text frames with
+/// the `AES70-OCP.2` subprotocol (AES70-4 10.4.3.4).
 public final class Ocp1FlyingFoxConnection: Ocp1Connection {
   private let url: URL
   private var webSocketTask: URLSessionWebSocketTask?
@@ -52,7 +54,11 @@ public final class Ocp1FlyingFoxConnection: Ocp1Connection {
   }
 
   override public nonisolated var connectionPrefix: String {
-    "\(OcaWebSocketTcpConnectionPrefix)/\(url.absoluteString)"
+    let prefix = _connectionPrefix(
+      ocp1: OcaWebSocketTcpConnectionPrefix,
+      ocp2: OcaJsonWebSocketTcpConnectionPrefix
+    )
+    return "\(prefix)/\(url.absoluteString)"
   }
 
   /// WebSocket ping/pong handles liveness; no OCP.1 keepalive needed.
@@ -72,11 +78,18 @@ public final class Ocp1FlyingFoxConnection: Ocp1Connection {
 
     let session = URLSession(configuration: .default)
     self.session = session
-    let task = session.webSocketTask(with: url)
-    task.maximumMessageSize = Int(UInt16.max)
+    let task: URLSessionWebSocketTask = if let subprotocol = controlProtocol.webSocketSubprotocol {
+      session.webSocketTask(with: url, protocols: [subprotocol])
+    } else {
+      session.webSocketTask(with: url)
+    }
+    task.maximumMessageSize = controlProtocol.webSocketUsesTextFrames
+      ? options.maximumPduSize
+      : Int(UInt16.max)
     webSocketTask = task
     task.resume()
 
+    let usesTextFrames = controlProtocol.webSocketUsesTextFrames
     receiveTask = Task { [weak self] in
       while !Task.isCancelled {
         guard let self else { return }
@@ -84,11 +97,15 @@ public final class Ocp1FlyingFoxConnection: Ocp1Connection {
           let message = try await task.receive()
           switch message {
           case let .data(data):
+            guard !usesTextFrames else {
+              // AES70-4 10.4.3.4.4: OCP.2 travels in text frames only
+              task.cancel(with: .unsupportedData, reason: nil)
+              receivedMessageContinuation?.finish(throwing: Ocp1Error.notConnected)
+              return
+            }
             receivedMessageContinuation?.yield(data)
           case let .string(string):
-            if let data = string.data(using: .utf8) {
-              receivedMessageContinuation?.yield(data)
-            }
+            receivedMessageContinuation?.yield(Data(string.utf8))
           @unknown default:
             break
           }
@@ -124,7 +141,9 @@ public final class Ocp1FlyingFoxConnection: Ocp1Connection {
     try await super.disconnectDevice()
   }
 
-  override public func read(_ length: Int) async throws -> Data {
+  /// One frame per read, whatever `length` and `awaitingAllRead`: the transport is
+  /// message-oriented.
+  override public func read(_ length: Int, awaitingAllRead: Bool) async throws -> Data {
     guard let receivedMessageStream else {
       throw Ocp1Error.notConnected
     }
@@ -138,7 +157,11 @@ public final class Ocp1FlyingFoxConnection: Ocp1Connection {
     guard let webSocketTask else {
       throw Ocp1Error.notConnected
     }
-    try await webSocketTask.send(.data(data))
+    if controlProtocol.webSocketUsesTextFrames {
+      try await webSocketTask.send(.string(String(decoding: data, as: UTF8.self)))
+    } else {
+      try await webSocketTask.send(.data(data))
+    }
     return data.count
   }
 }

--- a/Sources/SwiftOCA/OCP.1/Backend/Ocp1FlyingSocksConnection.swift
+++ b/Sources/SwiftOCA/OCP.1/Backend/Ocp1FlyingSocksConnection.swift
@@ -382,16 +382,20 @@ public class Ocp1FlyingSocksConnection: Ocp1Connection, Ocp1MutableSocketAddress
 
 public final class Ocp1FlyingSocksStreamConnection: Ocp1FlyingSocksConnection {
   override public var connectionPrefix: String {
-    "\(OcaTcpConnectionPrefix)/\(_currentPresentationAddress)"
+    let prefix = _connectionPrefix(ocp1: OcaTcpConnectionPrefix, ocp2: OcaJsonTcpConnectionPrefix)
+    return "\(prefix)/\(_currentPresentationAddress)"
   }
 
   override public var isDatagram: Bool { false }
 
   override var socketType: SocketType { .stream }
 
-  override public func read(_ length: Int) async throws -> Data {
+  override public func read(_ length: Int, awaitingAllRead: Bool) async throws -> Data {
     try await withMappedError { socket in
-      try await Data(socket.read(bytes: length))
+      if awaitingAllRead {
+        return try await Data(socket.read(bytes: length))
+      }
+      return try await Data(socket.read(atMost: length))
     }
   }
 
@@ -404,7 +408,8 @@ public final class Ocp1FlyingSocksStreamConnection: Ocp1FlyingSocksConnection {
 
 public final class Ocp1FlyingSocksDatagramConnection: Ocp1FlyingSocksConnection {
   override public var connectionPrefix: String {
-    "\(OcaUdpConnectionPrefix)/\(_currentPresentationAddress)"
+    let prefix = _connectionPrefix(ocp1: OcaUdpConnectionPrefix, ocp2: OcaJsonUdpConnectionPrefix)
+    return "\(prefix)/\(_currentPresentationAddress)"
   }
 
   override public var heartbeatTime: Duration {
@@ -415,7 +420,7 @@ public final class Ocp1FlyingSocksDatagramConnection: Ocp1FlyingSocksConnection 
 
   override var socketType: SocketType { .datagram }
 
-  override public func read(_ length: Int) async throws -> Data {
+  override public func read(_ length: Int, awaitingAllRead: Bool) async throws -> Data {
     try await withMappedError { socket in
       try await Data(socket.read(atMost: Ocp1MaximumDatagramPduSize))
     }

--- a/Sources/SwiftOCA/OCP.1/Backend/Ocp1IORingConnection.swift
+++ b/Sources/SwiftOCA/OCP.1/Backend/Ocp1IORingConnection.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 PADL Software Pty Ltd
+// Copyright (c) 2023-2026 PADL Software Pty Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.
@@ -200,7 +200,7 @@ public final class Ocp1IORingDatagramConnection: Ocp1IORingConnection {
     _socket = socket
   }
 
-  override public func read(_ length: Int) async throws -> Data {
+  override public func read(_ length: Int, awaitingAllRead: Bool) async throws -> Data {
     try await withMappedError { socket in
       try await Data(socket.receive(count: Ocp1MaximumDatagramPduSize))
     }
@@ -214,7 +214,8 @@ public final class Ocp1IORingDatagramConnection: Ocp1IORingConnection {
   }
 
   override public var connectionPrefix: String {
-    "\(OcaUdpConnectionPrefix)/\(_currentPresentationAddress)"
+    let prefix = _connectionPrefix(ocp1: OcaUdpConnectionPrefix, ocp2: OcaJsonUdpConnectionPrefix)
+    return "\(prefix)/\(_currentPresentationAddress)"
   }
 
   override public var isDatagram: Bool { true }
@@ -278,7 +279,7 @@ public final class Ocp1IORingDomainSocketDatagramConnection: Ocp1IORingConnectio
     _socket = socket
   }
 
-  override public func read(_ length: Int) async throws -> Data {
+  override public func read(_ length: Int, awaitingAllRead: Bool) async throws -> Data {
     try await withMappedError { socket in
       try await Data(socket.readFixed(
         count: receiveBufferSize,
@@ -301,7 +302,8 @@ public final class Ocp1IORingDomainSocketDatagramConnection: Ocp1IORingConnectio
   }
 
   override public var connectionPrefix: String {
-    "\(OcaLocalConnectionPrefix)/\(_currentPresentationAddress)"
+    let prefix = _connectionPrefix(ocp1: OcaLocalConnectionPrefix, ocp2: OcaJsonLocalConnectionPrefix)
+    return "\(prefix)/\(_currentPresentationAddress)"
   }
 
   override public var isDatagram: Bool { true }
@@ -332,9 +334,9 @@ public final class Ocp1IORingStreamConnection: Ocp1IORingConnection {
     _socket = socket
   }
 
-  override public func read(_ length: Int) async throws -> Data {
+  override public func read(_ length: Int, awaitingAllRead: Bool) async throws -> Data {
     try await withMappedError { socket in
-      try await Data(socket.read(count: length, awaitingAllRead: true))
+      try await Data(socket.read(count: length, awaitingAllRead: awaitingAllRead))
     }
   }
 
@@ -346,7 +348,8 @@ public final class Ocp1IORingStreamConnection: Ocp1IORingConnection {
 
   override public var connectionPrefix: String {
     let prefix = _currentSocketAddress?.family == sa_family_t(AF_LOCAL)
-      ? OcaLocalConnectionPrefix : OcaTcpConnectionPrefix
+      ? _connectionPrefix(ocp1: OcaLocalConnectionPrefix, ocp2: OcaJsonLocalConnectionPrefix)
+      : _connectionPrefix(ocp1: OcaTcpConnectionPrefix, ocp2: OcaJsonTcpConnectionPrefix)
     return "\(prefix)/\(_currentPresentationAddress)"
   }
 

--- a/Sources/SwiftOCA/OCP.1/Backend/Ocp1MachPortConnection.swift
+++ b/Sources/SwiftOCA/OCP.1/Backend/Ocp1MachPortConnection.swift
@@ -129,7 +129,7 @@ public final class Ocp1MachPortConnection: Ocp1Connection {
     try await super.disconnectDevice()
   }
 
-  override public func read(_ length: Int) async throws -> Data {
+  override public func read(_ length: Int, awaitingAllRead: Bool) async throws -> Data {
     guard let handle = clientHandle, let queue = receiveQueue else {
       throw Ocp1Error.notConnected
     }

--- a/Sources/SwiftOCA/OCP.1/Backend/Ocp1NWConnection.swift
+++ b/Sources/SwiftOCA/OCP.1/Backend/Ocp1NWConnection.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025 PADL Software Pty Ltd
+// Copyright (c) 2025-2026 PADL Software Pty Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.
@@ -261,13 +261,13 @@ open class Ocp1NWConnection: Ocp1Connection, Ocp1MutableSocketAddressConnection 
     try await super.disconnectDevice()
   }
 
-  override public func read(_ length: Int) async throws -> Data {
+  override public func read(_ length: Int, awaitingAllRead: Bool) async throws -> Data {
     // a stream hands over whatever is buffered, so a read bounded only by the datagram
     // size takes the start of the next PDU as well; a datagram is returned whole
     let maximumLength = isDatagram ? Ocp1MaximumDatagramPduSize : length
     return try await withUnsafeThrowingContinuation { continuation in
       _nwConnection.receive(
-        minimumIncompleteLength: length,
+        minimumIncompleteLength: awaitingAllRead ? length : 1,
         maximumLength: maximumLength
       ) { data, _, _, error in
         if let error {
@@ -347,7 +347,8 @@ public final class Ocp1NWUDPConnection: Ocp1NWConnection {
   }
 
   override public var connectionPrefix: String {
-    "\(OcaUdpConnectionPrefix)/\(presentationAddress)"
+    let prefix = _connectionPrefix(ocp1: OcaUdpConnectionPrefix, ocp2: OcaJsonUdpConnectionPrefix)
+    return "\(prefix)/\(presentationAddress)"
   }
 
   override public var isDatagram: Bool { true }
@@ -360,7 +361,8 @@ public final class Ocp1NWUDPConnection: Ocp1NWConnection {
 
 public final class Ocp1NWTCPConnection: Ocp1NWConnection {
   override public var connectionPrefix: String {
-    "\(OcaTcpConnectionPrefix)/\(presentationAddress)"
+    let prefix = _connectionPrefix(ocp1: OcaTcpConnectionPrefix, ocp2: OcaJsonTcpConnectionPrefix)
+    return "\(prefix)/\(presentationAddress)"
   }
 
   override public var isDatagram: Bool { false }

--- a/Sources/SwiftOCA/OCP.1/Ocp1CoderAPI.swift
+++ b/Sources/SwiftOCA/OCP.1/Ocp1CoderAPI.swift
@@ -52,6 +52,10 @@ protocol Ocp1MapRepresentable<Key, Value>: Collection, Codable {
   associatedtype Value: Codable
 
   init(from: Ocp1DecoderImpl) throws
+  #if NonEmbeddedBuild
+  /// OCP.2 marshals a map as an array of `[key, value]` pairs.
+  init(ocp2State: Ocp2DecodingState, json: Any, codingPath: [any CodingKey]) throws
+  #endif
   func withMapItems(_ block: (Key, Value) throws -> ()) rethrows
 }
 
@@ -66,6 +70,25 @@ extension Dictionary: Ocp1MapRepresentable where Key: Codable & Hashable, Value:
     let mapItemSet = try Set<Ocp1MapItem<Key, Value>>(from: ocp1Decoder)
     self.init(mapItemSet: mapItemSet)
   }
+
+  #if NonEmbeddedBuild
+  init(ocp2State state: Ocp2DecodingState, json: Any, codingPath: [any CodingKey]) throws {
+    guard let items = json as? [Any] else {
+      throw Ocp1Error.status(.badFormat)
+    }
+    var dictionary = [Key: Value]()
+    dictionary.reserveCapacity(items.count)
+    for item in items {
+      guard let pair = item as? [Any], pair.count == 2 else {
+        throw Ocp1Error.status(.badFormat)
+      }
+      let key = try state.decode(Key.self, from: pair[0], codingPath: codingPath)
+      let value = try state.decode(Value.self, from: pair[1], codingPath: codingPath)
+      dictionary[key] = value
+    }
+    self = dictionary
+  }
+  #endif
 
   func withMapItems(_ block: (Key, Value) throws -> ()) rethrows {
     for (key, value) in self {

--- a/Sources/SwiftOCA/OCP.1/Ocp1Connection+Connect.swift
+++ b/Sources/SwiftOCA/OCP.1/Ocp1Connection+Connect.swift
@@ -193,8 +193,8 @@ extension Ocp1Connection {
   package var _connectionTimeout: Duration {
     let timeout = options.connectionTimeout
 
-    if isDatagram, timeout < heartbeatTime * 2 {
-      return heartbeatTime * 2
+    if isDatagram, timeout < effectiveHeartbeatTime * 2 {
+      return effectiveHeartbeatTime * 2
     } else {
       return timeout
     }
@@ -224,7 +224,7 @@ extension Ocp1Connection {
   private func _didConnectDevice(isReconnecting: Bool) async throws {
     _startMonitor()
 
-    if heartbeatTime > .zero {
+    if effectiveHeartbeatTime > .zero {
       // send keepalive, necessary to open UDP connection
       try await sendKeepAlive()
     }

--- a/Sources/SwiftOCA/OCP.1/Ocp1Connection+Messages.swift
+++ b/Sources/SwiftOCA/OCP.1/Ocp1Connection+Messages.swift
@@ -67,7 +67,7 @@ extension Ocp1Connection {
 
   func sendKeepAlive() async throws {
     try await sendMessage(
-      Ocp1KeepAlive.message(interval: heartbeatTime),
+      Ocp1KeepAlive.message(interval: effectiveHeartbeatTime),
       type: .ocaKeepAlive
     )
   }

--- a/Sources/SwiftOCA/OCP.1/Ocp1Connection+Subscribe.swift
+++ b/Sources/SwiftOCA/OCP.1/Ocp1Connection+Subscribe.swift
@@ -72,6 +72,44 @@ public extension Ocp1Connection {
     subscriptions[event] != nil
   }
 
+  /// OCP.2 supports only EV2 subscriptions; OCP.1 keeps the EV1 form for the
+  /// widest device compatibility.
+  private func _addSubscription(_ event: OcaEvent) async throws {
+    switch controlProtocol {
+    case .ocp1:
+      try await subscriptionManager.addSubscription(
+        event: event,
+        subscriber: subscriber,
+        subscriberContext: OcaBlob(),
+        notificationDeliveryMode: .normal,
+        destinationInformation: OcaNetworkAddress()
+      )
+    #if NonEmbeddedBuild
+    case .ocp2:
+      try await subscriptionManager.addSubscription2(
+        event: event,
+        notificationDeliveryMode: .normal,
+        destinationInformation: OcaNetworkAddress()
+      )
+    #endif
+    }
+  }
+
+  private func _removeSubscription(_ event: OcaEvent) async throws {
+    switch controlProtocol {
+    case .ocp1:
+      try await subscriptionManager.removeSubscription(event: event, subscriber: subscriber)
+    #if NonEmbeddedBuild
+    case .ocp2:
+      try await subscriptionManager.removeSubscription2(
+        event: event,
+        notificationDeliveryMode: .normal,
+        destinationInformation: OcaNetworkAddress()
+      )
+    #endif
+    }
+  }
+
   func isSubscribed(_ cancellable: SubscriptionCancellable) -> Bool {
     guard let eventSubscriptions = subscriptions[cancellable.event] else { return false }
     return eventSubscriptions.subscriptions.contains(cancellable)
@@ -97,13 +135,7 @@ public extension Ocp1Connection {
       subscriptions[event] = eventSubscriptions
 
       do {
-        try await subscriptionManager.addSubscription(
-          event: event,
-          subscriber: subscriber,
-          subscriberContext: OcaBlob(),
-          notificationDeliveryMode: .normal,
-          destinationInformation: OcaNetworkAddress()
-        )
+        try await _addSubscription(event)
       } catch {
         // roll back, otherwise isSubscribed(event:) reports true with nothing
         // registered on the device and callers never retry
@@ -131,10 +163,7 @@ public extension Ocp1Connection {
     logger.trace("removeSubscription: removed \(cancellable) from subscription set")
     if eventSubscriptions.subscriptions.isEmpty {
       subscriptions[cancellable.event] = nil
-      try await subscriptionManager.removeSubscription(
-        event: cancellable.event,
-        subscriber: subscriber
-      )
+      try await _removeSubscription(cancellable.event)
       logger.trace("removeSubscription: removed OCA subscription for \(cancellable.event)")
     }
   }
@@ -143,7 +172,7 @@ public extension Ocp1Connection {
     await withTaskGroup(of: Void.self, returning: Void.self) { taskGroup in
       for event in subscribedEvents {
         taskGroup.addTask { [self] in
-          try? await subscriptionManager.removeSubscription(event: event, subscriber: subscriber)
+          try? await _removeSubscription(event)
         }
       }
     }
@@ -156,13 +185,7 @@ public extension Ocp1Connection {
       for event in events {
         taskGroup.addTask { [self] in
           do {
-            try await subscriptionManager.addSubscription(
-              event: event,
-              subscriber: subscriber,
-              subscriberContext: OcaBlob(),
-              notificationDeliveryMode: .normal,
-              destinationInformation: OcaNetworkAddress()
-            )
+            try await _addSubscription(event)
             logger.trace("\(self): addSubscriptions: refreshed \(event)")
           } catch is CancellationError {
             logger.debug("\(self): addSubscriptions: cancelled refreshing \(event)")

--- a/Sources/SwiftOCA/OCP.1/Ocp1Connection+Subscribe.swift
+++ b/Sources/SwiftOCA/OCP.1/Ocp1Connection+Subscribe.swift
@@ -52,11 +52,27 @@ public extension Ocp1Connection {
     public let label: String?
     public let event: OcaEvent
     public let callback: OcaSubscriptionCallback
+    /// Delivers event data as it arrived, so OCP.2 data is serialised only for a
+    /// `callback` that wants bytes.
+    let deliver: OcaEventDataHandler
 
     init(label: String?, event: OcaEvent, callback: @escaping OcaSubscriptionCallback) {
       self.label = label
       self.event = event
       self.callback = callback
+      deliver = { event, eventData in try await callback(event, eventData.data) }
+    }
+
+    init(
+      label: String?,
+      event: OcaEvent,
+      format: OcaParameterFormat,
+      handler: @escaping OcaEventDataHandler
+    ) {
+      self.label = label
+      self.event = event
+      callback = { event, data in try await handler(event, OcaEncodedEventData(data, format: format)) }
+      deliver = handler
     }
 
     public var description: String {
@@ -120,7 +136,29 @@ public extension Ocp1Connection {
     event: OcaEvent,
     callback: @escaping OcaSubscriptionCallback
   ) async throws -> SubscriptionCancellable {
-    let cancellable = SubscriptionCancellable(label: label, event: event, callback: callback)
+    try await _addSubscription(SubscriptionCancellable(label: label, event: event, callback: callback))
+  }
+
+  /// A subscription handed event data as it arrived: OCP.1 bytes, or OCP.2 data
+  /// already parsed. Named apart from `addSubscription` so a trailing closure that
+  /// ignores its arguments stays unambiguous for public callers.
+  package func addEventDataSubscription(
+    label: String? = nil,
+    event: OcaEvent,
+    handler: @escaping OcaEventDataHandler
+  ) async throws -> SubscriptionCancellable {
+    try await _addSubscription(SubscriptionCancellable(
+      label: label,
+      event: event,
+      format: controlProtocol.parameterFormat,
+      handler: handler
+    ))
+  }
+
+  private func _addSubscription(_ cancellable: SubscriptionCancellable) async throws
+    -> SubscriptionCancellable
+  {
+    let event = cancellable.event
     if let eventSubscriptions = subscriptions[event] {
       precondition(!eventSubscriptions.subscriptions.isEmpty)
       if eventSubscriptions.subscriptions.contains(cancellable) {
@@ -203,7 +241,7 @@ public extension Ocp1Connection {
     await addSubscriptions(events: Array(subscribedEvents))
   }
 
-  internal func notifySubscribers(of event: OcaEvent, with parameters: Data) {
+  internal func notifySubscribers(of event: OcaEvent, with eventData: OcaEncodedEventData) {
     guard let eventSubscriptions = subscriptions[event],
           !eventSubscriptions.subscriptions.isEmpty
     else {
@@ -216,7 +254,7 @@ public extension Ocp1Connection {
       await withTaskGroup(of: Void.self, returning: Void.self) { taskGroup in
         for subscription in subscriptions {
           taskGroup.addTask {
-            try? await subscription.callback(event, parameters)
+            try? await subscription.deliver(event, eventData)
           }
         }
       }

--- a/Sources/SwiftOCA/OCP.1/Ocp1Connection.swift
+++ b/Sources/SwiftOCA/OCP.1/Ocp1Connection.swift
@@ -76,6 +76,11 @@ public let OcaTcpConnectionPrefix = "oca/tcp"
 public let OcaUdpConnectionPrefix = "oca/udp"
 public let OcaWebSocketTcpConnectionPrefix = "ocaws/tcp"
 public let OcaLocalConnectionPrefix = "oca/local"
+// OCP.2 (AES70-4) equivalents, named after the DNS-SD service types
+public let OcaJsonTcpConnectionPrefix = "ocajson/tcp"
+public let OcaJsonUdpConnectionPrefix = "ocajson/udp"
+public let OcaJsonWebSocketTcpConnectionPrefix = "ocajsonws/tcp"
+public let OcaJsonLocalConnectionPrefix = "ocajson/local"
 public let OcaDatagramProxyConnectionPrefix = "oca/dg-proxy"
 // macOS-only, not Darwin-wide: see Ocp1MachPortSupport.swift.
 #if os(macOS)
@@ -126,6 +131,14 @@ public struct Ocp1ConnectionOptions: Sendable {
   public let reconnectPauseInterval: Duration
   public let reconnectExponentialBackoffThreshold: Range<Int>
   public let batchingOptions: BatchingOptions?
+  /// The control protocol to speak; the transport is chosen by the connection class.
+  public let controlProtocol: OcaControlProtocol
+  /// Largest PDU accepted from the device. Only enforced for OCP.2 (OCP.1 PDUs are
+  /// bounded by their 32-bit size field).
+  public let maximumPduSize: Int
+  /// Overrides the transport's default keep-alive interval when set; `.zero` disables
+  /// keep-alives.
+  public let heartbeatTime: Duration?
 
   public init(
     flags: Ocp1ConnectionFlags = .refreshDeviceTreeOnConnection,
@@ -134,7 +147,10 @@ public struct Ocp1ConnectionOptions: Sendable {
     reconnectMaxTries: Int = 15,
     reconnectPauseInterval: Duration = .milliseconds(250),
     reconnectExponentialBackoffThreshold: Range<Int> = 3..<8,
-    batchingOptions: BatchingOptions? = nil
+    batchingOptions: BatchingOptions? = nil,
+    controlProtocol: OcaControlProtocol = .ocp1,
+    maximumPduSize: Int = OcaControlProtocol.defaultMaximumPduSize,
+    heartbeatTime: Duration? = nil
   ) {
     self.flags = flags
     self.connectionTimeout = connectionTimeout
@@ -143,6 +159,9 @@ public struct Ocp1ConnectionOptions: Sendable {
     self.reconnectPauseInterval = reconnectPauseInterval
     self.reconnectExponentialBackoffThreshold = reconnectExponentialBackoffThreshold
     self.batchingOptions = batchingOptions
+    self.controlProtocol = controlProtocol
+    self.maximumPduSize = maximumPduSize
+    self.heartbeatTime = heartbeatTime
   }
 
   @available(*, deprecated, message: "use Ocp1ConnectionFlags initializer")
@@ -178,7 +197,10 @@ public struct Ocp1ConnectionOptions: Sendable {
     reconnectMaxTries: Int? = nil,
     reconnectPauseInterval: Duration? = nil,
     reconnectExponentialBackoffThreshold: Range<Int>? = nil,
-    batchingOptions: BatchingOptions? = nil
+    batchingOptions: BatchingOptions? = nil,
+    controlProtocol: OcaControlProtocol? = nil,
+    maximumPduSize: Int? = nil,
+    heartbeatTime: Duration?? = nil
   ) -> Self {
     Self(
       flags: flags ?? self.flags,
@@ -188,7 +210,10 @@ public struct Ocp1ConnectionOptions: Sendable {
       reconnectPauseInterval: reconnectPauseInterval ?? self.reconnectPauseInterval,
       reconnectExponentialBackoffThreshold:
       reconnectExponentialBackoffThreshold ?? self.reconnectExponentialBackoffThreshold,
-      batchingOptions: batchingOptions ?? self.batchingOptions
+      batchingOptions: batchingOptions ?? self.batchingOptions,
+      controlProtocol: controlProtocol ?? self.controlProtocol,
+      maximumPduSize: maximumPduSize ?? self.maximumPduSize,
+      heartbeatTime: heartbeatTime ?? self.heartbeatTime
     )
   }
 }
@@ -245,6 +270,11 @@ open class Ocp1Connection: CustomStringConvertible {
   public func set(options: Ocp1ConnectionOptions) async throws {
     let oldFlags = self.options.flags
     let oldBatchOptions = self.options.batchingOptions
+    // the control protocol is fixed at initialization: construct a new connection to
+    // speak a different one
+    guard options.controlProtocol == controlProtocol else {
+      throw Ocp1Error.unsupportedControlProtocol
+    }
     self.options = options
 
     if oldFlags.symmetricDifference(options.flags).contains(.enableTracing) {
@@ -261,6 +291,15 @@ open class Ocp1Connection: CustomStringConvertible {
   open var heartbeatTime: Duration {
     .seconds(1)
   }
+
+  /// The keep-alive interval in force: the options override, else the transport default.
+  var effectiveHeartbeatTime: Duration {
+    options.heartbeatTime ?? heartbeatTime
+  }
+
+  /// The control protocol this connection speaks, fixed at initialization. Readable off
+  /// the actor because parameter encoding happens wherever a command is built.
+  public nonisolated let controlProtocol: OcaControlProtocol
 
   let _connectionState = AsyncCurrentValueSubject<Ocp1ConnectionState>(.notConnected)
   public let connectionState: AnyAsyncSequence<Ocp1ConnectionState>
@@ -334,8 +373,8 @@ open class Ocp1Connection: CustomStringConvertible {
   var responseTimeout: Duration {
     let timeout = options.responseTimeout
 
-    if isDatagram, timeout < heartbeatTime * 2 {
-      return heartbeatTime * 2
+    if isDatagram, timeout < effectiveHeartbeatTime * 2 {
+      return effectiveHeartbeatTime * 2
     } else {
       return timeout
     }
@@ -362,6 +401,7 @@ open class Ocp1Connection: CustomStringConvertible {
   public init(options: Ocp1ConnectionOptions = Ocp1ConnectionOptions()) {
     connectionState = _connectionState.eraseToAnyAsyncSequence()
     self.options = options
+    controlProtocol = options.controlProtocol
     add(object: _rootBlock)
     add(object: _subscriptionManager)
     add(object: _deviceManager)
@@ -383,7 +423,12 @@ open class Ocp1Connection: CustomStringConvertible {
   }
 
   /// API to be impmlemented by concrete classes
-  open func read(_ length: Int) async throws -> Data {
+  ///
+  /// Returns exactly `length` bytes when `awaitingAllRead`, else between 1 and `length`
+  /// as soon as any are available, for framings that cannot know a PDU's length up
+  /// front (OCP.2). A message-oriented transport returns one whole message either way,
+  /// ignoring `length`.
+  open func read(_ length: Int, awaitingAllRead: Bool) async throws -> Data {
     fatalError("read must be implemented by a concrete subclass of Ocp1Connection")
   }
 
@@ -411,6 +456,16 @@ open class Ocp1Connection: CustomStringConvertible {
   /// The local socket address of the connection, if available.
   open var localAddress: Data? {
     nil
+  }
+
+  /// The connection prefix for the protocol in use: `ocp1` on OCP.1, `ocp2` on OCP.2.
+  package nonisolated func _connectionPrefix(ocp1: String, ocp2: String) -> String {
+    switch controlProtocol {
+    case .ocp1: ocp1
+    #if NonEmbeddedBuild
+    case .ocp2: ocp2
+    #endif
+    }
   }
 }
 

--- a/Sources/SwiftOCA/OCP.1/Ocp1Connection.swift
+++ b/Sources/SwiftOCA/OCP.1/Ocp1Connection.swift
@@ -50,6 +50,8 @@ public typealias Ocp1TCPConnection = Ocp1CFSocketTCPConnection
 public typealias Ocp1WSConnection = Ocp1FlyingFoxConnection
 #endif
 
+/// Event data arrives in the connection's `controlProtocol.parameterFormat`; decode it
+/// with `OcaEventDataCoding`.
 public typealias OcaSubscriptionCallback = @Sendable (OcaEvent, Data) async throws
   -> ()
 
@@ -133,8 +135,7 @@ public struct Ocp1ConnectionOptions: Sendable {
   public let batchingOptions: BatchingOptions?
   /// The control protocol to speak; the transport is chosen by the connection class.
   public let controlProtocol: OcaControlProtocol
-  /// Largest PDU accepted from the device. Only enforced for OCP.2 (OCP.1 PDUs are
-  /// bounded by their 32-bit size field).
+  /// Largest PDU accepted from the device, excluding OCP.2's line terminator.
   public let maximumPduSize: Int
   /// Overrides the transport's default keep-alive interval when set; `.zero` disables
   /// keep-alives.
@@ -267,15 +268,12 @@ open class Ocp1Connection: CustomStringConvertible {
 
   public internal(set) var options: Ocp1ConnectionOptions
 
+  /// The control protocol is fixed at initialization, so the one in `options` is
+  /// ignored: construct a new connection to speak a different one.
   public func set(options: Ocp1ConnectionOptions) async throws {
     let oldFlags = self.options.flags
     let oldBatchOptions = self.options.batchingOptions
-    // the control protocol is fixed at initialization: construct a new connection to
-    // speak a different one
-    guard options.controlProtocol == controlProtocol else {
-      throw Ocp1Error.unsupportedControlProtocol
-    }
-    self.options = options
+    self.options = options.copy(controlProtocol: controlProtocol)
 
     if oldFlags.symmetricDifference(options.flags).contains(.enableTracing) {
       _configureTracing()
@@ -460,12 +458,7 @@ open class Ocp1Connection: CustomStringConvertible {
 
   /// The connection prefix for the protocol in use: `ocp1` on OCP.1, `ocp2` on OCP.2.
   package nonisolated func _connectionPrefix(ocp1: String, ocp2: String) -> String {
-    switch controlProtocol {
-    case .ocp1: ocp1
-    #if NonEmbeddedBuild
-    case .ocp2: ocp2
-    #endif
-    }
+    controlProtocol.connectionPrefix(ocp1: ocp1, ocp2: ocp2)
   }
 }
 

--- a/Sources/SwiftOCA/OCP.1/Ocp1Connection.swift
+++ b/Sources/SwiftOCA/OCP.1/Ocp1Connection.swift
@@ -55,6 +55,9 @@ public typealias Ocp1WSConnection = Ocp1FlyingFoxConnection
 public typealias OcaSubscriptionCallback = @Sendable (OcaEvent, Data) async throws
   -> ()
 
+/// A subscription handler given event data as it arrived, unserialised on OCP.2.
+package typealias OcaEventDataHandler = @Sendable (OcaEvent, OcaEncodedEventData) async throws -> ()
+
 #if canImport(Darwin)
 package let SOCK_STREAM: Int32 = Darwin.SOCK_STREAM
 package let SOCK_DGRAM: Int32 = Darwin.SOCK_DGRAM

--- a/Sources/SwiftOCA/OCP.1/Ocp1ConnectionMonitor.swift
+++ b/Sources/SwiftOCA/OCP.1/Ocp1ConnectionMonitor.swift
@@ -91,7 +91,9 @@ extension Ocp1Connection {
       repeat {
         requests.count += 1
         let handle = OcaUint32(truncatingIfNeeded: requests.count)
-        if handle != 0 { return handle }
+        if handle != 0 {
+          return handle
+        }
       } while true
     }
 
@@ -139,7 +141,9 @@ extension Ocp1Connection {
     /// Reaching that needs 2^32 requests on one connection, so it is accepted.
     func releaseCommandHandle(_ handle: OcaUint32) {
       _requests.withLock { requests in
-        if case .waiting = requests.entries[handle] { return }
+        if case .waiting = requests.entries[handle] {
+          return
+        }
         requests.entries.removeValue(forKey: handle)
       }
     }
@@ -242,7 +246,9 @@ extension Ocp1Connection {
     /// state it means to exercise instead of sleeping and hoping.
     func isWaiting(handle: OcaUint32) -> Bool {
       _requests.withLock {
-        if case .waiting = $0.entries[handle] { return true }
+        if case .waiting = $0.entries[handle] {
+          return true
+        }
         return false
       }
     }
@@ -273,40 +279,35 @@ extension Ocp1Connection {
 
 extension Ocp1Connection.Monitor {
   private func receiveMessagePdu(
-    _ connection: Ocp1Connection
+    _ connection: Ocp1Connection,
+    reader: any OcaPduReader,
+    source: ReadSource
   ) async throws -> (OcaMessageType, [Ocp1Message]) {
-    var messagePduData = try await connection.read(Ocp1Connection.MinimumPduSize)
-
-    guard messagePduData.count > 0 else {
-      throw Ocp1Error.notConnected
+    let messagePduData: Data
+    do {
+      messagePduData = try await reader.nextPdu(read: source.read)
+    } catch let error as Ocp1Error {
+      switch error {
+      case .pduTooShort, .invalidSyncValue, .invalidPduSize:
+        connection.logger.warning("\(connection): dropping malformed PDU: \(error)")
+      default:
+        break
+      }
+      throw error
     }
 
-    // just parse enough of the protocol in order to read rest of message
-    // `syncVal: OcaUint8` || `protocolVersion: OcaUint16` || `pduSize: OcaUint32`
-    guard messagePduData.count >= Ocp1Connection.MinimumPduSize else {
-      connection.logger.warning("PDU of size \(messagePduData.count) is too short")
-      throw Ocp1Error.pduTooShort
-    }
-    guard messagePduData[0] == Ocp1SyncValue else {
-      connection.logger.warning(
-        "PDU has invalid sync value \(messagePduData.prefix(1).hexString)"
-      )
-      throw Ocp1Error.invalidSyncValue
-    }
+    return try connection.controlProtocol.decodePdu(messagePduData)
+  }
 
-    let pduSize: OcaUint32 = messagePduData.decodeInteger(index: 3)
-    guard pduSize >= (Ocp1Connection.MinimumPduSize - 1)
-    else { // doesn't include sync byte
-      connection.logger.warning("PDU size \(pduSize) is less than minimum PDU size")
-      throw Ocp1Error.invalidPduSize
-    }
+  /// The connection's read entry point, formed once per receive loop rather than per
+  /// PDU: `connection.read` is a partial application of an actor-isolated method, so
+  /// each mention of it allocates a closure.
+  struct ReadSource {
+    let read: (Int, Bool) async throws -> Data
 
-    let bytesLeft = Int(pduSize) + 1 - messagePduData.count
-    if bytesLeft > 0 {
-      messagePduData += try await connection.read(bytesLeft)
+    init(_ connection: Ocp1Connection) {
+      read = connection.read(_:awaitingAllRead:)
     }
-
-    return try Ocp1Connection.decodeOcp1MessagePdu(from: messagePduData)
   }
 
   private func processMessage(
@@ -344,8 +345,16 @@ extension Ocp1Connection.Monitor {
     }
   }
 
-  private func receiveMessage(_ connection: Ocp1Connection) async throws {
-    let (_, messages) = try await receiveMessagePdu(connection)
+  private func receiveMessage(
+    _ connection: Ocp1Connection,
+    reader: any OcaPduReader,
+    source: ReadSource
+  ) async throws {
+    let (_, messages) = try await receiveMessagePdu(
+      connection,
+      reader: reader,
+      source: source
+    )
 
     updateLastMessageReceivedTime()
     await onDatagramConnectionOpen(connection)
@@ -365,7 +374,7 @@ extension Ocp1Connection.Monitor {
   }
 
   private func keepAlive(_ connection: Ocp1Connection) async throws {
-    let heartbeatTime = await connection.heartbeatTime
+    let heartbeatTime = await connection.effectiveHeartbeatTime
     let keepAliveThreshold = heartbeatTime * 3
 
     repeat {
@@ -393,15 +402,30 @@ extension Ocp1Connection.Monitor {
 
   @concurrent
   func receiveMessages(_ connection: Ocp1Connection) async throws {
-    let heartbeatTime = await connection.heartbeatTime
+    let heartbeatTime = await connection.effectiveHeartbeatTime
+    let controlProtocol = connection.controlProtocol
+    // `isMessageOriented` describes writes (whole PDUs per send, so the write queue
+    // can be bypassed); a stream that takes whole PDUs on send may still deliver
+    // coalesced or partial ones on receive. Only a datagram guarantees one PDU per
+    // read, so that is what the reader is given.
+    let (isDatagram, maximumPduSize) = await (
+      connection.isDatagram,
+      connection.options.maximumPduSize
+    )
 
     do {
       try await withThrowingTaskGroup(of: Void.self) { group in
         group.addTask { [weak self] in
+          // one reader per receive loop: it buffers bytes between PDUs
+          let reader = controlProtocol.makeReader(
+            isMessageOriented: isDatagram,
+            maximumPduSize: maximumPduSize
+          )
+          let source = ReadSource(connection)
           repeat {
             try Task.checkCancellation()
             guard let self else { return }
-            try await receiveMessage(connection)
+            try await receiveMessage(connection, reader: reader, source: source)
           } while true
         }
         if heartbeatTime > .zero {

--- a/Sources/SwiftOCA/OCP.1/Ocp1ConnectionMonitor.swift
+++ b/Sources/SwiftOCA/OCP.1/Ocp1ConnectionMonitor.swift
@@ -321,7 +321,7 @@ extension Ocp1Connection.Monitor {
       if notification.parameters.parameterCount == 2 {
         await connection.notifySubscribers(
           of: notification.parameters.eventData.event,
-          with: notification.parameters.eventData.eventParameters
+          with: .ocp1(notification.parameters.eventData.eventParameters)
         )
       }
     case let response as Ocp1Response:
@@ -332,7 +332,7 @@ extension Ocp1Connection.Monitor {
       break
     case let notification as Ocp1Notification2:
       try notification.throwIfException()
-      await connection.notifySubscribers(of: notification.event, with: notification.data)
+      await connection.notifySubscribers(of: notification.event, with: notification.eventData)
     default:
       throw Ocp1Error.unknownPduType
     }

--- a/Sources/SwiftOCA/OCP.1/Ocp1MessageBatcher.swift
+++ b/Sources/SwiftOCA/OCP.1/Ocp1MessageBatcher.swift
@@ -28,6 +28,7 @@ final class Ocp1MessageBatcher: Sendable {
   private let batchSize: OcaUint32
   private let dequeueInterval: Duration
   private let sendEncodedPdu: SendEncodedPDU
+  private let controlProtocol: OcaControlProtocol
 
   private var encodedPdus = [EncodedPDU]()
   private var lastMessageType: OcaMessageType?
@@ -38,10 +39,12 @@ final class Ocp1MessageBatcher: Sendable {
   package init(
     batchSize: OcaUint32,
     dequeueInterval: Duration = .zero,
+    controlProtocol: OcaControlProtocol = .ocp1,
     sendEncodedPdu: @escaping SendEncodedPDU
   ) {
     self.batchSize = batchSize
     self.dequeueInterval = dequeueInterval
+    self.controlProtocol = controlProtocol
     self.sendEncodedPdu = sendEncodedPdu
   }
 
@@ -50,7 +53,8 @@ final class Ocp1MessageBatcher: Sendable {
   }
 
   var currentSize: Int {
-    Ocp1Connection.MinimumPduSize + encodedPdus.reduce(0) { $0 + $1.count }
+    controlProtocol.pduOverhead(messageCount: encodedPdus.count + 1) +
+      encodedPdus.reduce(0) { $0 + $1.count }
   }
 
   private func canCombine(type messageType: OcaMessageType) -> Bool {
@@ -60,17 +64,19 @@ final class Ocp1MessageBatcher: Sendable {
   }
 
   private func send(encodedPdus: [EncodedPDU], type messageType: OcaMessageType) async throws {
-    let encodedPdu = try Ocp1Connection.encodeOcp1MessagePduData(
+    let encodedPdu = try controlProtocol.assemblePdu(
       type: messageType,
-      encodedPdus: encodedPdus
+      encodedMessages: encodedPdus
     )
 
     try await sendEncodedPdu(Data(encodedPdu))
   }
 
-  func enqueue(_ message: some _Ocp1MessageCodable, type messageType: OcaMessageType) async throws {
-    var encodedPdu = EncodedPDU()
-    try message.encode(type: messageType, into: &encodedPdu)
+  func enqueue(
+    _ message: some _Ocp1MessageCodable,
+    type messageType: OcaMessageType
+  ) async throws {
+    let encodedPdu: EncodedPDU = try controlProtocol.encodeMessage(message, type: messageType)
 
     // short-circuit, send immediately if batching is disabled
     guard dequeueInterval > .zero else {
@@ -165,7 +171,7 @@ extension Ocp1Connection {
   ) -> (UInt32, Duration) {
     let batchSize = batchingOptions.batchSize ??
       (isDatagram ? OcaUint32(Ocp1MaximumDatagramPduSize) : OcaUint32(OcaUint16.max))
-    var dequeueInterval = batchingOptions.batchThreshold ?? heartbeatTime / 100
+    var dequeueInterval = batchingOptions.batchThreshold ?? effectiveHeartbeatTime / 100
     if dequeueInterval == .zero { dequeueInterval = .milliseconds(10) }
     return (batchSize, dequeueInterval)
   }
@@ -184,6 +190,7 @@ extension Ocp1Connection {
     batcher = Ocp1MessageBatcher(
       batchSize: batchSize,
       dequeueInterval: dequeueInterval,
+      controlProtocol: controlProtocol,
       sendEncodedPdu: { [weak self] data in
         try await self?.sendMessagePduData(data)
       }

--- a/Sources/SwiftOCA/OCP.1/Ocp1WireFormat.swift
+++ b/Sources/SwiftOCA/OCP.1/Ocp1WireFormat.swift
@@ -1,0 +1,69 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+/// AES70-3 binary framing: a sync byte, a 9-byte header, then length-prefixed
+/// messages; the framing itself lives on `OcaControlProtocol`.
+///
+/// Reads the sync byte and header, then the number of bytes the header declares.
+/// On a message-oriented transport the first read returns the whole PDU and the
+/// second is skipped.
+package final class Ocp1PduReader: OcaPduReader {
+  private let maximumPduSize: Int
+
+  package init(maximumPduSize: Int) {
+    self.maximumPduSize = maximumPduSize
+  }
+
+  package func nextPdu(
+    read: (_ count: Int, _ awaitingAllRead: Bool) async throws -> Data
+  ) async throws -> Data {
+    var messagePduData = try await read(Ocp1Connection.MinimumPduSize, true)
+
+    guard messagePduData.count > 0 else {
+      throw Ocp1Error.notConnected
+    }
+
+    // just parse enough of the protocol in order to read rest of message
+    // `syncVal: OcaUint8` || `protocolVersion: OcaUint16` || `pduSize: OcaUint32`
+    guard messagePduData.count >= Ocp1Connection.MinimumPduSize else {
+      throw Ocp1Error.pduTooShort
+    }
+    guard messagePduData[messagePduData.startIndex] == Ocp1SyncValue else {
+      throw Ocp1Error.invalidSyncValue
+    }
+
+    let pduSize: OcaUint32 = messagePduData.decodeInteger(index: messagePduData.startIndex + 3)
+    guard pduSize >= (Ocp1Connection.MinimumPduSize - 1) else { // doesn't include sync byte
+      throw Ocp1Error.invalidPduSize
+    }
+    guard Int(pduSize) <= maximumPduSize else {
+      throw Ocp1Error.invalidPduSize
+    }
+
+    let bytesLeft = Int(pduSize) + 1 - messagePduData.count
+    if bytesLeft > 0 {
+      messagePduData += try await read(bytesLeft, true)
+    }
+
+    return messagePduData
+  }
+}

--- a/Sources/SwiftOCA/OCP.2/Ocp2Decoder.swift
+++ b/Sources/SwiftOCA/OCP.2/Ocp2Decoder.swift
@@ -1,0 +1,607 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if NonEmbeddedBuild
+import Foundation
+
+/// Decodes OCA values from JSON per AES70-4 clause 8, leniently: member names match
+/// case-insensitively, a single-parameter object is accepted whatever its member is
+/// called, enumerations may be spelled by name or number, and an integer may arrive
+/// as a string.
+public struct Ocp2Decoder {
+  public var userInfo: [CodingUserInfoKey: Any] = [:]
+
+  public init() {}
+
+  /// Decodes a method's parameters from the OCP.2 `Parameters` object. `nil` stands
+  /// for an omitted `Parameters` member.
+  public func decodeParameters<T: Decodable>(
+    _ type: T.Type,
+    from object: [String: Any]?,
+    parameterNames: [String]? = nil
+  ) throws -> T {
+    let object = object ?? [:]
+    let state = Ocp2DecodingState(userInfo: userInfo)
+
+    if type is OcaRoot.Placeholder.Type {
+      return OcaRoot.Placeholder() as! T
+    }
+
+    if type is Ocp1ParametersReflectable.Type {
+      let fieldNames = Ocp2Naming.fieldNames(of: type)
+      let names = Ocp2Naming.parameterNames(explicit: parameterNames, fieldNames: fieldNames)
+      let frame = Ocp2NamingFrame(parameterNames: names, fieldNames: fieldNames)
+      return try T(from: Ocp2DecoderImpl(state: state, json: object, codingPath: [], frame: frame))
+    }
+
+    // a single parameter: by name if we can find it, else the sole member
+    let name = parameterNames?.first ?? Ocp2Naming.unnamedParameter
+    if let json = Self.member(named: name, in: object) {
+      return try state.decode(type, from: json, codingPath: [])
+    }
+    if object.count == 1, let json = object.values.first {
+      return try state.decode(type, from: json, codingPath: [])
+    }
+    if object.isEmpty, let optional = type as? any ExpressibleByNilLiteral.Type {
+      return optional.init(nilLiteral: ()) as! T
+    }
+    throw Ocp1Error.status(.parameterError)
+  }
+
+  public func decodeParameters<T: Decodable>(
+    _ type: T.Type,
+    from data: Data,
+    parameterNames: [String]? = nil
+  ) throws -> T {
+    let object: [String: Any]? = data.isEmpty ? nil : try Ocp2JSON.parseObject(data)
+    return try decodeParameters(type, from: object, parameterNames: parameterNames)
+  }
+
+  /// Decodes a free-standing value.
+  public func decodeValue<T: Decodable>(_ type: T.Type, from json: Any) throws -> T {
+    try Ocp2DecodingState(userInfo: userInfo).decode(type, from: json, codingPath: [])
+  }
+
+  static func member(named name: String, in object: [String: Any]) -> Any? {
+    if let json = object[name] {
+      return json
+    }
+    for (key, json) in object where Ocp2Naming.matches(key, name) {
+      return json
+    }
+    return nil
+  }
+}
+
+final class Ocp2DecodingState {
+  let userInfo: [CodingUserInfoKey: Any]
+
+  init(userInfo: [CodingUserInfoKey: Any]) {
+    self.userInfo = userInfo
+  }
+
+  func decode<T: Decodable>(
+    _ type: T.Type,
+    from json: Any,
+    codingPath: [any CodingKey]
+  ) throws -> T {
+    if type == Data.self {
+      return try Ocp2JSON.data(from: json) as! T
+    }
+    // identifier datatypes have array or string forms (AES70-4 8.11.1)
+    if type == OcaPropertyID.self {
+      let (defLevel, index) = try _ocp2ElementID(from: json)
+      return OcaPropertyID(defLevel: defLevel, propertyIndex: index) as! T
+    }
+    if type == OcaMethodID.self {
+      let (defLevel, index) = try _ocp2ElementID(from: json)
+      return OcaMethodID(defLevel: defLevel, methodIndex: index) as! T
+    }
+    if type == OcaEventID.self {
+      let (defLevel, index) = try _ocp2ElementID(from: json)
+      return OcaEventID(defLevel: defLevel, eventIndex: index) as! T
+    }
+    if type == OcaClassID.self {
+      return try OcaClassID(ocp2JSON: json) as! T
+    }
+    if type == OcaOrganizationID.self {
+      return try OcaOrganizationID(Ocp2JSON.string(from: json)) as! T
+    }
+    if let blobType = type as? any Ocp1BlobRepresentable.Type {
+      return try blobType.init(blobData: Ocp2JSON.data(from: json)) as! T
+    }
+    if let mapType = type as? any Ocp1MapRepresentable.Type {
+      return try mapType.init(ocp2State: self, json: json, codingPath: codingPath) as! T
+    }
+    if let string = json as? String, let enumType = type as? any CaseIterable.Type {
+      // an enumeration spelled by name: match the Swift case name
+      if let value = Self.enumCase(named: string, of: enumType) as? T {
+        return value
+      }
+      throw Ocp1Error.status(.parameterOutOfRange)
+    }
+    return try T(from: Ocp2DecoderImpl(state: self, json: json, codingPath: codingPath, frame: nil))
+  }
+
+  private static func enumCase(named name: String, of type: any CaseIterable.Type) -> Any? {
+    func cases(_ type: (some CaseIterable).Type) -> [Any] {
+      type.allCases.map { $0 }
+    }
+    return cases(type).first { Ocp2Naming.matches(String(describing: $0), name) }
+  }
+}
+
+struct Ocp2DecoderImpl: Decoder {
+  let state: Ocp2DecodingState
+  let json: Any
+  let codingPath: [any CodingKey]
+  let frame: Ocp2NamingFrame?
+
+  var userInfo: [CodingUserInfoKey: Any] {
+    state.userInfo
+  }
+
+  func container<Key: CodingKey>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> {
+    guard let object = json as? [String: Any] else {
+      throw DecodingError.typeMismatch(
+        [String: Any].self,
+        .init(codingPath: codingPath, debugDescription: "expected a JSON object")
+      )
+    }
+    return .init(KeyedOcp2DecodingContainer(
+      state: state,
+      object: object,
+      codingPath: codingPath,
+      frame: frame
+    ))
+  }
+
+  func unkeyedContainer() throws -> any UnkeyedDecodingContainer {
+    guard let array = json as? [Any] else {
+      throw DecodingError.typeMismatch(
+        [Any].self,
+        .init(codingPath: codingPath, debugDescription: "expected a JSON array")
+      )
+    }
+    return UnkeyedOcp2DecodingContainer(state: state, array: array, codingPath: codingPath)
+  }
+
+  func singleValueContainer() throws -> any SingleValueDecodingContainer {
+    SingleValueOcp2DecodingContainer(state: state, json: json, codingPath: codingPath)
+  }
+}
+
+package extension Decoder {
+  var _isOcp2Decoder: Bool {
+    self is Ocp2DecoderImpl
+  }
+}
+
+struct KeyedOcp2DecodingContainer<Key: CodingKey>: KeyedDecodingContainerProtocol {
+  let state: Ocp2DecodingState
+  let object: [String: Any]
+  let codingPath: [any CodingKey]
+  let frame: Ocp2NamingFrame?
+
+  var allKeys: [Key] {
+    object.keys.compactMap { Key(stringValue: $0) }
+  }
+
+  /// The member for `key`: by its model name when this is a parameter record, then by
+  /// its derived wire name, then by its Swift name, all case-insensitively; finally, a
+  /// one-field record accepts a one-member object whatever the member is called.
+  private func lookup(_ key: Key) -> Any? {
+    let swiftName = key.stringValue
+    if let frame, let name = frame.wireName(for: key),
+       let json = Ocp2Decoder.member(named: name, in: object)
+    {
+      return json
+    }
+    // the derived wire name differs from the Swift name only in its first letter,
+    // so one case-insensitive search covers both
+    if let json = Ocp2Decoder.member(named: swiftName, in: object) {
+      return json
+    }
+    if let frame, frame.fieldNames.count == 1, object.count == 1 {
+      return object.values.first
+    }
+    return nil
+  }
+
+  private func require(_ key: Key) throws -> Any {
+    guard let json = lookup(key) else {
+      throw DecodingError.keyNotFound(
+        key,
+        .init(codingPath: codingPath, debugDescription: "no member for \(key.stringValue)")
+      )
+    }
+    return json
+  }
+
+  func contains(_ key: Key) -> Bool {
+    lookup(key) != nil
+  }
+
+  func decodeNil(forKey key: Key) throws -> Bool {
+    guard let json = lookup(key) else { return true }
+    return Ocp2JSON.isNull(json)
+  }
+
+  func decode(_ type: Bool.Type, forKey key: Key) throws -> Bool {
+    try Ocp2JSON.bool(from: require(key))
+  }
+
+  func decode(_ type: String.Type, forKey key: Key) throws -> String {
+    try Ocp2JSON.string(from: require(key))
+  }
+
+  func decode(_ type: Double.Type, forKey key: Key) throws -> Double {
+    try Ocp2JSON.double(from: require(key))
+  }
+
+  func decode(_ type: Float.Type, forKey key: Key) throws -> Float {
+    try Float(Ocp2JSON.double(from: require(key)))
+  }
+
+  func decode(_ type: Int.Type, forKey key: Key) throws -> Int {
+    try Ocp2JSON.integer(
+      type,
+      from: require(key)
+    )
+  }
+
+  func decode(_ type: Int8.Type, forKey key: Key) throws -> Int8 {
+    try Ocp2JSON.integer(
+      type,
+      from: require(key)
+    )
+  }
+
+  func decode(_ type: Int16.Type, forKey key: Key) throws -> Int16 {
+    try Ocp2JSON.integer(
+      type,
+      from: require(key)
+    )
+  }
+
+  func decode(_ type: Int32.Type, forKey key: Key) throws -> Int32 {
+    try Ocp2JSON.integer(
+      type,
+      from: require(key)
+    )
+  }
+
+  func decode(_ type: Int64.Type, forKey key: Key) throws -> Int64 {
+    try Ocp2JSON.integer(
+      type,
+      from: require(key)
+    )
+  }
+
+  func decode(_ type: UInt.Type, forKey key: Key) throws -> UInt {
+    try Ocp2JSON.integer(
+      type,
+      from: require(key)
+    )
+  }
+
+  func decode(_ type: UInt8.Type, forKey key: Key) throws -> UInt8 {
+    try Ocp2JSON.integer(
+      type,
+      from: require(key)
+    )
+  }
+
+  func decode(_ type: UInt16.Type, forKey key: Key) throws -> UInt16 {
+    try Ocp2JSON.integer(
+      type,
+      from: require(key)
+    )
+  }
+
+  func decode(_ type: UInt32.Type, forKey key: Key) throws -> UInt32 {
+    try Ocp2JSON.integer(
+      type,
+      from: require(key)
+    )
+  }
+
+  func decode(_ type: UInt64.Type, forKey key: Key) throws -> UInt64 {
+    try Ocp2JSON.integer(
+      type,
+      from: require(key)
+    )
+  }
+
+  func decode<T: Decodable>(_ type: T.Type, forKey key: Key) throws -> T {
+    try state.decode(type, from: require(key), codingPath: codingPath + [key])
+  }
+
+  func nestedContainer<NestedKey: CodingKey>(
+    keyedBy type: NestedKey.Type,
+    forKey key: Key
+  ) throws -> KeyedDecodingContainer<NestedKey> {
+    try Ocp2DecoderImpl(
+      state: state,
+      json: require(key),
+      codingPath: codingPath + [key],
+      frame: nil
+    )
+    .container(keyedBy: type)
+  }
+
+  func nestedUnkeyedContainer(forKey key: Key) throws -> any UnkeyedDecodingContainer {
+    try Ocp2DecoderImpl(
+      state: state,
+      json: require(key),
+      codingPath: codingPath + [key],
+      frame: nil
+    )
+    .unkeyedContainer()
+  }
+
+  func superDecoder() throws -> any Decoder {
+    Ocp2DecoderImpl(state: state, json: object, codingPath: codingPath, frame: nil)
+  }
+
+  func superDecoder(forKey key: Key) throws -> any Decoder {
+    try Ocp2DecoderImpl(
+      state: state,
+      json: require(key),
+      codingPath: codingPath + [key],
+      frame: nil
+    )
+  }
+}
+
+struct UnkeyedOcp2DecodingContainer: UnkeyedDecodingContainer {
+  let state: Ocp2DecodingState
+  let array: [Any]
+  let codingPath: [any CodingKey]
+  private(set) var currentIndex = 0
+
+  init(state: Ocp2DecodingState, array: [Any], codingPath: [any CodingKey]) {
+    self.state = state
+    self.array = array
+    self.codingPath = codingPath
+  }
+
+  var count: Int? {
+    array.count
+  }
+
+  var isAtEnd: Bool {
+    currentIndex >= array.count
+  }
+
+  private func peek() throws -> Any {
+    guard !isAtEnd else {
+      throw DecodingError.valueNotFound(
+        Any.self,
+        .init(codingPath: codingPath, debugDescription: "unkeyed container is at end")
+      )
+    }
+    return array[currentIndex]
+  }
+
+  /// The element is consumed only if `convert` succeeds, so a caller can probe
+  /// one representation and fall back to another.
+  private mutating func take<T>(_ convert: (Any) throws -> T) throws -> T {
+    let value = try convert(peek())
+    currentIndex += 1
+    return value
+  }
+
+  mutating func decodeNil() throws -> Bool {
+    guard !isAtEnd else { return true }
+    if Ocp2JSON.isNull(array[currentIndex]) {
+      currentIndex += 1
+      return true
+    }
+    return false
+  }
+
+  mutating func decode(_ type: Bool.Type) throws -> Bool {
+    try take { try Ocp2JSON.bool(from: $0) }
+  }
+
+  mutating func decode(_ type: String
+    .Type) throws -> String
+  {
+    try take { try Ocp2JSON.string(from: $0) }
+  }
+
+  mutating func decode(_ type: Double
+    .Type) throws -> Double
+  {
+    try take { try Ocp2JSON.double(from: $0) }
+  }
+
+  mutating func decode(_ type: Float
+    .Type) throws -> Float
+  {
+    try take { try Float(Ocp2JSON.double(from: $0)) }
+  }
+
+  mutating func decode(_ type: Int.Type) throws -> Int {
+    try take { try Ocp2JSON.integer(
+      type,
+      from: $0
+    ) }
+  }
+
+  mutating func decode(_ type: Int8.Type) throws -> Int8 {
+    try take { try Ocp2JSON.integer(
+      type,
+      from: $0
+    ) }
+  }
+
+  mutating func decode(_ type: Int16.Type) throws -> Int16 {
+    try take { try Ocp2JSON.integer(
+      type,
+      from: $0
+    ) }
+  }
+
+  mutating func decode(_ type: Int32.Type) throws -> Int32 {
+    try take { try Ocp2JSON.integer(
+      type,
+      from: $0
+    ) }
+  }
+
+  mutating func decode(_ type: Int64.Type) throws -> Int64 {
+    try take { try Ocp2JSON.integer(
+      type,
+      from: $0
+    ) }
+  }
+
+  mutating func decode(_ type: UInt.Type) throws -> UInt {
+    try take { try Ocp2JSON.integer(
+      type,
+      from: $0
+    ) }
+  }
+
+  mutating func decode(_ type: UInt8.Type) throws -> UInt8 {
+    try take { try Ocp2JSON.integer(
+      type,
+      from: $0
+    ) }
+  }
+
+  mutating func decode(_ type: UInt16.Type) throws -> UInt16 {
+    try take { try Ocp2JSON.integer(
+      type,
+      from: $0
+    ) }
+  }
+
+  mutating func decode(_ type: UInt32.Type) throws -> UInt32 {
+    try take { try Ocp2JSON.integer(
+      type,
+      from: $0
+    ) }
+  }
+
+  mutating func decode(_ type: UInt64.Type) throws -> UInt64 {
+    try take { try Ocp2JSON.integer(
+      type,
+      from: $0
+    ) }
+  }
+
+  mutating func decode<T: Decodable>(_ type: T.Type) throws -> T {
+    let (state, codingPath) = (state, codingPath)
+    return try take { try state.decode(type, from: $0, codingPath: codingPath) }
+  }
+
+  mutating func nestedContainer<NestedKey: CodingKey>(
+    keyedBy type: NestedKey.Type
+  ) throws -> KeyedDecodingContainer<NestedKey> {
+    let (state, codingPath) = (state, codingPath)
+    return try take {
+      try Ocp2DecoderImpl(state: state, json: $0, codingPath: codingPath, frame: nil)
+        .container(keyedBy: type)
+    }
+  }
+
+  mutating func nestedUnkeyedContainer() throws -> any UnkeyedDecodingContainer {
+    let (state, codingPath) = (state, codingPath)
+    return try take {
+      try Ocp2DecoderImpl(state: state, json: $0, codingPath: codingPath, frame: nil)
+        .unkeyedContainer()
+    }
+  }
+
+  mutating func superDecoder() throws -> any Decoder {
+    let (state, codingPath) = (state, codingPath)
+    return try take { Ocp2DecoderImpl(state: state, json: $0, codingPath: codingPath, frame: nil) }
+  }
+}
+
+struct SingleValueOcp2DecodingContainer: SingleValueDecodingContainer {
+  let state: Ocp2DecodingState
+  let json: Any
+  let codingPath: [any CodingKey]
+
+  func decodeNil() -> Bool {
+    Ocp2JSON.isNull(json)
+  }
+
+  func decode(_ type: Bool.Type) throws -> Bool {
+    try Ocp2JSON.bool(from: json)
+  }
+
+  func decode(_ type: String.Type) throws -> String {
+    try Ocp2JSON.string(from: json)
+  }
+
+  func decode(_ type: Double.Type) throws -> Double {
+    try Ocp2JSON.double(from: json)
+  }
+
+  func decode(_ type: Float.Type) throws -> Float {
+    try Float(Ocp2JSON.double(from: json))
+  }
+
+  func decode(_ type: Int.Type) throws -> Int {
+    try Ocp2JSON.integer(type, from: json)
+  }
+
+  func decode(_ type: Int8.Type) throws -> Int8 {
+    try Ocp2JSON.integer(type, from: json)
+  }
+
+  func decode(_ type: Int16.Type) throws -> Int16 {
+    try Ocp2JSON.integer(type, from: json)
+  }
+
+  func decode(_ type: Int32.Type) throws -> Int32 {
+    try Ocp2JSON.integer(type, from: json)
+  }
+
+  func decode(_ type: Int64.Type) throws -> Int64 {
+    try Ocp2JSON.integer(type, from: json)
+  }
+
+  func decode(_ type: UInt.Type) throws -> UInt {
+    try Ocp2JSON.integer(type, from: json)
+  }
+
+  func decode(_ type: UInt8.Type) throws -> UInt8 {
+    try Ocp2JSON.integer(type, from: json)
+  }
+
+  func decode(_ type: UInt16.Type) throws -> UInt16 {
+    try Ocp2JSON.integer(type, from: json)
+  }
+
+  func decode(_ type: UInt32.Type) throws -> UInt32 {
+    try Ocp2JSON.integer(type, from: json)
+  }
+
+  func decode(_ type: UInt64.Type) throws -> UInt64 {
+    try Ocp2JSON.integer(type, from: json)
+  }
+
+  func decode<T: Decodable>(_ type: T.Type) throws -> T {
+    try state.decode(type, from: json, codingPath: codingPath)
+  }
+}
+#endif

--- a/Sources/SwiftOCA/OCP.2/Ocp2Encoder.swift
+++ b/Sources/SwiftOCA/OCP.2/Ocp2Encoder.swift
@@ -1,0 +1,437 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if NonEmbeddedBuild
+import Foundation
+
+/// Encodes OCA values to JSON per AES70-4 clause 8: blobs as base64, maps as arrays of
+/// `[key, value]` pairs, class and element IDs as arrays, enums as numbers, composite
+/// datatypes as objects keyed by field name.
+public struct Ocp2Encoder {
+  public var userInfo: [CodingUserInfoKey: Any] = [:]
+
+  public init() {}
+
+  /// Encodes a method's parameters as the OCP.2 `Parameters` object.
+  ///
+  /// A parameter record (`Ocp1ParametersReflectable`) becomes one member per stored
+  /// property, named by `parameterNames` in declaration order and then by the derived
+  /// wire name. Anything else is a single parameter named `parameterNames.first`, or
+  /// `Ocp2Naming.unnamedParameter` when no name was supplied.
+  public func encodeParameters(
+    _ value: some Encodable,
+    parameterNames: [String]? = nil
+  ) throws -> [String: Any] {
+    if value is OcaRoot.Placeholder {
+      return [:]
+    }
+
+    let state = Ocp2EncodingState(userInfo: userInfo)
+
+    if type(of: value) is Ocp1ParametersReflectable.Type {
+      let fieldNames = Ocp2Naming.fieldNames(of: type(of: value))
+      let names = Ocp2Naming.parameterNames(explicit: parameterNames, fieldNames: fieldNames)
+      let node = Ocp2EncodingNode()
+      node.frame = Ocp2NamingFrame(parameterNames: names, fieldNames: fieldNames)
+      try value.encode(to: Ocp2EncoderImpl(state: state, node: node, codingPath: []))
+      if let object = node.object {
+        return Ocp2EncodingNode.json(object: object)
+      }
+      // a record that encoded itself as something other than an object
+      return [names.first ?? Ocp2Naming.unnamedParameter: node.json()]
+    }
+
+    let node = try state.encode(value, codingPath: [])
+    return [parameterNames?.first ?? Ocp2Naming.unnamedParameter: node.json()]
+  }
+
+  /// Serialised form of `encodeParameters`.
+  public func encodeParametersData(
+    _ value: some Encodable,
+    parameterNames: [String]? = nil
+  ) throws -> Data {
+    try Ocp2JSON.serialize(encodeParameters(value, parameterNames: parameterNames))
+  }
+
+  /// Encodes a free-standing value (a property value, event data, a struct field).
+  public func encodeValue(_ value: some Encodable) throws -> Any {
+    let state = Ocp2EncodingState(userInfo: userInfo)
+    return try state.encode(value, codingPath: []).json()
+  }
+}
+
+/// The names of a top-level parameter record: the wire name for each Swift field,
+/// by exact field name (the synthesized `CodingKey`) with a case-insensitive
+/// fallback for hand-written keys.
+struct Ocp2NamingFrame {
+  let parameterNames: [String]
+  let fieldNames: [String]
+  private let byField: [String: String]
+
+  init(parameterNames: [String], fieldNames: [String]) {
+    self.parameterNames = parameterNames
+    self.fieldNames = fieldNames
+    var byField = [String: String]()
+    for (index, field) in fieldNames.enumerated() where index < parameterNames.count {
+      byField[field] = parameterNames[index]
+    }
+    self.byField = byField
+  }
+
+  /// The wire name for `key`, or `nil` when the key is not a field of the record.
+  func wireName(for key: any CodingKey) -> String? {
+    let swiftName = key.stringValue
+    if let name = byField[swiftName] {
+      return name
+    }
+    guard let index = fieldNames.firstIndex(where: { Ocp2Naming.matches($0, swiftName) }),
+          index < parameterNames.count
+    else { return nil }
+    return parameterNames[index]
+  }
+
+  func name(for key: any CodingKey, position: Int) -> String {
+    if let name = wireName(for: key) {
+      return name
+    }
+    if position < parameterNames.count, position >= fieldNames.count {
+      return parameterNames[position]
+    }
+    return Ocp2Naming.wireName(key.stringValue)
+  }
+}
+
+/// A node in the JSON tree under construction. Containers are structs holding a
+/// reference to the node they fill.
+final class Ocp2EncodingNode {
+  var value: Any?
+  var object: [(String, Ocp2EncodingNode)]?
+  var array: [Ocp2EncodingNode]?
+  var frame: Ocp2NamingFrame?
+
+  func json() -> Any {
+    if let object {
+      return Self.json(object: object)
+    }
+    if let array {
+      return array.map { $0.json() }
+    }
+    return value ?? NSNull()
+  }
+
+  static func json(object: [(String, Ocp2EncodingNode)]) -> [String: Any] {
+    var dict = [String: Any]()
+    for (key, node) in object {
+      dict[key] = node.json()
+    }
+    return dict
+  }
+
+  func adopt(_ other: Ocp2EncodingNode) {
+    value = other.value
+    object = other.object
+    array = other.array
+  }
+}
+
+final class Ocp2EncodingState {
+  let userInfo: [CodingUserInfoKey: Any]
+
+  init(userInfo: [CodingUserInfoKey: Any]) {
+    self.userInfo = userInfo
+  }
+
+  /// Encodes `value` into a fresh node, handling the types whose OCP.2 form is not
+  /// what their `Codable` conformance produces.
+  func encode(_ value: some Encodable, codingPath: [any CodingKey]) throws -> Ocp2EncodingNode {
+    let node = Ocp2EncodingNode()
+    switch value {
+    // primitives are leaves: their own `encode(to:)` would hand them straight back
+    case let bool as Bool:
+      node.value = bool
+    case let string as String:
+      node.value = string
+    case let int as Int:
+      node.value = int
+    case let int as Int8:
+      node.value = Int(int)
+    case let int as Int16:
+      node.value = Int(int)
+    case let int as Int32:
+      node.value = Int(int)
+    case let int as Int64:
+      node.value = int
+    case let uint as UInt:
+      node.value = UInt64(uint)
+    case let uint as UInt8:
+      node.value = Int(uint)
+    case let uint as UInt16:
+      node.value = Int(uint)
+    case let uint as UInt32:
+      node.value = Int(uint)
+    case let uint as UInt64:
+      node.value = uint
+    // identifier datatypes have array or string forms (AES70-4 8.11.1)
+    case let id as OcaPropertyID:
+      node.value = _ocp2ElementID(id.defLevel, id.propertyIndex)
+    case let id as OcaMethodID:
+      node.value = _ocp2ElementID(id.defLevel, id.methodIndex)
+    case let id as OcaEventID:
+      node.value = _ocp2ElementID(id.defLevel, id.eventIndex)
+    case let classID as OcaClassID:
+      node.value = classID.ocp2JSON
+    case let organization as OcaOrganizationID:
+      node.value = organization.description
+    case let data as Data:
+      node.value = Ocp2JSON.base64(data)
+    case let blob as any Ocp1BlobRepresentable:
+      node.value = Ocp2JSON.base64(blob.blobData)
+    case let map as any Ocp1MapRepresentable:
+      var items = [Ocp2EncodingNode]()
+      try map.withMapItems { key, item in
+        let pair = Ocp2EncodingNode()
+        pair.array = try [encode(key, codingPath: codingPath), encode(item, codingPath: codingPath)]
+        items.append(pair)
+      }
+      node.array = items
+    case let double as Double:
+      node.value = Ocp2JSON.json(double)
+    case let float as Float:
+      node.value = Ocp2JSON.json(float)
+    default:
+      try value.encode(to: Ocp2EncoderImpl(state: self, node: node, codingPath: codingPath))
+    }
+    return node
+  }
+}
+
+struct Ocp2EncoderImpl: Encoder {
+  let state: Ocp2EncodingState
+  let node: Ocp2EncodingNode
+  let codingPath: [any CodingKey]
+
+  var userInfo: [CodingUserInfoKey: Any] {
+    state.userInfo
+  }
+
+  func container<Key: CodingKey>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> {
+    if node.object == nil {
+      node.object = []
+    }
+    return .init(KeyedOcp2EncodingContainer(state: state, node: node, codingPath: codingPath))
+  }
+
+  func unkeyedContainer() -> any UnkeyedEncodingContainer {
+    if node.array == nil {
+      node.array = []
+    }
+    return UnkeyedOcp2EncodingContainer(state: state, node: node, codingPath: codingPath)
+  }
+
+  func singleValueContainer() -> any SingleValueEncodingContainer {
+    SingleValueOcp2EncodingContainer(state: state, node: node, codingPath: codingPath)
+  }
+}
+
+package extension Encoder {
+  var _isOcp2Encoder: Bool {
+    self is Ocp2EncoderImpl
+  }
+}
+
+struct KeyedOcp2EncodingContainer<Key: CodingKey>: KeyedEncodingContainerProtocol {
+  let state: Ocp2EncodingState
+  let node: Ocp2EncodingNode
+  let codingPath: [any CodingKey]
+
+  private func name(for key: Key) -> String {
+    if let frame = node.frame {
+      return frame.name(for: key, position: node.object?.count ?? 0)
+    }
+    return Ocp2Naming.wireName(key.stringValue)
+  }
+
+  private func append(_ child: Ocp2EncodingNode, forKey key: Key) {
+    let name = name(for: key)
+    node.object?.append((name, child))
+  }
+
+  mutating func encodeNil(forKey key: Key) throws {
+    let child = Ocp2EncodingNode()
+    child.value = NSNull()
+    append(child, forKey: key)
+  }
+
+  mutating func encode(_ value: Bool, forKey key: Key) throws {
+    try encodeLeaf(value, forKey: key)
+  }
+
+  mutating func encode(_ value: String, forKey key: Key) throws {
+    try encodeLeaf(value, forKey: key)
+  }
+
+  mutating func encode(_ value: Double, forKey key: Key) throws {
+    try encodeLeaf(value, forKey: key)
+  }
+
+  mutating func encode(_ value: Float, forKey key: Key) throws {
+    try encodeLeaf(value, forKey: key)
+  }
+
+  mutating func encode(_ value: Int, forKey key: Key) throws {
+    try encodeLeaf(value, forKey: key)
+  }
+
+  mutating func encode(_ value: Int8, forKey key: Key) throws {
+    try encodeLeaf(value, forKey: key)
+  }
+
+  mutating func encode(_ value: Int16, forKey key: Key) throws {
+    try encodeLeaf(value, forKey: key)
+  }
+
+  mutating func encode(_ value: Int32, forKey key: Key) throws {
+    try encodeLeaf(value, forKey: key)
+  }
+
+  mutating func encode(_ value: Int64, forKey key: Key) throws {
+    try encodeLeaf(value, forKey: key)
+  }
+
+  mutating func encode(_ value: UInt, forKey key: Key) throws {
+    try encodeLeaf(value, forKey: key)
+  }
+
+  mutating func encode(_ value: UInt8, forKey key: Key) throws {
+    try encodeLeaf(value, forKey: key)
+  }
+
+  mutating func encode(_ value: UInt16, forKey key: Key) throws {
+    try encodeLeaf(value, forKey: key)
+  }
+
+  mutating func encode(_ value: UInt32, forKey key: Key) throws {
+    try encodeLeaf(value, forKey: key)
+  }
+
+  mutating func encode(_ value: UInt64, forKey key: Key) throws {
+    try encodeLeaf(value, forKey: key)
+  }
+
+  private mutating func encodeLeaf(_ value: some Encodable, forKey key: Key) throws {
+    try append(state.encode(value, codingPath: codingPath + [key]), forKey: key)
+  }
+
+  mutating func encode(_ value: some Encodable, forKey key: Key) throws {
+    try append(state.encode(value, codingPath: codingPath + [key]), forKey: key)
+  }
+
+  mutating func nestedContainer<NestedKey: CodingKey>(
+    keyedBy keyType: NestedKey.Type,
+    forKey key: Key
+  ) -> KeyedEncodingContainer<NestedKey> {
+    let child = Ocp2EncodingNode()
+    child.object = []
+    append(child, forKey: key)
+    return .init(KeyedOcp2EncodingContainer<NestedKey>(
+      state: state,
+      node: child,
+      codingPath: codingPath + [key]
+    ))
+  }
+
+  mutating func nestedUnkeyedContainer(forKey key: Key) -> any UnkeyedEncodingContainer {
+    let child = Ocp2EncodingNode()
+    child.array = []
+    append(child, forKey: key)
+    return UnkeyedOcp2EncodingContainer(state: state, node: child, codingPath: codingPath + [key])
+  }
+
+  mutating func superEncoder() -> any Encoder {
+    Ocp2EncoderImpl(state: state, node: node, codingPath: codingPath)
+  }
+
+  mutating func superEncoder(forKey key: Key) -> any Encoder {
+    let child = Ocp2EncodingNode()
+    append(child, forKey: key)
+    return Ocp2EncoderImpl(state: state, node: child, codingPath: codingPath + [key])
+  }
+}
+
+struct UnkeyedOcp2EncodingContainer: UnkeyedEncodingContainer {
+  let state: Ocp2EncodingState
+  let node: Ocp2EncodingNode
+  let codingPath: [any CodingKey]
+
+  var count: Int {
+    node.array?.count ?? 0
+  }
+
+  private func append(_ child: Ocp2EncodingNode) {
+    node.array?.append(child)
+  }
+
+  mutating func encodeNil() throws {
+    let child = Ocp2EncodingNode()
+    child.value = NSNull()
+    append(child)
+  }
+
+  mutating func encode(_ value: some Encodable) throws {
+    try append(state.encode(value, codingPath: codingPath))
+  }
+
+  mutating func nestedContainer<NestedKey: CodingKey>(
+    keyedBy keyType: NestedKey.Type
+  ) -> KeyedEncodingContainer<NestedKey> {
+    let child = Ocp2EncodingNode()
+    child.object = []
+    append(child)
+    return .init(KeyedOcp2EncodingContainer<NestedKey>(
+      state: state,
+      node: child,
+      codingPath: codingPath
+    ))
+  }
+
+  mutating func nestedUnkeyedContainer() -> any UnkeyedEncodingContainer {
+    let child = Ocp2EncodingNode()
+    child.array = []
+    append(child)
+    return UnkeyedOcp2EncodingContainer(state: state, node: child, codingPath: codingPath)
+  }
+
+  mutating func superEncoder() -> any Encoder {
+    let child = Ocp2EncodingNode()
+    append(child)
+    return Ocp2EncoderImpl(state: state, node: child, codingPath: codingPath)
+  }
+}
+
+struct SingleValueOcp2EncodingContainer: SingleValueEncodingContainer {
+  let state: Ocp2EncodingState
+  let node: Ocp2EncodingNode
+  let codingPath: [any CodingKey]
+
+  mutating func encodeNil() throws {
+    node.value = NSNull()
+  }
+
+  mutating func encode(_ value: some Encodable) throws {
+    try node.adopt(state.encode(value, codingPath: codingPath))
+  }
+}
+#endif

--- a/Sources/SwiftOCA/OCP.2/Ocp2EventData.swift
+++ b/Sources/SwiftOCA/OCP.2/Ocp2EventData.swift
@@ -21,9 +21,10 @@ import Foundation
 #endif
 
 /// Event data as delivered by a notification: OCP.1 bytes or an OCP.2 JSON object.
-package enum OcaEventDataCoding {
+/// A subscription callback receives the data in the connection's `parameterFormat`.
+public enum OcaEventDataCoding {
   /// Decodes event-specific data in `format`.
-  package static func decode<T: Decodable>(
+  public static func decode<T: Decodable>(
     _ type: T.Type,
     from data: Data,
     format: OcaParameterFormat
@@ -41,7 +42,7 @@ package enum OcaEventDataCoding {
   }
 
   /// The property a property-changed event refers to, without decoding its value.
-  package static func propertyID(from data: Data, format: OcaParameterFormat) throws -> OcaPropertyID {
+  public static func propertyID(from data: Data, format: OcaParameterFormat) throws -> OcaPropertyID {
     switch format {
     case .ocp1:
       return try OcaPropertyID(bytes: data)
@@ -60,7 +61,7 @@ package enum OcaEventDataCoding {
   }
 
   /// Encodes event-specific data in `format`.
-  package static func encode(_ value: some Encodable, format: OcaParameterFormat) throws -> Data {
+  public static func encode(_ value: some Encodable, format: OcaParameterFormat) throws -> Data {
     switch format {
     case .ocp1:
       return try Ocp1Encoder().encode(value)
@@ -74,7 +75,8 @@ package enum OcaEventDataCoding {
   }
 }
 
-package extension OcaControlProtocol {
+public extension OcaControlProtocol {
+  /// The format of parameters and event data carried by this protocol.
   var parameterFormat: OcaParameterFormat {
     switch self {
     case .ocp1: .ocp1

--- a/Sources/SwiftOCA/OCP.2/Ocp2EventData.swift
+++ b/Sources/SwiftOCA/OCP.2/Ocp2EventData.swift
@@ -20,6 +20,63 @@ import FoundationEssentials
 import Foundation
 #endif
 
+/// Event data as a notification carries it: OCP.1 bytes, or the OCP.2 JSON value as
+/// parsed from or encoded for the wire, `nil` when there is none. The value is passed
+/// through unserialised, so only a recipient wanting bytes pays for them.
+package enum OcaEncodedEventData: Sendable {
+  case ocp1(Data)
+  #if NonEmbeddedBuild
+  case ocp2((any Sendable)?)
+  #endif
+
+  /// Wire bytes in `format`; OCP.2 data is parsed, which can fail.
+  package init(_ data: Data, format: OcaParameterFormat) throws {
+    switch format {
+    case .ocp1:
+      self = .ocp1(data)
+    case .ocp2:
+      #if NonEmbeddedBuild
+      self = .ocp2(data.isEmpty ? nil : Ocp2JSON.sendable(try Ocp2JSON.parse(data)))
+      #else
+      throw Ocp1Error.unsupportedControlProtocol
+      #endif
+    }
+  }
+
+  package var format: OcaParameterFormat {
+    switch self {
+    case .ocp1: .ocp1
+    #if NonEmbeddedBuild
+    case .ocp2: .ocp2
+    #endif
+    }
+  }
+
+  package var isEmpty: Bool {
+    switch self {
+    case let .ocp1(data): data.isEmpty
+    #if NonEmbeddedBuild
+    case let .ocp2(value): value == nil
+    #endif
+    }
+  }
+
+  /// The wire bytes, serialised on demand for OCP.2.
+  package var data: Data {
+    get throws {
+      switch self {
+      case let .ocp1(data):
+        return data
+      #if NonEmbeddedBuild
+      case let .ocp2(value):
+        guard let value else { return Data() }
+        return try Ocp2JSON.serialize(value)
+      #endif
+      }
+    }
+  }
+}
+
 /// Event data as delivered by a notification: OCP.1 bytes or an OCP.2 JSON object.
 /// A subscription callback receives the data in the connection's `parameterFormat`.
 public enum OcaEventDataCoding {
@@ -29,45 +86,60 @@ public enum OcaEventDataCoding {
     from data: Data,
     format: OcaParameterFormat
   ) throws -> T {
-    switch format {
-    case .ocp1:
+    try decode(type, from: OcaEncodedEventData(data, format: format))
+  }
+
+  package static func decode<T: Decodable>(
+    _ type: T.Type,
+    from eventData: OcaEncodedEventData
+  ) throws -> T {
+    switch eventData {
+    case let .ocp1(data):
       return try Ocp1Decoder().decode(type, from: data)
-    case .ocp2:
-      #if NonEmbeddedBuild
-      return try Ocp2Decoder().decodeValue(type, from: Ocp2JSON.parse(data))
-      #else
-      throw Ocp1Error.unsupportedControlProtocol
-      #endif
+    #if NonEmbeddedBuild
+    case let .ocp2(value):
+      guard let value else { throw Ocp1Error.status(.badFormat) }
+      return try Ocp2Decoder().decodeValue(type, from: value)
+    #endif
     }
   }
 
   /// The property a property-changed event refers to, without decoding its value.
   public static func propertyID(from data: Data, format: OcaParameterFormat) throws -> OcaPropertyID {
-    switch format {
-    case .ocp1:
+    try propertyID(from: OcaEncodedEventData(data, format: format))
+  }
+
+  package static func propertyID(from eventData: OcaEncodedEventData) throws -> OcaPropertyID {
+    switch eventData {
+    case let .ocp1(data):
       return try OcaPropertyID(bytes: data)
-    case .ocp2:
-      #if NonEmbeddedBuild
-      guard let object = try Ocp2JSON.parse(data) as? [String: Any],
+    #if NonEmbeddedBuild
+    case let .ocp2(value):
+      guard let object = value as? [String: Any],
             let propertyID = Ocp2Decoder.member(named: "PropertyID", in: object)
       else {
         throw Ocp1Error.status(.badFormat)
       }
       return try Ocp2Decoder().decodeValue(OcaPropertyID.self, from: propertyID)
-      #else
-      throw Ocp1Error.unsupportedControlProtocol
-      #endif
+    #endif
     }
   }
 
   /// Encodes event-specific data in `format`.
   public static func encode(_ value: some Encodable, format: OcaParameterFormat) throws -> Data {
+    try encodeEventData(value, format: format).data
+  }
+
+  package static func encodeEventData(
+    _ value: some Encodable,
+    format: OcaParameterFormat
+  ) throws -> OcaEncodedEventData {
     switch format {
     case .ocp1:
-      return try Ocp1Encoder().encode(value)
+      return .ocp1(try Ocp1Encoder().encode(value))
     case .ocp2:
       #if NonEmbeddedBuild
-      return try Ocp2JSON.serialize(Ocp2Encoder().encodeValue(value))
+      return .ocp2(Ocp2JSON.sendable(try Ocp2Encoder().encodeValue(value)))
       #else
       throw Ocp1Error.unsupportedControlProtocol
       #endif

--- a/Sources/SwiftOCA/OCP.2/Ocp2EventData.swift
+++ b/Sources/SwiftOCA/OCP.2/Ocp2EventData.swift
@@ -1,0 +1,86 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+/// Event data as delivered by a notification: OCP.1 bytes or an OCP.2 JSON object.
+package enum OcaEventDataCoding {
+  /// Decodes event-specific data in `format`.
+  package static func decode<T: Decodable>(
+    _ type: T.Type,
+    from data: Data,
+    format: OcaParameterFormat
+  ) throws -> T {
+    switch format {
+    case .ocp1:
+      return try Ocp1Decoder().decode(type, from: data)
+    case .ocp2:
+      #if NonEmbeddedBuild
+      return try Ocp2Decoder().decodeValue(type, from: Ocp2JSON.parse(data))
+      #else
+      throw Ocp1Error.unsupportedControlProtocol
+      #endif
+    }
+  }
+
+  /// The property a property-changed event refers to, without decoding its value.
+  package static func propertyID(from data: Data, format: OcaParameterFormat) throws -> OcaPropertyID {
+    switch format {
+    case .ocp1:
+      return try OcaPropertyID(bytes: data)
+    case .ocp2:
+      #if NonEmbeddedBuild
+      guard let object = try Ocp2JSON.parse(data) as? [String: Any],
+            let propertyID = Ocp2Decoder.member(named: "PropertyID", in: object)
+      else {
+        throw Ocp1Error.status(.badFormat)
+      }
+      return try Ocp2Decoder().decodeValue(OcaPropertyID.self, from: propertyID)
+      #else
+      throw Ocp1Error.unsupportedControlProtocol
+      #endif
+    }
+  }
+
+  /// Encodes event-specific data in `format`.
+  package static func encode(_ value: some Encodable, format: OcaParameterFormat) throws -> Data {
+    switch format {
+    case .ocp1:
+      return try Ocp1Encoder().encode(value)
+    case .ocp2:
+      #if NonEmbeddedBuild
+      return try Ocp2JSON.serialize(Ocp2Encoder().encodeValue(value))
+      #else
+      throw Ocp1Error.unsupportedControlProtocol
+      #endif
+    }
+  }
+}
+
+package extension OcaControlProtocol {
+  var parameterFormat: OcaParameterFormat {
+    switch self {
+    case .ocp1: .ocp1
+    #if NonEmbeddedBuild
+    case .ocp2: .ocp2
+    #endif
+    }
+  }
+}

--- a/Sources/SwiftOCA/OCP.2/Ocp2JSON.swift
+++ b/Sources/SwiftOCA/OCP.2/Ocp2JSON.swift
@@ -159,8 +159,13 @@ package enum Ocp2JSON {
   }
 }
 
-/// Lets the JSON export convert coder output into `Sendable` containers.
+/// Lets the JSON export and message parameters hold coder output as `Sendable`
+/// containers.
 package extension Ocp2JSON {
+  static func sendableObject(_ object: [String: Any]) -> [String: any Sendable] {
+    object.mapValues { sendable($0) }
+  }
+
   static func sendable(_ json: Any) -> any Sendable {
     switch json {
     case let object as [String: Any]:

--- a/Sources/SwiftOCA/OCP.2/Ocp2JSON.swift
+++ b/Sources/SwiftOCA/OCP.2/Ocp2JSON.swift
@@ -1,0 +1,189 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if NonEmbeddedBuild
+import Foundation
+
+/// Thin shims over `JSONSerialization`, plus the numeric conversions the coder
+/// needs. JSON values are the Foundation container types: `[String: Any]`, `[Any]`,
+/// `String`, `Bool`, integers, `Double`, and `NSNull`.
+package enum Ocp2JSON {
+  /// JSON has no spelling for non-finite numbers; these are the ones
+  /// `JSONDecoder.convertFromString` accepts, shared with the property export.
+  static let positiveInfinity = "Infinity"
+  static let negativeInfinity = "-Infinity"
+  static let nan = "NaN"
+
+  package static func serialize(_ object: Any) throws -> Data {
+    guard JSONSerialization.isValidJSONObject(object) else {
+      throw Ocp1Error.status(.badFormat)
+    }
+    return try JSONSerialization.data(withJSONObject: object, options: [])
+  }
+
+  package static func parse(_ data: Data) throws -> Any {
+    do {
+      return try JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+    } catch {
+      throw Ocp1Error.status(.badFormat)
+    }
+  }
+
+  package static func parseObject(_ data: Data) throws -> [String: Any] {
+    guard let object = try parse(data) as? [String: Any] else {
+      throw Ocp1Error.status(.badFormat)
+    }
+    return object
+  }
+
+  static func isNull(_ json: Any) -> Bool {
+    json is NSNull
+  }
+
+  // MARK: numbers
+
+  static func integer<I: FixedWidthInteger>(_: I.Type, from json: Any) throws -> I {
+    if let bool = json as? Bool, Swift.type(of: json) == Bool.self {
+      return bool ? 1 : 0
+    }
+    if let int = json as? Int, let value = I(exactly: int) {
+      return value
+    }
+    if let int = json as? Int64, let value = I(exactly: int) {
+      return value
+    }
+    if let uint = json as? UInt64, let value = I(exactly: uint) {
+      return value
+    }
+    if let double = json as? Double {
+      guard double.isFinite, double == double.rounded(), let value = I(exactly: double) else {
+        throw Ocp1Error.status(.parameterOutOfRange)
+      }
+      return value
+    }
+    // AES70-4's own examples send an object number as a string
+    if let string = json as? String, let value = I(string) {
+      return value
+    }
+    throw Ocp1Error.status(.badFormat)
+  }
+
+  static func double(from json: Any) throws -> Double {
+    if let double = json as? Double {
+      return double
+    }
+    if let int = json as? Int {
+      return Double(int)
+    }
+    if let int = json as? Int64 {
+      return Double(int)
+    }
+    if let uint = json as? UInt64 {
+      return Double(uint)
+    }
+    if let string = json as? String {
+      switch string {
+      case positiveInfinity: return .infinity
+      case negativeInfinity: return -.infinity
+      case nan: return .nan
+      default:
+        if let value = Double(string) { return value }
+      }
+    }
+    throw Ocp1Error.status(.badFormat)
+  }
+
+  static func bool(from json: Any) throws -> Bool {
+    if let bool = json as? Bool {
+      return bool
+    }
+    if let int = json as? Int {
+      return int != 0
+    }
+    throw Ocp1Error.status(.badFormat)
+  }
+
+  static func string(from json: Any) throws -> String {
+    guard let string = json as? String else {
+      throw Ocp1Error.status(.badFormat)
+    }
+    return string
+  }
+
+  /// Non-finite doubles are spelled as strings.
+  static func json(_ double: Double) -> Any {
+    if double.isNaN { return nan }
+    if double.isInfinite { return double < 0 ? negativeInfinity : positiveInfinity }
+    return double
+  }
+
+  /// A float is re-parsed from its shortest decimal spelling so it serialises with
+  /// single precision digits rather than a double's 17.
+  static func json(_ float: Float) -> Any {
+    if float.isNaN { return nan }
+    if float.isInfinite { return float < 0 ? negativeInfinity : positiveInfinity }
+    return Double(String(float)) ?? Double(float)
+  }
+
+  // MARK: blobs
+
+  static func base64(_ data: Data) -> String {
+    data.base64EncodedString()
+  }
+
+  static func data(from json: Any) throws -> Data {
+    if let string = json as? String {
+      guard let data = Data(base64Encoded: string) else {
+        throw Ocp1Error.status(.badFormat)
+      }
+      return data
+    }
+    // tolerate an array of byte values
+    if let array = json as? [Any] {
+      return try Data(array.map { try integer(UInt8.self, from: $0) })
+    }
+    throw Ocp1Error.status(.badFormat)
+  }
+}
+
+/// Lets the JSON export convert coder output into `Sendable` containers.
+package extension Ocp2JSON {
+  static func sendable(_ json: Any) -> any Sendable {
+    switch json {
+    case let object as [String: Any]:
+      return object.mapValues { sendable($0) }
+    case let array as [Any]:
+      return array.map { sendable($0) }
+    case let string as String:
+      return string
+    case let bool as Bool where Swift.type(of: json) == Bool.self:
+      return bool
+    case let int as Int:
+      return int
+    case let int as Int64:
+      return int
+    case let uint as UInt64:
+      return uint
+    case let double as Double:
+      return double
+    case is NSNull:
+      return NSNull()
+    default:
+      return String(describing: json)
+    }
+  }
+}
+#endif

--- a/Sources/SwiftOCA/OCP.2/Ocp2Message.swift
+++ b/Sources/SwiftOCA/OCP.2/Ocp2Message.swift
@@ -20,9 +20,8 @@ import Foundation
 /// AES70-4 clause 6.3: the OCP.2 PDU is a JSON object with `ProtocolVersion` and
 /// exactly one payload member. Messages are the same model types OCP.1 uses.
 ///
-/// Encoding assembles text directly so a message's already-serialised `Parameters`
-/// object can be spliced in unchanged; decoding goes through `JSONSerialization` and
-/// re-serialises each `Parameters` object for the message model.
+/// A message carries its `Parameters` as the parsed JSON object, so encoding splices
+/// it into the PDU and decoding stores the parsed member, without serialising either.
 package enum Ocp2Message {
   package static let protocolVersion = 1
 
@@ -138,8 +137,8 @@ package enum Ocp2Message {
   private static func parametersObject(_ parameters: Ocp1Parameters) throws -> [String: Any]? {
     switch parameters.format {
     case .ocp2:
-      guard !parameters.parameterData.isEmpty else { return nil }
-      return try Ocp2JSON.parseObject(parameters.parameterData)
+      guard let object = parameters.ocp2Parameters, !object.isEmpty else { return nil }
+      return object
     case .ocp1:
       guard parameters.isEmpty else { throw Ocp1Error.invalidMessageType }
       return nil
@@ -294,10 +293,9 @@ package enum Ocp2Message {
   }
 
   private static func parameters(_ json: Any?) throws -> Ocp1Parameters {
-    guard let json, !(json is NSNull) else { return Ocp1Parameters(ocp2ParameterData: Data()) }
+    guard let json, !(json is NSNull) else { return Ocp1Parameters(ocp2Parameters: [:]) }
     guard let object = json as? [String: Any] else { throw Ocp1Error.status(.badFormat) }
-    guard !object.isEmpty else { return Ocp1Parameters(ocp2ParameterData: Data()) }
-    return try Ocp1Parameters(ocp2ParameterData: Ocp2JSON.serialize(object))
+    return Ocp1Parameters(ocp2Parameters: object)
   }
 
   private static func decodeCommand(_ json: Any) throws -> Ocp1Command {

--- a/Sources/SwiftOCA/OCP.2/Ocp2Message.swift
+++ b/Sources/SwiftOCA/OCP.2/Ocp2Message.swift
@@ -160,9 +160,12 @@ package enum Ocp2Message {
       var event: [String: Any] = [
         Key.eventIdentification: eventIdentificationObject(notification.event),
       ]
-      if !notification.data.isEmpty {
-        guard notification.dataFormat == .ocp2 else { throw Ocp1Error.invalidMessageType }
-        event[Key.eventData] = try Ocp2JSON.parse(notification.data)
+      if !notification.eventData.isEmpty {
+        // OCP.1-encoded event data cannot be represented
+        guard case let .ocp2(value?) = notification.eventData else {
+          throw Ocp1Error.invalidMessageType
+        }
+        event[Key.eventData] = value
       }
       return [Key.event: event]
     case .exception:
@@ -382,16 +385,15 @@ package enum Ocp2Message {
         keys: [Key.eventIdentification, Key.event, Key.eventData],
         required: []
       )
-      let eventData: Data = if let data = object[Key.eventData], !(data is NSNull) {
-        try Ocp2JSON.serialize(data)
+      let eventData: (any Sendable)? = if let data = object[Key.eventData], !(data is NSNull) {
+        Ocp2JSON.sendable(data)
       } else {
-        Data()
+        nil
       }
       return try Ocp1Notification2(
         event: eventIdentification(object),
         notificationType: .event,
-        data: eventData,
-        dataFormat: .ocp2
+        eventData: .ocp2(eventData)
       )
     }
 
@@ -422,8 +424,7 @@ package enum Ocp2Message {
     return try Ocp1Notification2(
       event: eventIdentification(object),
       notificationType: .exception,
-      data: Ocp1Encoder().encode(exception),
-      dataFormat: .ocp1
+      eventData: .ocp1(Ocp1Encoder().encode(exception))
     )
   }
 }

--- a/Sources/SwiftOCA/OCP.2/Ocp2Message.swift
+++ b/Sources/SwiftOCA/OCP.2/Ocp2Message.swift
@@ -1,0 +1,458 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if NonEmbeddedBuild
+import Foundation
+
+/// AES70-4 clause 6.3: the OCP.2 PDU is a JSON object with `ProtocolVersion` and
+/// exactly one payload member. Messages are the same model types OCP.1 uses.
+///
+/// Encoding assembles text directly so a message's already-serialised `Parameters`
+/// object can be spliced in unchanged; decoding goes through `JSONSerialization` and
+/// re-serialises each `Parameters` object for the message model.
+package enum Ocp2Message {
+  package static let protocolVersion = 1
+
+  enum Key {
+    static let protocolVersion = "ProtocolVersion"
+    static let commands = "Commands"
+    static let commandNRs = "CommandNRs"
+    static let responses = "Responses"
+    static let notifications = "Notifications"
+    static let keepAlive = "KeepAlive"
+    static let deviceReset = "DeviceReset"
+
+    static let handle = "Handle"
+    static let targetONo = "TargetONo"
+    static let methodID = "MethodID"
+    static let parameters = "Parameters"
+    static let statusCode = "StatusCode"
+
+    static let event = "Event"
+    static let exception = "Exception"
+    static let eventIdentification = "EventIdentification"
+    static let emitterONo = "EmitterONo"
+    static let eventID = "EventID"
+    static let eventData = "EventData"
+    static let exceptionType = "ExceptionType"
+    static let tryAgain = "TryAgain"
+    static let exceptionData = "ExceptionData"
+
+    static let heartbeatTimeout = "HeartbeatTimeout"
+    static let resetKey = "ResetKey"
+
+    static let payloads: Set<String> = [
+      commands, commandNRs, responses, notifications, keepAlive, deviceReset,
+    ]
+  }
+
+  /// `Ocp2ExceptionType` spelled as in the AES70-4 JSON schema.
+  static let exceptionTypeNames: [Ocp1Notification2ExceptionType: String] = [
+    .unspecified: "Unspecified",
+    .cancelledByDevice: "CancelledByDevice",
+    .objectDeleted: "ObjectDeleted",
+    .deviceError: "DeviceError",
+  ]
+
+  // MARK: - encoding
+
+  static func payloadKey(for messageType: OcaMessageType) throws -> String {
+    switch messageType {
+    case .ocaCmd: Key.commandNRs
+    case .ocaCmdRrq: Key.commands
+    case .ocaRsp: Key.responses
+    case .ocaNtf2: Key.notifications
+    case .ocaKeepAlive: Key.keepAlive
+    case .ocaNtf1: throw Ocp1Error.invalidMessageType // EV1 is not part of OCP.2
+    }
+  }
+
+  /// One message as serialised JSON (no trailing newline).
+  package static func encodeMessage(
+    _ message: Ocp1Message,
+    type messageType: OcaMessageType
+  ) throws -> [UInt8] {
+    try Array(Ocp2JSON.serialize(messageObject(message, type: messageType)))
+  }
+
+  /// The message's JSON object.
+  static func messageObject(
+    _ message: Ocp1Message,
+    type messageType: OcaMessageType
+  ) throws -> [String: Any] {
+    switch message {
+    case let command as Ocp1Command:
+      guard messageType == .ocaCmd || messageType == .ocaCmdRrq else {
+        throw Ocp1Error.invalidMessageType
+      }
+      var object: [String: Any] = [
+        Key.handle: command.handle,
+        Key.targetONo: command.targetONo,
+        Key.methodID: _ocp2ElementID(command.methodID.defLevel, command.methodID.methodIndex),
+      ]
+      if let parameters = try parametersObject(command.parameters) {
+        object[Key.parameters] = parameters
+      }
+      return object
+    case let response as Ocp1Response:
+      guard messageType == .ocaRsp else { throw Ocp1Error.invalidMessageType }
+      var object: [String: Any] = [
+        Key.handle: response.handle,
+        Key.statusCode: response.statusCode.ocp2Name,
+      ]
+      if let parameters = try parametersObject(response.parameters) {
+        object[Key.parameters] = parameters
+      }
+      return object
+    case let notification as Ocp1Notification2:
+      guard messageType == .ocaNtf2 else { throw Ocp1Error.invalidMessageType }
+      return try notificationObject(notification)
+    case let keepAlive as Ocp1KeepAlive1:
+      guard messageType == .ocaKeepAlive else { throw Ocp1Error.invalidMessageType }
+      return [Key.heartbeatTimeout: UInt32(keepAlive.heartBeatTime) * 1000]
+    case let keepAlive as Ocp1KeepAlive2:
+      guard messageType == .ocaKeepAlive else { throw Ocp1Error.invalidMessageType }
+      return [Key.heartbeatTimeout: keepAlive.heartBeatTime]
+    case let reset as Ocp2DeviceReset:
+      return [Key.resetKey: Ocp2JSON.base64(reset.resetKey)]
+    default:
+      throw Ocp1Error.invalidMessageType
+    }
+  }
+
+  /// The `Parameters` object, or `nil` when there are none. OCP.1-encoded parameters
+  /// cannot be represented and are an error rather than a silent blob.
+  private static func parametersObject(_ parameters: Ocp1Parameters) throws -> [String: Any]? {
+    switch parameters.format {
+    case .ocp2:
+      guard !parameters.parameterData.isEmpty else { return nil }
+      return try Ocp2JSON.parseObject(parameters.parameterData)
+    case .ocp1:
+      guard parameters.isEmpty else { throw Ocp1Error.invalidMessageType }
+      return nil
+    }
+  }
+
+  private static func eventIdentificationObject(_ event: OcaEvent) -> [String: Any] {
+    [
+      Key.emitterONo: event.emitterONo,
+      Key.eventID: _ocp2ElementID(event.eventID.defLevel, event.eventID.eventIndex),
+    ]
+  }
+
+  private static func notificationObject(_ notification: Ocp1Notification2) throws
+    -> [String: Any]
+  {
+    switch notification.notificationType {
+    case .event:
+      var event: [String: Any] = [
+        Key.eventIdentification: eventIdentificationObject(notification.event),
+      ]
+      if !notification.data.isEmpty {
+        guard notification.dataFormat == .ocp2 else { throw Ocp1Error.invalidMessageType }
+        event[Key.eventData] = try Ocp2JSON.parse(notification.data)
+      }
+      return [Key.event: event]
+    case .exception:
+      let exception = try Ocp1Decoder().decode(
+        Ocp1Notification2ExceptionData.self,
+        from: notification.data
+      )
+      var object: [String: Any] = [
+        Key.eventIdentification: eventIdentificationObject(notification.event),
+        Key.exceptionType: exceptionTypeNames[exception.exceptionType]
+          ?? Int(exception.exceptionType.rawValue),
+        Key.tryAgain: exception.tryAgain,
+      ]
+      if !exception.exceptionData.isEmpty {
+        object[Key.exceptionData] = Ocp2JSON.base64(exception.exceptionData.wrappedValue)
+      }
+      return [Key.exception: object]
+    }
+  }
+
+  /// One PDU from pre-serialised messages, newline-terminated. The messages are
+  /// spliced as bytes so a batch need not re-parse what it already serialised; the
+  /// envelope has no string content of its own.
+  package static func assemblePdu(
+    type messageType: OcaMessageType,
+    encodedMessages: [[UInt8]],
+    deviceReset: Bool = false
+  ) throws -> [UInt8] {
+    let key = deviceReset ? Key.deviceReset : try payloadKey(for: messageType)
+    var pdu = Array("{\"\(Key.protocolVersion)\":\(protocolVersion),\"\(key)\":".utf8)
+    if messageType == .ocaKeepAlive || deviceReset {
+      guard encodedMessages.count == 1 else { throw Ocp1Error.invalidMessageType }
+      pdu += encodedMessages[0]
+    } else {
+      pdu.append(UInt8(ascii: "["))
+      for (index, message) in encodedMessages.enumerated() {
+        if index > 0 {
+          pdu.append(UInt8(ascii: ","))
+        }
+        pdu += message
+      }
+      pdu.append(UInt8(ascii: "]"))
+    }
+    pdu += Array("}\n".utf8)
+    return pdu
+  }
+
+  package static func encodePdu(
+    _ messages: [Ocp1Message],
+    type messageType: OcaMessageType
+  ) throws -> Data {
+    let deviceReset = messages.count == 1 && messages[0] is Ocp2DeviceReset
+    let encoded = try messages.map { try encodeMessage($0, type: messageType) }
+    return try Data(assemblePdu(
+      type: messageType,
+      encodedMessages: encoded,
+      deviceReset: deviceReset
+    ))
+  }
+
+  /// Envelope bytes beyond the messages: `{"ProtocolVersion":1,"<key>":[` … `]}\n`
+  /// plus a comma between messages. Sized for the longest payload key.
+  package static func pduOverhead(messageCount: Int) -> Int {
+    30 + Key.notifications.count + max(messageCount - 1, 0)
+  }
+
+  // MARK: - decoding
+
+  package static func decodePdu(_ data: Data) throws -> (OcaMessageType, [Ocp1Message]) {
+    let object = try Ocp2JSON.parseObject(data)
+
+    guard let version = object[Key.protocolVersion] else {
+      throw Ocp1Error.status(.badFormat)
+    }
+    guard try Ocp2JSON.integer(Int.self, from: version) == protocolVersion else {
+      throw Ocp1Error.invalidProtocolVersion
+    }
+
+    let payloadKeys = object.keys.filter { $0 != Key.protocolVersion }
+    guard payloadKeys.count == 1, let payloadKey = payloadKeys.first,
+          Key.payloads.contains(payloadKey), let payload = object[payloadKey]
+    else {
+      throw Ocp1Error.invalidMessageType
+    }
+
+    switch payloadKey {
+    case Key.commands, Key.commandNRs:
+      let type: OcaMessageType = payloadKey == Key.commands ? .ocaCmdRrq : .ocaCmd
+      return try (type, array(payload).map { try decodeCommand($0) })
+    case Key.responses:
+      return try (.ocaRsp, array(payload).map { try decodeResponse($0) })
+    case Key.notifications:
+      return try (.ocaNtf2, array(payload).map { try decodeNotification($0) })
+    case Key.keepAlive:
+      let object = try expectObject(
+        payload,
+        keys: [Key.heartbeatTimeout],
+        required: [Key.heartbeatTimeout]
+      )
+      let timeout = try Ocp2JSON.integer(OcaUint32.self, from: object[Key.heartbeatTimeout]!)
+      return (.ocaKeepAlive, [Ocp1KeepAlive2(heartBeatTime: timeout)])
+    case Key.deviceReset:
+      let object = try expectObject(payload, keys: [Key.resetKey], required: [Key.resetKey])
+      let key = try Ocp2JSON.data(from: object[Key.resetKey]!)
+      return (.ocaCmd, [Ocp2DeviceReset(resetKey: key)])
+    default:
+      throw Ocp1Error.invalidMessageType
+    }
+  }
+
+  private static func array(_ json: Any) throws -> [Any] {
+    guard let array = json as? [Any] else { throw Ocp1Error.status(.badFormat) }
+    return array
+  }
+
+  /// Rejects a member outside `keys` (AES70-4 example X03) or a missing `required`
+  /// member (X02).
+  private static func expectObject(
+    _ json: Any,
+    keys: Set<String>,
+    required: Set<String>
+  ) throws -> [String: Any] {
+    guard let object = json as? [String: Any] else { throw Ocp1Error.status(.badFormat) }
+    guard Set(object.keys).isSubset(of: keys), required.isSubset(of: object.keys) else {
+      throw Ocp1Error.status(.badFormat)
+    }
+    return object
+  }
+
+  private static func parameters(_ json: Any?) throws -> Ocp1Parameters {
+    guard let json, !(json is NSNull) else { return Ocp1Parameters(ocp2ParameterData: Data()) }
+    guard let object = json as? [String: Any] else { throw Ocp1Error.status(.badFormat) }
+    guard !object.isEmpty else { return Ocp1Parameters(ocp2ParameterData: Data()) }
+    return try Ocp1Parameters(ocp2ParameterData: Ocp2JSON.serialize(object))
+  }
+
+  private static func decodeCommand(_ json: Any) throws -> Ocp1Command {
+    let object = try expectObject(
+      json,
+      keys: [Key.handle, Key.targetONo, Key.methodID, Key.parameters],
+      required: [Key.handle, Key.targetONo, Key.methodID]
+    )
+    let (defLevel, index) = try _ocp2ElementID(from: object[Key.methodID]!)
+    return try Ocp1Command(
+      handle: Ocp2JSON.integer(OcaUint32.self, from: object[Key.handle]!),
+      targetONo: Ocp2JSON.integer(OcaONo.self, from: object[Key.targetONo]!),
+      methodID: OcaMethodID(defLevel: defLevel, methodIndex: index),
+      parameters: parameters(object[Key.parameters])
+    )
+  }
+
+  private static func status(_ json: Any) throws -> OcaStatus {
+    if let name = json as? String {
+      guard let status = OcaStatus.allCases.first(where: { Ocp2Naming.matches($0.ocp2Name, name) })
+      else {
+        throw Ocp1Error.status(.badFormat)
+      }
+      return status
+    }
+    guard let status = try OcaStatus(rawValue: Ocp2JSON.integer(OcaUint8.self, from: json)) else {
+      throw Ocp1Error.status(.badFormat)
+    }
+    return status
+  }
+
+  private static func decodeResponse(_ json: Any) throws -> Ocp1Response {
+    let object = try expectObject(
+      json,
+      keys: [Key.handle, Key.statusCode, Key.parameters],
+      required: [Key.handle, Key.statusCode]
+    )
+    return try Ocp1Response(
+      handle: Ocp2JSON.integer(OcaUint32.self, from: object[Key.handle]!),
+      statusCode: status(object[Key.statusCode]!),
+      parameters: parameters(object[Key.parameters])
+    )
+  }
+
+  /// The schema and examples name it `EventIdentification`; the prose says `Event`.
+  private static func eventIdentification(_ object: [String: Any]) throws -> OcaEvent {
+    guard let json = object[Key.eventIdentification] ?? object[Key.event],
+          let identification = json as? [String: Any],
+          let emitter = Ocp2Decoder.member(named: Key.emitterONo, in: identification),
+          let eventID = Ocp2Decoder.member(named: Key.eventID, in: identification)
+    else {
+      throw Ocp1Error.status(.badFormat)
+    }
+    let (defLevel, index) = try _ocp2ElementID(from: eventID)
+    return try OcaEvent(
+      emitterONo: Ocp2JSON.integer(OcaONo.self, from: emitter),
+      eventID: OcaEventID(defLevel: defLevel, eventIndex: index)
+    )
+  }
+
+  private static func exceptionType(_ json: Any) throws -> Ocp1Notification2ExceptionType {
+    if let name = json as? String {
+      guard let type = exceptionTypeNames.first(where: { Ocp2Naming.matches($0.value, name) })?.key
+      else {
+        throw Ocp1Error.status(.badFormat)
+      }
+      return type
+    }
+    guard let type = try Ocp1Notification2ExceptionType(
+      rawValue: Ocp2JSON.integer(OcaUint8.self, from: json)
+    ) else {
+      throw Ocp1Error.status(.badFormat)
+    }
+    return type
+  }
+
+  private static func decodeNotification(_ json: Any) throws -> Ocp1Notification2 {
+    let wrapper = try expectObject(json, keys: [Key.event, Key.exception], required: [])
+    guard wrapper.count == 1 else { throw Ocp1Error.status(.badFormat) }
+
+    if let event = wrapper[Key.event] {
+      let object = try expectObject(
+        event,
+        keys: [Key.eventIdentification, Key.event, Key.eventData],
+        required: []
+      )
+      let eventData: Data = if let data = object[Key.eventData], !(data is NSNull) {
+        try Ocp2JSON.serialize(data)
+      } else {
+        Data()
+      }
+      return try Ocp1Notification2(
+        event: eventIdentification(object),
+        notificationType: .event,
+        data: eventData,
+        dataFormat: .ocp2
+      )
+    }
+
+    let object = try expectObject(
+      wrapper[Key.exception]!,
+      keys: [
+        Key.eventIdentification,
+        Key.event,
+        Key.exceptionType,
+        Key.tryAgain,
+        Key.exceptionData,
+      ],
+      required: [Key.exceptionType, Key.tryAgain]
+    )
+    var exceptionData = Data()
+    if let data = object[Key.exceptionData], !(data is NSNull) {
+      if let blob = try? Ocp2JSON.data(from: data) {
+        exceptionData = blob
+      } else {
+        exceptionData = try Ocp2JSON.serialize(data)
+      }
+    }
+    let exception = try Ocp1Notification2ExceptionData(
+      exceptionType: exceptionType(object[Key.exceptionType]!),
+      tryAgain: Ocp2JSON.bool(from: object[Key.tryAgain]!),
+      exceptionData: OcaBlob(exceptionData)
+    )
+    return try Ocp1Notification2(
+      event: eventIdentification(object),
+      notificationType: .exception,
+      data: Ocp1Encoder().encode(exception),
+      dataFormat: .ocp1
+    )
+  }
+}
+
+extension OcaStatus {
+  /// `OcaStatus` spelled as in the AES70-4 JSON schema.
+  var ocp2Name: String {
+    switch self {
+    case .ok: "OK"
+    case .protocolVersionError: "ProtocolVersionError"
+    case .deviceError: "DeviceError"
+    case .locked: "Locked"
+    case .badFormat: "BadFormat"
+    case .badONo: "BadONo"
+    case .parameterError: "ParameterError"
+    case .parameterOutOfRange: "ParameterOutOfRange"
+    case .notImplemented: "NotImplemented"
+    case .invalidRequest: "InvalidRequest"
+    case .processingFailed: "ProcessingFailed"
+    case .badMethod: "BadMethod"
+    case .partiallySucceeded: "PartiallySucceeded"
+    case .timeout: "Timeout"
+    case .bufferOverflow: "BufferOverflow"
+    case .permissionDenied: "PermissionDenied"
+    case .outOfMemory: "OutOfMemory"
+    case .busy: "Busy"
+    }
+  }
+}
+#endif

--- a/Sources/SwiftOCA/OCP.2/Ocp2Naming.swift
+++ b/Sources/SwiftOCA/OCP.2/Ocp2Naming.swift
@@ -1,0 +1,97 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Synchronization
+
+/// OCP.2 names parameters and fields by the AES70-2A model names. SwiftOCA derives
+/// them from Swift identifiers: a property or `CodingKey` name with its first letter
+/// upper-cased (`gain` → `Gain`, `oNo` → `ONo`), or explicit names supplied by the
+/// caller. On receipt names are matched case-insensitively, and a single-parameter
+/// object is accepted whatever its member is called, so a peer still using the 2023
+/// model's lower-case spellings (`minGain`, `lockable`), which OCA 1.5B makes
+/// UpperCamelCase, is understood.
+package enum Ocp2Naming {
+  /// The wire name derived from a Swift identifier.
+  package static func wireName(_ swiftName: String) -> String {
+    var name = Substring(swiftName)
+    while name.hasPrefix("_") {
+      name = name.dropFirst()
+    }
+    guard let first = name.first else { return swiftName }
+    return first.uppercased() + name.dropFirst()
+  }
+
+  /// The wire names for a bounded property: `Gain`, `MinGain`, `MaxGain`.
+  package static func boundedWireNames(_ name: String) -> [String] {
+    [name, "Min" + name, "Max" + name]
+  }
+
+  /// Case-insensitive match, ignoring leading underscores on either side. ASCII
+  /// case folding only, which is all AES70 names use; allocation-free, as it runs
+  /// once per member on every decode.
+  package static func matches(_ a: String, _ b: String) -> Bool {
+    let underscore = UInt8(ascii: "_")
+    var x = a.utf8[...].drop(while: { $0 == underscore })
+    var y = b.utf8[...].drop(while: { $0 == underscore })
+    guard x.count == y.count else { return false }
+    while let cx = x.popFirst(), let cy = y.popFirst() {
+      if cx != cy, cx & 0xDF != cy & 0xDF || !(cx & 0xDF >= 0x41 && cx & 0xDF <= 0x5A) {
+        return false
+      }
+    }
+    return true
+  }
+
+  private static let _fieldNameCache = Mutex<[ObjectIdentifier: [String]]>([:])
+
+  /// Stored-property names of `type` in declaration order (leading `_` stripped, so
+  /// a property wrapper's storage reads as the property).
+  package static func fieldNames(of type: Any.Type) -> [String] {
+    let key = ObjectIdentifier(type)
+    if let cached = _fieldNameCache.withLock({ $0[key] }) {
+      return cached
+    }
+    var names = [String]()
+    _forEachField(of: type) { name, _, _, _ in
+      var s = String(cString: name)
+      while s.hasPrefix("_") {
+        s = String(s.dropFirst())
+      }
+      names.append(s)
+      return true
+    }
+    _fieldNameCache.withLock { $0[key] = names }
+    return names
+  }
+
+  /// The parameter names a top-level parameter object uses: explicit names first,
+  /// then names derived from the type's fields.
+  static func parameterNames(
+    explicit: [String]?,
+    fieldNames: [String]
+  ) -> [String] {
+    var names = explicit ?? []
+    if names.count < fieldNames.count {
+      names += fieldNames[names.count...].map(wireName)
+    }
+    return names
+  }
+
+  /// Placeholder key for a single unnamed parameter sent by a caller that did not
+  /// supply a name. Peers that match by position accept it; use a name where the
+  /// model's spelling matters.
+  package static let unnamedParameter = "Value"
+}

--- a/Sources/SwiftOCA/OCP.2/Ocp2WireFormat.swift
+++ b/Sources/SwiftOCA/OCP.2/Ocp2WireFormat.swift
@@ -53,17 +53,20 @@ package final class Ocp2PduReader: OcaPduReader {
       return pdu
     }
 
+    // the cap applies to the PDU itself, so a line may run to CR LF beyond it
+    let maximumLineSize = maximumPduSize + 2
     while true {
       if let index = buffer[scanned...].firstIndex(of: Self.newline) {
+        var end = index
+        if end > 0, buffer[end - 1] == Self.carriageReturn {
+          end -= 1
+        }
         // a transport may hand over more than was asked for (a whole WebSocket
         // frame), so the cap applies to the PDU itself, not to the read size
-        guard index <= maximumPduSize else { throw Ocp1Error.invalidPduSize }
-        var line = Array(buffer[..<index])
+        guard end <= maximumPduSize else { throw Ocp1Error.invalidPduSize }
+        let line = Array(buffer[..<end])
         buffer.removeSubrange(...index)
         scanned = 0
-        if line.last == Self.carriageReturn {
-          line.removeLast()
-        }
         // an empty line between PDUs is tolerated
         if line.isEmpty {
           continue
@@ -71,10 +74,10 @@ package final class Ocp2PduReader: OcaPduReader {
         return Data(line)
       }
       scanned = buffer.count
-      guard buffer.count < maximumPduSize else {
+      guard buffer.count < maximumLineSize else {
         throw Ocp1Error.invalidPduSize
       }
-      let chunk = try await read(min(Self.readChunk, maximumPduSize - buffer.count), false)
+      let chunk = try await read(min(Self.readChunk, maximumLineSize - buffer.count), false)
       guard !chunk.isEmpty else { throw Ocp1Error.notConnected }
       buffer += chunk
     }

--- a/Sources/SwiftOCA/OCP.2/Ocp2WireFormat.swift
+++ b/Sources/SwiftOCA/OCP.2/Ocp2WireFormat.swift
@@ -1,0 +1,95 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if NonEmbeddedBuild
+import Foundation
+
+/// AES70-4 framing is one JSON object per PDU, terminated by a newline; the framing
+/// itself lives on `OcaControlProtocol`.
+///
+/// Reads newline-delimited PDUs. On a stream, bytes after a newline are kept for the
+/// next PDU; on a message-oriented transport each read is one PDU.
+package final class Ocp2PduReader: OcaPduReader {
+  private static let newline = UInt8(ascii: "\n")
+  private static let carriageReturn = UInt8(ascii: "\r")
+  private static let readChunk = 64 * 1024
+
+  private let isMessageOriented: Bool
+  private let maximumPduSize: Int
+  private var buffer = [UInt8]()
+  /// index up to which `buffer` is known to hold no newline
+  private var scanned = 0
+
+  package init(isMessageOriented: Bool, maximumPduSize: Int) {
+    self.isMessageOriented = isMessageOriented
+    self.maximumPduSize = maximumPduSize
+  }
+
+  package func nextPdu(
+    read: (_ count: Int, _ awaitingAllRead: Bool) async throws -> Data
+  ) async throws -> Data {
+    if isMessageOriented {
+      // read past the cap (a PDU may be terminated, so allow for CR LF) rather
+      // than up to it: a frame the transport would otherwise truncate to exactly
+      // `maximumPduSize` is indistinguishable from one that fits, and would be
+      // decoded as a malformed PDU instead of being rejected as oversized
+      let message = try await read(maximumPduSize + 2, false)
+      guard !message.isEmpty else { throw Ocp1Error.notConnected }
+      let pdu = Self.trimmed(message)
+      guard pdu.count <= maximumPduSize else { throw Ocp1Error.invalidPduSize }
+      return pdu
+    }
+
+    while true {
+      if let index = buffer[scanned...].firstIndex(of: Self.newline) {
+        // a transport may hand over more than was asked for (a whole WebSocket
+        // frame), so the cap applies to the PDU itself, not to the read size
+        guard index <= maximumPduSize else { throw Ocp1Error.invalidPduSize }
+        var line = Array(buffer[..<index])
+        buffer.removeSubrange(...index)
+        scanned = 0
+        if line.last == Self.carriageReturn {
+          line.removeLast()
+        }
+        // an empty line between PDUs is tolerated
+        if line.isEmpty {
+          continue
+        }
+        return Data(line)
+      }
+      scanned = buffer.count
+      guard buffer.count < maximumPduSize else {
+        throw Ocp1Error.invalidPduSize
+      }
+      let chunk = try await read(min(Self.readChunk, maximumPduSize - buffer.count), false)
+      guard !chunk.isEmpty else { throw Ocp1Error.notConnected }
+      buffer += chunk
+    }
+  }
+
+  /// One datagram or frame holds one PDU; strip its terminator and anything after it.
+  private static func trimmed(_ message: Data) -> Data {
+    if let index = message.firstIndex(of: newline) {
+      var end = index
+      if end > message.startIndex, message[end - 1] == carriageReturn {
+        end -= 1
+      }
+      return message[message.startIndex..<end]
+    }
+    return message
+  }
+}
+#endif

--- a/Sources/SwiftOCADevice/OCA/ClassRegistry.swift
+++ b/Sources/SwiftOCADevice/OCA/ClassRegistry.swift
@@ -22,6 +22,8 @@ public class OcaDeviceClassRegistry {
 
   private var _classIDMap = [OcaClassIdentification: OcaRoot.Type]()
 
+  package var registeredClasses: [OcaClassIdentification: OcaRoot.Type] { _classIDMap }
+
   public func register<T: OcaRoot>(
     classID: OcaClassID = T.classID,
     classVersion: OcaClassVersionNumber = T.classVersion,

--- a/Sources/SwiftOCADevice/OCA/Controller.swift
+++ b/Sources/SwiftOCADevice/OCA/Controller.swift
@@ -37,6 +37,11 @@ public protocol OcaController: Actor {
   /// only proves *some* trusted peer is on the wire, not which.
   nonisolated var peerIdentity: OcaPeerIdentity { get }
 
+  /// The control protocol this controller speaks; notifications and responses are
+  /// encoded to match. Fixed for the controller's lifetime — it comes from the
+  /// endpoint that accepted it — so it is `nonisolated` and needs no synchronisation.
+  nonisolated var controlProtocol: OcaControlProtocol { get }
+
   func addSubscription(
     _ subscription: OcaSubscriptionManagerSubscription
   ) async throws
@@ -59,6 +64,8 @@ public protocol OcaController: Actor {
 
 public extension OcaController {
   nonisolated var peerIdentity: OcaPeerIdentity { .anonymous }
+
+  nonisolated var controlProtocol: OcaControlProtocol { .ocp1 }
 
   func sendMessage(
     _ messages: Ocp1Message,

--- a/Sources/SwiftOCADevice/OCA/ControllerDefaultSubscribing.swift
+++ b/Sources/SwiftOCADevice/OCA/ControllerDefaultSubscribing.swift
@@ -148,12 +148,12 @@ public extension OcaControllerDefaultSubscribing {
     let property = eventParameters.propertyID
     let format = controlProtocol.parameterFormat
     // encoded once, for the first subscription that is delivered
-    var encoded: Data?
-    func parameters() throws -> Data {
+    var encoded: OcaEncodedEventData?
+    func parameters() throws -> OcaEncodedEventData {
       if let encoded { return encoded }
-      let data = try eventParameters.encoded(as: format)
-      encoded = data
-      return data
+      let eventData = try eventParameters.encodedEventData(as: format)
+      encoded = eventData
+      return eventData
     }
 
     for subscription in subscriptions {
@@ -174,7 +174,7 @@ public extension OcaControllerDefaultSubscribing {
         }
         let eventData = Ocp1EventData(
           event: subscription.event,
-          eventParameters: try parameters()
+          eventParameters: try parameters().data
         )
         let ntfParams = Ocp1NtfParams(
           parameterCount: 2,
@@ -201,8 +201,7 @@ public extension OcaControllerDefaultSubscribing {
         let notification = Ocp1Notification2(
           event: subscription.event,
           notificationType: .event,
-          data: try parameters(),
-          dataFormat: format
+          eventData: try parameters()
         )
         if subscription.notificationDeliveryMode == .lightweight {
           try await (self as! OcaControllerLightweightNotifying)

--- a/Sources/SwiftOCADevice/OCA/ControllerDefaultSubscribing.swift
+++ b/Sources/SwiftOCADevice/OCA/ControllerDefaultSubscribing.swift
@@ -129,19 +129,24 @@ public extension OcaControllerDefaultSubscribing {
     }
   }
 
+  /// OCP.1-encoded parameters
   func notifySubscribers(
     _ event: OcaEvent,
     parameters: Data
+  ) async throws {
+    try await notifySubscribers(event, parameters: OcaEventParameters(parameters, event: event))
+  }
+
+  func notifySubscribers(
+    _ event: OcaEvent,
+    parameters eventParameters: OcaEventParameters
   ) async throws {
     guard let subscriptions = subscriptions[event.emitterONo] else {
       return
     }
 
-    let property: OcaPropertyID? = if event.eventID == OcaPropertyChangedEventID {
-      try OcaPropertyID(bytes: parameters)
-    } else {
-      nil
-    }
+    let property = eventParameters.propertyID
+    let format = controlProtocol.parameterFormat
 
     for subscription in subscriptions {
       guard subscription.property == nil || property == subscription.property else {
@@ -150,6 +155,11 @@ public extension OcaControllerDefaultSubscribing {
 
       switch subscription.version {
       case .ev1:
+        guard format == .ocp1 else {
+          // EV1 subscriptions are refused on OCP.2, so this cannot arise
+          throw Ocp1Error.unsupportedControlProtocol
+        }
+        let parameters = try eventParameters.encoded(as: .ocp1)
         let eventData = Ocp1EventData(
           event: subscription.event,
           eventParameters: parameters
@@ -179,7 +189,8 @@ public extension OcaControllerDefaultSubscribing {
         let notification = Ocp1Notification2(
           event: subscription.event,
           notificationType: .event,
-          data: parameters
+          data: try eventParameters.encoded(as: format),
+          dataFormat: format
         )
         if subscription.notificationDeliveryMode == .lightweight {
           try await (self as! OcaControllerLightweightNotifying)

--- a/Sources/SwiftOCADevice/OCA/ControllerDefaultSubscribing.swift
+++ b/Sources/SwiftOCADevice/OCA/ControllerDefaultSubscribing.swift
@@ -147,6 +147,14 @@ public extension OcaControllerDefaultSubscribing {
 
     let property = eventParameters.propertyID
     let format = controlProtocol.parameterFormat
+    // encoded once, for the first subscription that is delivered
+    var encoded: Data?
+    func parameters() throws -> Data {
+      if let encoded { return encoded }
+      let data = try eventParameters.encoded(as: format)
+      encoded = data
+      return data
+    }
 
     for subscription in subscriptions {
       // subscriptions are kept per emitter, so an emitter's other events must not be
@@ -164,10 +172,9 @@ public extension OcaControllerDefaultSubscribing {
           // EV1 subscriptions are refused on OCP.2, so this cannot arise
           throw Ocp1Error.unsupportedControlProtocol
         }
-        let parameters = try eventParameters.encoded(as: .ocp1)
         let eventData = Ocp1EventData(
           event: subscription.event,
-          eventParameters: parameters
+          eventParameters: try parameters()
         )
         let ntfParams = Ocp1NtfParams(
           parameterCount: 2,
@@ -194,7 +201,7 @@ public extension OcaControllerDefaultSubscribing {
         let notification = Ocp1Notification2(
           event: subscription.event,
           notificationType: .event,
-          data: try eventParameters.encoded(as: format),
+          data: try parameters(),
           dataFormat: format
         )
         if subscription.notificationDeliveryMode == .lightweight {

--- a/Sources/SwiftOCADevice/OCA/ControllerDefaultSubscribing.swift
+++ b/Sources/SwiftOCADevice/OCA/ControllerDefaultSubscribing.swift
@@ -149,6 +149,11 @@ public extension OcaControllerDefaultSubscribing {
     let format = controlProtocol.parameterFormat
 
     for subscription in subscriptions {
+      // subscriptions are kept per emitter, so an emitter's other events must not be
+      // delivered to a controller that subscribed to only one of them
+      guard subscription.event.eventID == event.eventID else {
+        continue
+      }
       guard subscription.property == nil || property == subscription.property else {
         continue
       }

--- a/Sources/SwiftOCADevice/OCA/Device.swift
+++ b/Sources/SwiftOCADevice/OCA/Device.swift
@@ -27,9 +27,9 @@ import Synchronization
 
 /// Event parameters that are encoded on demand, in the format of whichever controller
 /// receives them, so a recipient that only needs the event never pays for encoding
-/// them. Encoding happens on each access: a controller's fan-out asks for one format
-/// for all of its own subscriptions, so there is little to memoise and nothing here
-/// needs synchronising.
+/// them. Encoding happens on each access: a controller's fan-out encodes once for all
+/// of its own subscriptions, so there is little to memoise and nothing here needs
+/// synchronising.
 public struct OcaEventParameters: Sendable {
   private let _encode: @Sendable (OcaParameterFormat) throws -> Data
 
@@ -358,10 +358,17 @@ public actor OcaDevice {
     case .normal:
       let subscribers = await _subscribers(to: event)
       guard !subscribers.isEmpty else { return }
+      let logger = logger
       await withDiscardingTaskGroup { group in
         for subscriber in subscribers {
           group.addTask {
-            try? await subscriber.notifySubscribers(event, parameters: parameters)
+            do {
+              try await subscriber.notifySubscribers(event, parameters: parameters)
+            } catch Ocp1Error.notConnected {
+              // a controller on its way out
+            } catch {
+              logger.warning("failed to notify \(subscriber) of \(event): \(error)")
+            }
           }
         }
       }

--- a/Sources/SwiftOCADevice/OCA/Device.swift
+++ b/Sources/SwiftOCADevice/OCA/Device.swift
@@ -31,14 +31,14 @@ import Synchronization
 /// of its own subscriptions, so there is little to memoise and nothing here needs
 /// synchronising.
 public struct OcaEventParameters: Sendable {
-  private let _encode: @Sendable (OcaParameterFormat) throws -> Data
+  private let _encode: @Sendable (OcaParameterFormat) throws -> OcaEncodedEventData
 
   /// The property a property-changed event refers to, if known; lets a controller
   /// filter per-property subscriptions without decoding the parameters.
   public let propertyID: OcaPropertyID?
 
   init(
-    _ encode: @escaping @Sendable (OcaParameterFormat) throws -> Data,
+    _ encode: @escaping @Sendable (OcaParameterFormat) throws -> OcaEncodedEventData,
     propertyID: OcaPropertyID?
   ) {
     _encode = encode
@@ -46,11 +46,14 @@ public struct OcaEventParameters: Sendable {
   }
 
   init(_ value: OcaPropertyChangedEventData<some Codable & Sendable>) {
-    self.init({ try OcaEventDataCoding.encode(value, format: $0) }, propertyID: value.propertyID)
+    self.init(
+      { try OcaEventDataCoding.encodeEventData(value, format: $0) },
+      propertyID: value.propertyID
+    )
   }
 
   init(_ value: some Codable & Sendable) {
-    self.init({ try OcaEventDataCoding.encode(value, format: $0) }, propertyID: nil)
+    self.init({ try OcaEventDataCoding.encodeEventData(value, format: $0) }, propertyID: nil)
   }
 
   /// Pre-encoded OCP.1 parameters. A property-changed event's property ID is read from
@@ -65,7 +68,7 @@ public struct OcaEventParameters: Sendable {
       guard format == .ocp1 || encoded.isEmpty else {
         throw Ocp1Error.unsupportedControlProtocol
       }
-      return encoded
+      return try OcaEncodedEventData(encoded, format: format)
     }, propertyID: propertyID)
   }
 
@@ -76,9 +79,9 @@ public struct OcaEventParameters: Sendable {
     self.init({ format in
       switch format {
       case .ocp1:
-        return encoded
+        return .ocp1(encoded)
       case .ocp2:
-        return try OcaEventDataCoding.encode(value, format: format)
+        return try OcaEventDataCoding.encodeEventData(value, format: format)
       }
     }, propertyID: value.propertyID)
   }
@@ -90,6 +93,12 @@ public struct OcaEventParameters: Sendable {
 
   /// The parameters in `format`, encoded on each access.
   public func encoded(as format: OcaParameterFormat = .ocp1) throws -> Data {
+    try _encode(format).data
+  }
+
+  /// The parameters in `format`, as a notification carries them: OCP.2 data stays a
+  /// JSON value until the PDU is serialised.
+  package func encodedEventData(as format: OcaParameterFormat) throws -> OcaEncodedEventData {
     try _encode(format)
   }
 

--- a/Sources/SwiftOCADevice/OCA/Device.swift
+++ b/Sources/SwiftOCADevice/OCA/Device.swift
@@ -69,6 +69,20 @@ public struct OcaEventParameters: Sendable {
     }, propertyID: propertyID)
   }
 
+  /// Pre-encoded OCP.1 parameters together with the value they encode, for a sender that
+  /// encodes its own OCP.1 bytes: OCP.1 keeps those bytes, and any other protocol encodes
+  /// from the value on demand, so only a controller speaking one pays for it.
+  init<T: Codable & Sendable>(_ encoded: Data, value: OcaPropertyChangedEventData<T>) {
+    self.init({ format in
+      switch format {
+      case .ocp1:
+        return encoded
+      case .ocp2:
+        return try OcaEventDataCoding.encode(value, format: format)
+      }
+    }, propertyID: value.propertyID)
+  }
+
   /// OCP.1 encoding of the parameters
   public var encoded: Data {
     get throws { try encoded(as: .ocp1) }
@@ -304,6 +318,16 @@ public actor OcaDevice {
     parameters: Data
   ) async throws {
     try await _notifySubscribers(event, parameters: OcaEventParameters(parameters, event: event))
+  }
+
+  /// OCP.1-encoded parameters and the value they encode, for a sender that encodes its own
+  /// OCP.1 bytes: OCP.2 controllers are encoded for from the value, rather than missing out.
+  public func notifySubscribers<T: Codable & Sendable>(
+    _ event: OcaEvent,
+    parameters: Data,
+    value: OcaPropertyChangedEventData<T>
+  ) async throws {
+    try await _notifySubscribers(event, parameters: OcaEventParameters(parameters, value: value))
   }
 
   func notifySubscribers(_ event: OcaEvent) async throws {

--- a/Sources/SwiftOCADevice/OCA/Device.swift
+++ b/Sources/SwiftOCADevice/OCA/Device.swift
@@ -23,33 +23,67 @@ import Foundation
 #endif
 import Logging
 @_spi(SwiftOCAPrivate) import SwiftOCA
+import Synchronization
 
-/// Event parameters that are encoded on demand, so a recipient that only needs the event
-/// never pays for encoding them.
+/// Event parameters that are encoded on demand, in the format of whichever controller
+/// receives them, so a recipient that only needs the event never pays for encoding
+/// them. Encoding happens on each access: a controller's fan-out asks for one format
+/// for all of its own subscriptions, so there is little to memoise and nothing here
+/// needs synchronising.
 public struct OcaEventParameters: Sendable {
-  private let _eventID: OcaEventID
-  private let _encode: @Sendable () throws -> Data
+  private let _encode: @Sendable (OcaParameterFormat) throws -> Data
 
-  init(eventID: OcaEventID, _ encode: @escaping @Sendable () throws -> Data) {
-    _eventID = eventID
+  /// The property a property-changed event refers to, if known; lets a controller
+  /// filter per-property subscriptions without decoding the parameters.
+  public let propertyID: OcaPropertyID?
+
+  init(
+    _ encode: @escaping @Sendable (OcaParameterFormat) throws -> Data,
+    propertyID: OcaPropertyID?
+  ) {
     _encode = encode
+    self.propertyID = propertyID
   }
 
-  init(eventID: OcaEventID, _ encoded: Data) {
-    _eventID = eventID
-    _encode = { encoded }
+  init(_ value: OcaPropertyChangedEventData<some Codable & Sendable>) {
+    self.init({ try OcaEventDataCoding.encode(value, format: $0) }, propertyID: value.propertyID)
   }
 
-  /// OCP.1 encoding of the parameters; each access encodes afresh
+  init(_ value: some Codable & Sendable) {
+    self.init({ try OcaEventDataCoding.encode(value, format: $0) }, propertyID: nil)
+  }
+
+  /// Pre-encoded OCP.1 parameters. A property-changed event's property ID is read from
+  /// the encoding so per-property filtering still works.
+  init(_ encoded: Data, event: OcaEvent? = nil) {
+    let propertyID: OcaPropertyID? = if event?.eventID == OcaPropertyChangedEventID {
+      try? OcaEventDataCoding.propertyID(from: encoded, format: .ocp1)
+    } else {
+      nil
+    }
+    self.init({ format in
+      guard format == .ocp1 || encoded.isEmpty else {
+        throw Ocp1Error.unsupportedControlProtocol
+      }
+      return encoded
+    }, propertyID: propertyID)
+  }
+
+  /// OCP.1 encoding of the parameters
   public var encoded: Data {
-    get throws { try _encode() }
+    get throws { try encoded(as: .ocp1) }
+  }
+
+  /// The parameters in `format`, encoded on each access.
+  public func encoded(as format: OcaParameterFormat = .ocp1) throws -> Data {
+    try _encode(format)
   }
 
   /// The ID of the property that changed; throws for any event but PropertyChanged.
   public var changedPropertyID: OcaPropertyID {
     get throws {
-      guard _eventID == OcaPropertyChangedEventID else { throw Ocp1Error.unhandledEvent }
-      return try OcaAnyPropertyChangedEventData(data: encoded).propertyID
+      guard let propertyID else { throw Ocp1Error.unhandledEvent }
+      return propertyID
     }
   }
 }
@@ -212,6 +246,8 @@ public actor OcaDevice {
         throw Ocp1Error.status(.badONo)
       }
 
+      // the response format comes from the controller, which knows the protocol it
+      // speaks; nothing is carried implicitly
       if command.methodID.defLevel > 1,
          let peerToPeerObject = object as? any OcaGroupPeerToPeerMember
       {
@@ -250,21 +286,28 @@ public actor OcaDevice {
     _ event: OcaEvent,
     parameters: OcaPropertyChangedEventData<some Codable & Sendable>
   ) async throws {
-    try await _notifySubscribers(
-      event,
-      parameters: OcaEventParameters(eventID: event.eventID) { try Ocp1Encoder().encode(parameters) as Data }
-    )
+    try await _notifySubscribers(event, parameters: OcaEventParameters(parameters))
   }
 
+  /// `parameters` is any event-specific data structure; it is encoded per controller.
+  public func notifySubscribers(
+    _ event: OcaEvent,
+    eventData parameters: some Codable & Sendable
+  ) async throws {
+    try await _notifySubscribers(event, parameters: OcaEventParameters(parameters))
+  }
+
+  /// OCP.1-encoded parameters; OCP.2 controllers cannot be notified from these unless
+  /// they are empty.
   public func notifySubscribers(
     _ event: OcaEvent,
     parameters: Data
   ) async throws {
-    try await _notifySubscribers(event, parameters: OcaEventParameters(eventID: event.eventID, parameters))
+    try await _notifySubscribers(event, parameters: OcaEventParameters(parameters, event: event))
   }
 
   func notifySubscribers(_ event: OcaEvent) async throws {
-    try await _notifySubscribers(event, parameters: OcaEventParameters(eventID: event.eventID, Data()))
+    try await _notifySubscribers(event, parameters: OcaEventParameters(Data(), event: event))
   }
 
   /// Parameters are only encoded for a recipient that asks for them: the event delegate on
@@ -291,7 +334,6 @@ public actor OcaDevice {
     case .normal:
       let subscribers = await _subscribers(to: event)
       guard !subscribers.isEmpty else { return }
-      let parameters = try parameters.encoded
       await withDiscardingTaskGroup { group in
         for subscriber in subscribers {
           group.addTask {

--- a/Sources/SwiftOCADevice/OCA/DeviceEndpoint.swift
+++ b/Sources/SwiftOCADevice/OCA/DeviceEndpoint.swift
@@ -40,6 +40,13 @@ package protocol OcaDeviceEndpointPrivate: OcaDeviceEndpoint {
   nonisolated var logger: Logger { get }
   nonisolated var enableMessageTracing: Bool { get }
 
+  /// The control protocol controllers on this endpoint speak. Defaults to OCP.1.
+  nonisolated var controlProtocol: OcaControlProtocol { get }
+
+  /// Largest PDU accepted from a controller (enforced for OCP.2 framing). Override to
+  /// narrow it: the default lets a peer buffer 16 MB before a PDU is framed.
+  nonisolated var maximumPduSize: Int { get }
+
   @OcaDevice
   func add(controller: ControllerType) async
   @OcaDevice
@@ -47,6 +54,10 @@ package protocol OcaDeviceEndpointPrivate: OcaDeviceEndpoint {
 }
 
 extension OcaDeviceEndpointPrivate {
+  package nonisolated var controlProtocol: OcaControlProtocol { .ocp1 }
+
+  package nonisolated var maximumPduSize: Int { OcaControlProtocol.defaultMaximumPduSize }
+
   package func unlockAndRemove(controller: ControllerType) async {
     await controller.cancelKeepAlive()
 

--- a/Sources/SwiftOCADevice/OCA/DeviceEndpointRegistrar.swift
+++ b/Sources/SwiftOCADevice/OCA/DeviceEndpointRegistrar.swift
@@ -33,15 +33,33 @@ import Logging
 public protocol OcaBonjourRegistrableDeviceEndpoint: OcaDeviceEndpoint {
   var serviceType: OcaNetworkAdvertisingServiceType { get }
   var port: UInt16 { get }
+  /// Endpoint-specific TXT records (e.g. a WebSocket `path`), in registration order.
+  var txtRecordAdditions: [(String, String)] { get }
+  /// Every service advertised for this endpoint, each with its TXT records. Defaults to
+  /// the one `serviceType`; an endpoint serving several control protocols lists one each.
+  var advertisedServices: [(
+    serviceType: OcaNetworkAdvertisingServiceType,
+    txtRecordAdditions: [(String, String)]
+  )] { get }
+}
+
+public extension OcaBonjourRegistrableDeviceEndpoint {
+  var txtRecordAdditions: [(String, String)] { [] }
+
+  var advertisedServices: [(
+    serviceType: OcaNetworkAdvertisingServiceType,
+    txtRecordAdditions: [(String, String)]
+  )] {
+    [(serviceType, txtRecordAdditions)]
+  }
 }
 
 extension OcaDeviceManager {
   /// In registration order: AES70 requires the record to begin with `txtvers` and
-  /// `protovers`, in that order.
-  var txtRecords: [(String, String)] {
-    [
-      ("txtvers", "1"),
-      ("protovers", "\(version)"),
+  /// `protovers`, in that order. An endpoint's `additions` follow them, as AES70-4
+  /// lists `path` after the two, then the device's own records.
+  func txtRecords(adding additions: [(String, String)] = []) -> [(String, String)] {
+    [("txtvers", "1"), ("protovers", "\(version)")] + additions + [
       ("modelGUID", "\(modelGUID)"),
       ("serialNumber", "\(serialNumber)"),
     ]
@@ -53,17 +71,26 @@ extension OcaBonjourRegistrableDeviceEndpoint {
   // the returned task strongly would otherwise form a retain cycle
   // (endpoint → task → self), preventing the deinit-based cancel from
   // ever firing and the mDNS goodbye from being sent on shutdown.
-  // Reads serviceType/port synchronously here so the Task closure only
-  // captures the extracted values plus `device`.
+  // Reads the advertised services and port synchronously here so the Task
+  // closure only captures the extracted values plus `device`.
   package func makeBonjourRegistrarTask(for device: OcaDevice) -> Task<(), Error> {
-    let serviceType = serviceType
+    let services = advertisedServices
     let port = port
     return Task {
-      try await runBonjourEndpointRegistrar(
-        serviceType: serviceType,
-        port: port,
-        for: device
-      )
+      // one registration per service, all cancelled with the task
+      try await withThrowingTaskGroup(of: Void.self) { group in
+        for service in services {
+          group.addTask {
+            try await runBonjourEndpointRegistrar(
+              serviceType: service.serviceType,
+              port: port,
+              txtRecordAdditions: service.txtRecordAdditions,
+              for: device
+            )
+          }
+        }
+        try await group.waitForAll()
+      }
     }
   }
 }
@@ -72,6 +99,7 @@ extension OcaBonjourRegistrableDeviceEndpoint {
 package func runBonjourEndpointRegistrar(
   serviceType: OcaNetworkAdvertisingServiceType,
   port: UInt16,
+  txtRecordAdditions: [(String, String)] = [],
   for device: OcaDevice
 ) async throws {
   let logger = await device.logger
@@ -88,7 +116,7 @@ package func runBonjourEndpointRegistrar(
         name: deviceName,
         regType: serviceType.rawValue,
         port: port,
-        txtRecord: deviceManager.txtRecords
+        txtRecord: deviceManager.txtRecords(adding: txtRecordAdditions)
       )
     }
   } catch {

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Agents/Agent.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Agents/Agent.swift
@@ -17,7 +17,9 @@
 import SwiftOCA
 
 open class OcaAgent: OcaRoot, OcaOwnable, OcaLabelRepresentable {
-  override open class var classID: OcaClassID { OcaClassID("1.2") }
+  override open class var classID: OcaClassID {
+    OcaClassID("1.2")
+  }
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("2.1"),

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Agents/Group.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Agents/Group.swift
@@ -378,8 +378,7 @@ extension OcaGroup {
           eventID: OcaGroupExceptionEventID
         ),
         notificationType: .event,
-        data: try OcaEventDataCoding.encode(exceptions, format: format),
-        dataFormat: format
+        eventData: try OcaEventDataCoding.encodeEventData(exceptions, format: format)
       )
       try await controller.sendMessage(notification, type: .ocaNtf2)
     }

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Agents/Group.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Agents/Group.swift
@@ -371,14 +371,15 @@ extension OcaGroup {
     }
 
     if !exceptions.isEmpty {
-      let exceptionData: [UInt8] = try Ocp1Encoder().encode(exceptions)
+      let format = await controller.controlProtocol.parameterFormat
       let notification = Ocp1Notification2(
         event: OcaEvent(
           emitterONo: group.objectNumber,
           eventID: OcaGroupExceptionEventID
         ),
         notificationType: .event,
-        data: Data(exceptionData)
+        data: try OcaEventDataCoding.encode(exceptions, format: format),
+        dataFormat: format
       )
       try await controller.sendMessage(notification, type: .ocaNtf2)
     }

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Agents/MediaClock3.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Agents/MediaClock3.swift
@@ -48,7 +48,7 @@ open class OcaMediaClock3: OcaAgent {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.5"),
     getMethodID: OcaMethodID("3.7"),
-    ocp2Name: "Rates"
+    ocp2GetName: "Rates"
   )
   public var supportedRates: OcaMultiMap<OcaONo, OcaMediaClockRate> = [:]
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Agents/MediaClock3.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Agents/MediaClock3.swift
@@ -47,7 +47,8 @@ open class OcaMediaClock3: OcaAgent {
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.5"),
-    getMethodID: OcaMethodID("3.7")
+    getMethodID: OcaMethodID("3.7"),
+    ocp2Name: "Rates"
   )
   public var supportedRates: OcaMultiMap<OcaONo, OcaMediaClockRate> = [:]
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Agents/MediaTransportSessionAgent.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Agents/MediaTransportSessionAgent.swift
@@ -27,7 +27,8 @@ open class OcaMediaTransportSessionAgent: OcaAgent {
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.1"),
-    getMethodID: OcaMethodID("3.1")
+    getMethodID: OcaMethodID("3.1"),
+    ocp2Name: "Type"
   )
   public var sessionType = ""
 
@@ -39,14 +40,16 @@ open class OcaMediaTransportSessionAgent: OcaAgent {
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.3"),
-    getMethodID: OcaMethodID("3.11")
+    getMethodID: OcaMethodID("3.11"),
+    ocp2Name: "Sessions"
   )
   public var sessionStatuses = OcaMediaTransportSessionStatusMap()
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.4"),
     getMethodID: OcaMethodID("3.17"),
-    setMethodID: OcaMethodID("3.18")
+    setMethodID: OcaMethodID("3.18"),
+    ocp2Name: "Data"
   )
   public var adaptationData: OcaAdaptationData = OcaBlob()
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Agents/MediaTransportSessionAgent.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Agents/MediaTransportSessionAgent.swift
@@ -49,7 +49,8 @@ open class OcaMediaTransportSessionAgent: OcaAgent {
     propertyID: OcaPropertyID("3.4"),
     getMethodID: OcaMethodID("3.17"),
     setMethodID: OcaMethodID("3.18"),
-    ocp2Name: "Data"
+    ocp2Name: "Data",
+    ocp2SetName: "Data"
   )
   public var adaptationData: OcaAdaptationData = OcaBlob()
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Agents/MediaTransportSessionAgent.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Agents/MediaTransportSessionAgent.swift
@@ -173,11 +173,11 @@ open class OcaMediaTransportSessionAgent: OcaAgent {
     case OcaMethodID("3.3"):
       let id: OcaMediaTransportSessionID = try decodeCommand(command)
       try await ensureReadable(by: controller, command: command)
-      return try controller.encodeResponse(session(id))
+      return try controller.encodeResponse(session(id), name: "Session")
     case OcaMethodID("3.4"):
       let session: OcaMediaTransportSession = try decodeCommand(command)
       try await ensureWritable(by: controller, command: command)
-      return try await controller.encodeResponse(add(session: session))
+      return try await controller.encodeResponse(add(session: session), name: "Session")
     case OcaMethodID("3.5"):
       let session: OcaMediaTransportSession = try decodeCommand(command)
       try await ensureWritable(by: controller, command: command)
@@ -211,14 +211,15 @@ open class OcaMediaTransportSessionAgent: OcaAgent {
     case OcaMethodID("3.12"):
       let id: OcaMediaTransportSessionID = try decodeCommand(command)
       try await ensureReadable(by: controller, command: command)
-      return try controller.encodeResponse(sessionStatus(id))
+      // the model names GetSessionStatus's output Session, like GetSession's
+      return try controller.encodeResponse(sessionStatus(id), name: "Session")
     case OcaMethodID("3.13"):
       let parameters: Parameters.AddConnectionParameters = try decodeCommand(command)
       try await ensureWritable(by: controller, command: command)
-      return try await controller.encodeResponse(add(
-        connection: parameters.connection,
-        to: parameters.sessionID
-      ))
+      return try await controller.encodeResponse(
+        add(connection: parameters.connection, to: parameters.sessionID),
+        name: "Connection"
+      )
     case OcaMethodID("3.14"):
       let parameters: Parameters.ConfigureConnectionParameters = try decodeCommand(command)
       try await ensureWritable(by: controller, command: command)

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Agents/MediaTransportSessionAgent.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Agents/MediaTransportSessionAgent.swift
@@ -28,7 +28,7 @@ open class OcaMediaTransportSessionAgent: OcaAgent {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.1"),
     getMethodID: OcaMethodID("3.1"),
-    ocp2Name: "Type"
+    ocp2GetName: "Type"
   )
   public var sessionType = ""
 
@@ -41,7 +41,7 @@ open class OcaMediaTransportSessionAgent: OcaAgent {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.3"),
     getMethodID: OcaMethodID("3.11"),
-    ocp2Name: "Sessions"
+    ocp2GetName: "Sessions"
   )
   public var sessionStatuses = OcaMediaTransportSessionStatusMap()
 
@@ -49,7 +49,7 @@ open class OcaMediaTransportSessionAgent: OcaAgent {
     propertyID: OcaPropertyID("3.4"),
     getMethodID: OcaMethodID("3.17"),
     setMethodID: OcaMethodID("3.18"),
-    ocp2Name: "Data",
+    ocp2GetName: "Data",
     ocp2SetName: "Data"
   )
   public var adaptationData: OcaAdaptationData = OcaBlob()

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Agents/PowerSupply.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Agents/PowerSupply.swift
@@ -29,7 +29,7 @@ open class OcaPowerSupply: OcaAgent {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.2"),
     getMethodID: OcaMethodID("3.2"),
-    ocp2Name: "Info"
+    ocp2GetName: "Info"
   )
   public var modelInfo: OcaString = ""
 
@@ -52,7 +52,7 @@ open class OcaPowerSupply: OcaAgent {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.5"),
     getMethodID: OcaMethodID("3.6"),
-    ocp2Name: "Fraction"
+    ocp2GetName: "Fraction"
   )
   public var loadFractionAvailable: OcaFloat32 = -1
 
@@ -61,7 +61,7 @@ open class OcaPowerSupply: OcaAgent {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.6"),
     getMethodID: OcaMethodID("3.7"),
-    ocp2Name: "Fraction"
+    ocp2GetName: "Fraction"
   )
   public var storageFractionAvailable: OcaFloat32 = -1
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Agents/PowerSupply.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Agents/PowerSupply.swift
@@ -28,7 +28,8 @@ open class OcaPowerSupply: OcaAgent {
   /// implementation-dependent model information
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.2"),
-    getMethodID: OcaMethodID("3.2")
+    getMethodID: OcaMethodID("3.2"),
+    ocp2Name: "Info"
   )
   public var modelInfo: OcaString = ""
 
@@ -50,7 +51,8 @@ open class OcaPowerSupply: OcaAgent {
   /// range zero to one; a negative value indicates the data is unavailable
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.5"),
-    getMethodID: OcaMethodID("3.6")
+    getMethodID: OcaMethodID("3.6"),
+    ocp2Name: "Fraction"
   )
   public var loadFractionAvailable: OcaFloat32 = -1
 
@@ -58,7 +60,8 @@ open class OcaPowerSupply: OcaAgent {
   /// range zero to one; a negative value indicates the data is unavailable
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.6"),
-    getMethodID: OcaMethodID("3.7")
+    getMethodID: OcaMethodID("3.7"),
+    ocp2Name: "Fraction"
   )
   public var storageFractionAvailable: OcaFloat32 = -1
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Agents/TimeSource.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Agents/TimeSource.swift
@@ -29,14 +29,16 @@ open class OcaTimeSource: OcaAgent {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.2"),
     getMethodID: OcaMethodID("3.2"),
-    setMethodID: OcaMethodID("3.3")
+    setMethodID: OcaMethodID("3.3"),
+    ocp2Name: "Mechanism"
   )
   public var timeDeliveryMechanism: OcaTimeDeliveryMechanism = .undefined
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.3"),
     getMethodID: OcaMethodID("3.4"),
-    setMethodID: OcaMethodID("3.5")
+    setMethodID: OcaMethodID("3.5"),
+    ocp2Name: "Parameters"
   )
   public var referenceSDPDescription: OcaSDPString = ""
 
@@ -50,7 +52,8 @@ open class OcaTimeSource: OcaAgent {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.5"),
     getMethodID: OcaMethodID("3.8"),
-    setMethodID: OcaMethodID("3.9")
+    setMethodID: OcaMethodID("3.9"),
+    ocp2Name: "ID"
   )
   public var referenceID: OcaString = ""
 
@@ -63,7 +66,8 @@ open class OcaTimeSource: OcaAgent {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.7"),
     getMethodID: OcaMethodID("3.12"),
-    setMethodID: OcaMethodID("3.13")
+    setMethodID: OcaMethodID("3.13"),
+    ocp2Name: "Record"
   )
   public var timeDeliveryParameters: OcaParameterRecord = "{}"
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Agents/TimeSource.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Agents/TimeSource.swift
@@ -30,7 +30,8 @@ open class OcaTimeSource: OcaAgent {
     propertyID: OcaPropertyID("3.2"),
     getMethodID: OcaMethodID("3.2"),
     setMethodID: OcaMethodID("3.3"),
-    ocp2Name: "Mechanism"
+    ocp2Name: "Mechanism",
+    ocp2SetName: "Mechanism"
   )
   public var timeDeliveryMechanism: OcaTimeDeliveryMechanism = .undefined
 
@@ -38,7 +39,8 @@ open class OcaTimeSource: OcaAgent {
     propertyID: OcaPropertyID("3.3"),
     getMethodID: OcaMethodID("3.4"),
     setMethodID: OcaMethodID("3.5"),
-    ocp2Name: "Parameters"
+    ocp2Name: "Parameters",
+    ocp2SetName: "Parameters"
   )
   public var referenceSDPDescription: OcaSDPString = ""
 
@@ -53,7 +55,8 @@ open class OcaTimeSource: OcaAgent {
     propertyID: OcaPropertyID("3.5"),
     getMethodID: OcaMethodID("3.8"),
     setMethodID: OcaMethodID("3.9"),
-    ocp2Name: "ID"
+    ocp2Name: "ID",
+    ocp2SetName: "ID"
   )
   public var referenceID: OcaString = ""
 
@@ -67,7 +70,8 @@ open class OcaTimeSource: OcaAgent {
     propertyID: OcaPropertyID("3.7"),
     getMethodID: OcaMethodID("3.12"),
     setMethodID: OcaMethodID("3.13"),
-    ocp2Name: "Record"
+    ocp2Name: "Record",
+    ocp2SetName: "Record"
   )
   public var timeDeliveryParameters: OcaParameterRecord = "{}"
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Agents/TimeSource.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Agents/TimeSource.swift
@@ -30,7 +30,7 @@ open class OcaTimeSource: OcaAgent {
     propertyID: OcaPropertyID("3.2"),
     getMethodID: OcaMethodID("3.2"),
     setMethodID: OcaMethodID("3.3"),
-    ocp2Name: "Mechanism",
+    ocp2GetName: "Mechanism",
     ocp2SetName: "Mechanism"
   )
   public var timeDeliveryMechanism: OcaTimeDeliveryMechanism = .undefined
@@ -39,7 +39,7 @@ open class OcaTimeSource: OcaAgent {
     propertyID: OcaPropertyID("3.3"),
     getMethodID: OcaMethodID("3.4"),
     setMethodID: OcaMethodID("3.5"),
-    ocp2Name: "Parameters",
+    ocp2GetName: "Parameters",
     ocp2SetName: "Parameters"
   )
   public var referenceSDPDescription: OcaSDPString = ""
@@ -55,7 +55,7 @@ open class OcaTimeSource: OcaAgent {
     propertyID: OcaPropertyID("3.5"),
     getMethodID: OcaMethodID("3.8"),
     setMethodID: OcaMethodID("3.9"),
-    ocp2Name: "ID",
+    ocp2GetName: "ID",
     ocp2SetName: "ID"
   )
   public var referenceID: OcaString = ""
@@ -70,7 +70,7 @@ open class OcaTimeSource: OcaAgent {
     propertyID: OcaPropertyID("3.7"),
     getMethodID: OcaMethodID("3.12"),
     setMethodID: OcaMethodID("3.13"),
-    ocp2Name: "Record",
+    ocp2GetName: "Record",
     ocp2SetName: "Record"
   )
   public var timeDeliveryParameters: OcaParameterRecord = "{}"

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/ApplicationNetworks/ApplicationNetwork.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/ApplicationNetworks/ApplicationNetwork.swift
@@ -42,7 +42,7 @@ open class OcaApplicationNetwork: OcaRoot, OcaOwnable, OcaLabelRepresentable {
     propertyID: OcaPropertyID("2.3"),
     getMethodID: OcaMethodID("2.4"),
     setMethodID: OcaMethodID("2.5"),
-    ocp2Name: "Name",
+    ocp2GetName: "Name",
     ocp2SetName: "Name"
   )
   public var serviceID: OcaApplicationNetworkServiceID = .init()
@@ -51,7 +51,7 @@ open class OcaApplicationNetwork: OcaRoot, OcaOwnable, OcaLabelRepresentable {
     propertyID: OcaPropertyID("2.4"),
     getMethodID: OcaMethodID("2.6"),
     setMethodID: OcaMethodID("2.7"),
-    ocp2Name: "SystemInterfaces",
+    ocp2GetName: "SystemInterfaces",
     ocp2SetName: "Descriptors"
   )
   public var systemInterfaces = [OcaNetworkSystemInterfaceDescriptor]()

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/ApplicationNetworks/ApplicationNetwork.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/ApplicationNetworks/ApplicationNetwork.swift
@@ -42,14 +42,17 @@ open class OcaApplicationNetwork: OcaRoot, OcaOwnable, OcaLabelRepresentable {
     propertyID: OcaPropertyID("2.3"),
     getMethodID: OcaMethodID("2.4"),
     setMethodID: OcaMethodID("2.5"),
-    ocp2Name: "Name"
+    ocp2Name: "Name",
+    ocp2SetName: "Name"
   )
   public var serviceID: OcaApplicationNetworkServiceID = .init()
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("2.4"),
     getMethodID: OcaMethodID("2.6"),
-    setMethodID: OcaMethodID("2.7")
+    setMethodID: OcaMethodID("2.7"),
+    ocp2Name: "SystemInterfaces",
+    ocp2SetName: "Descriptors"
   )
   public var systemInterfaces = [OcaNetworkSystemInterfaceDescriptor]()
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/ApplicationNetworks/ApplicationNetwork.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/ApplicationNetworks/ApplicationNetwork.swift
@@ -17,8 +17,13 @@
 import SwiftOCA
 
 open class OcaApplicationNetwork: OcaRoot, OcaOwnable, OcaLabelRepresentable {
-  override open class var classID: OcaClassID { OcaClassID("1.4") }
-  override open class var classVersion: OcaClassVersionNumber { 1 }
+  override open class var classID: OcaClassID {
+    OcaClassID("1.4")
+  }
+
+  override open class var classVersion: OcaClassVersionNumber {
+    1
+  }
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("2.1"),

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/ApplicationNetworks/ApplicationNetwork.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/ApplicationNetworks/ApplicationNetwork.swift
@@ -41,7 +41,8 @@ open class OcaApplicationNetwork: OcaRoot, OcaOwnable, OcaLabelRepresentable {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("2.3"),
     getMethodID: OcaMethodID("2.4"),
-    setMethodID: OcaMethodID("2.5")
+    setMethodID: OcaMethodID("2.5"),
+    ocp2Name: "Name"
   )
   public var serviceID: OcaApplicationNetworkServiceID = .init()
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/ApplicationNetworks/MediaTransportNetwork.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/ApplicationNetworks/MediaTransportNetwork.swift
@@ -34,7 +34,7 @@ open class OcaMediaTransportNetwork: OcaApplicationNetwork, OcaPortsRepresentabl
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.2"),
     getMethodID: OcaMethodID("3.2"),
-    ocp2Name: "OcaPorts"
+    ocp2GetName: "OcaPorts"
   )
   public var ports = [OcaPort]()
 
@@ -53,14 +53,14 @@ open class OcaMediaTransportNetwork: OcaApplicationNetwork, OcaPortsRepresentabl
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.5"),
     getMethodID: OcaMethodID("3.7"),
-    ocp2Name: "MaxPins"
+    ocp2GetName: "MaxPins"
   )
   public var maxPinsPerConnector: OcaUint16 = 0
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.6"),
     getMethodID: OcaMethodID("3.8"),
-    ocp2Name: "MaxPins"
+    ocp2GetName: "MaxPins"
   )
   public var maxPortsPerPin: OcaUint16 = 0
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/ApplicationNetworks/MediaTransportNetwork.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/ApplicationNetworks/MediaTransportNetwork.swift
@@ -27,14 +27,14 @@ open class OcaMediaTransportNetwork: OcaApplicationNetwork, OcaPortsRepresentabl
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.1"),
-    getMethodID: OcaMethodID("3.1"),
-    ocp2Name: "OcaPorts"
+    getMethodID: OcaMethodID("3.1")
   )
   public var `protocol`: OcaNetworkMediaProtocol = .none
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.2"),
-    getMethodID: OcaMethodID("3.2")
+    getMethodID: OcaMethodID("3.2"),
+    ocp2Name: "OcaPorts"
   )
   public var ports = [OcaPort]()
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/ApplicationNetworks/MediaTransportNetwork.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/ApplicationNetworks/MediaTransportNetwork.swift
@@ -27,7 +27,8 @@ open class OcaMediaTransportNetwork: OcaApplicationNetwork, OcaPortsRepresentabl
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.1"),
-    getMethodID: OcaMethodID("3.1")
+    getMethodID: OcaMethodID("3.1"),
+    ocp2Name: "OcaPorts"
   )
   public var `protocol`: OcaNetworkMediaProtocol = .none
 
@@ -51,13 +52,15 @@ open class OcaMediaTransportNetwork: OcaApplicationNetwork, OcaPortsRepresentabl
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.5"),
-    getMethodID: OcaMethodID("3.7")
+    getMethodID: OcaMethodID("3.7"),
+    ocp2Name: "MaxPins"
   )
   public var maxPinsPerConnector: OcaUint16 = 0
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.6"),
-    getMethodID: OcaMethodID("3.8")
+    getMethodID: OcaMethodID("3.8"),
+    ocp2Name: "MaxPins"
   )
   public var maxPortsPerPin: OcaUint16 = 0
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Dataset/Dataset.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Dataset/Dataset.swift
@@ -54,7 +54,7 @@ Sendable {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("2.5"),
     getMethodID: OcaMethodID("2.14"),
-    ocp2Name: "Time"
+    ocp2GetName: "Time"
   )
   public var lastModificationTime = OcaTime()
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Dataset/Dataset.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Dataset/Dataset.swift
@@ -53,7 +53,8 @@ Sendable {
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("2.5"),
-    getMethodID: OcaMethodID("2.14")
+    getMethodID: OcaMethodID("2.14"),
+    ocp2Name: "Time"
   )
   public var lastModificationTime = OcaTime()
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Managers/CodingManager.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Managers/CodingManager.swift
@@ -23,14 +23,14 @@ open class OcaCodingManager: OcaManager {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.1"),
     getMethodID: OcaMethodID("3.1"),
-    ocp2Name: "Schemes"
+    ocp2GetName: "Schemes"
   )
   public var availableEncodingSchemes: [OcaMediaCodingSchemeID: OcaString] = [:]
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.2"),
     getMethodID: OcaMethodID("3.2"),
-    ocp2Name: "Schemes"
+    ocp2GetName: "Schemes"
   )
   public var availableDecodingSchemes: [OcaMediaCodingSchemeID: OcaString] = [:]
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Managers/CodingManager.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Managers/CodingManager.swift
@@ -22,13 +22,15 @@ open class OcaCodingManager: OcaManager {
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.1"),
-    getMethodID: OcaMethodID("3.1")
+    getMethodID: OcaMethodID("3.1"),
+    ocp2Name: "Schemes"
   )
   public var availableEncodingSchemes: [OcaMediaCodingSchemeID: OcaString] = [:]
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.2"),
-    getMethodID: OcaMethodID("3.2")
+    getMethodID: OcaMethodID("3.2"),
+    ocp2Name: "Schemes"
   )
   public var availableDecodingSchemes: [OcaMediaCodingSchemeID: OcaString] = [:]
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Managers/DeviceManager.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Managers/DeviceManager.swift
@@ -27,7 +27,8 @@ open class OcaDeviceManager: OcaManager {
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.1"),
-    getMethodID: OcaMethodID("3.2")
+    getMethodID: OcaMethodID("3.2"),
+    ocp2Name: "GUID"
   )
   public var modelGUID = OcaModelGUID(
     reserved: 0,
@@ -43,7 +44,8 @@ open class OcaDeviceManager: OcaManager {
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.3"),
-    getMethodID: OcaMethodID("3.6")
+    getMethodID: OcaMethodID("3.6"),
+    ocp2Name: "Description"
   )
   public var modelDescription = OcaModelDescription(
     manufacturer: "PADL",
@@ -54,27 +56,31 @@ open class OcaDeviceManager: OcaManager {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.4"),
     getMethodID: OcaMethodID("3.4"),
-    setMethodID: OcaMethodID("3.5")
+    setMethodID: OcaMethodID("3.5"),
+    ocp2Name: "Name"
   )
   public var deviceName = ""
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.5"),
-    getMethodID: OcaMethodID("3.1")
+    getMethodID: OcaMethodID("3.1"),
+    ocp2Name: "OcaVersion"
   )
   public var version: OcaUint16 = OcaProtocolVersion.aes70_2024.rawValue
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.6"),
     getMethodID: OcaMethodID("3.7"),
-    setMethodID: OcaMethodID("3.8")
+    setMethodID: OcaMethodID("3.8"),
+    ocp2Name: "Role"
   )
   public var deviceRole = ""
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.7"),
     getMethodID: OcaMethodID("3.9"),
-    setMethodID: OcaMethodID("3.10")
+    setMethodID: OcaMethodID("3.10"),
+    ocp2Name: "Code"
   )
   public var userInventoryCode = ""
 
@@ -115,7 +121,8 @@ open class OcaDeviceManager: OcaManager {
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.14"),
-    getMethodID: OcaMethodID("3.20")
+    getMethodID: OcaMethodID("3.20"),
+    ocp2Name: "ID"
   )
   public var deviceRevisionID = ""
 
@@ -133,20 +140,23 @@ open class OcaDeviceManager: OcaManager {
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.17"),
-    getMethodID: OcaMethodID("3.23")
+    getMethodID: OcaMethodID("3.23"),
+    ocp2Name: "State"
   )
   public var operationalState = OcaDeviceOperationalState()
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.18"),
     getMethodID: OcaMethodID("3.24"),
-    setMethodID: OcaMethodID("3.25")
+    setMethodID: OcaMethodID("3.25"),
+    ocp2Name: "Enabled"
   )
   public var loggingEnabled = false
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.19"),
-    getMethodID: OcaMethodID("3.26")
+    getMethodID: OcaMethodID("3.26"),
+    ocp2Name: "ONo"
   )
   public var mostRecentPatchDatasetONo: OcaONo = OcaInvalidONo
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Managers/DeviceManager.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Managers/DeviceManager.swift
@@ -28,7 +28,7 @@ open class OcaDeviceManager: OcaManager {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.1"),
     getMethodID: OcaMethodID("3.2"),
-    ocp2Name: "GUID"
+    ocp2GetName: "GUID"
   )
   public var modelGUID = OcaModelGUID(
     reserved: 0,
@@ -45,7 +45,7 @@ open class OcaDeviceManager: OcaManager {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.3"),
     getMethodID: OcaMethodID("3.6"),
-    ocp2Name: "Description"
+    ocp2GetName: "Description"
   )
   public var modelDescription = OcaModelDescription(
     manufacturer: "PADL",
@@ -57,7 +57,7 @@ open class OcaDeviceManager: OcaManager {
     propertyID: OcaPropertyID("3.4"),
     getMethodID: OcaMethodID("3.4"),
     setMethodID: OcaMethodID("3.5"),
-    ocp2Name: "Name",
+    ocp2GetName: "Name",
     ocp2SetName: "Name"
   )
   public var deviceName = ""
@@ -65,7 +65,7 @@ open class OcaDeviceManager: OcaManager {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.5"),
     getMethodID: OcaMethodID("3.1"),
-    ocp2Name: "OcaVersion"
+    ocp2GetName: "OcaVersion"
   )
   public var version: OcaUint16 = OcaProtocolVersion.aes70_2024.rawValue
 
@@ -73,7 +73,7 @@ open class OcaDeviceManager: OcaManager {
     propertyID: OcaPropertyID("3.6"),
     getMethodID: OcaMethodID("3.7"),
     setMethodID: OcaMethodID("3.8"),
-    ocp2Name: "Role",
+    ocp2GetName: "Role",
     ocp2SetName: "Role"
   )
   public var deviceRole = ""
@@ -82,7 +82,7 @@ open class OcaDeviceManager: OcaManager {
     propertyID: OcaPropertyID("3.7"),
     getMethodID: OcaMethodID("3.9"),
     setMethodID: OcaMethodID("3.10"),
-    ocp2Name: "Code",
+    ocp2GetName: "Code",
     ocp2SetName: "Code"
   )
   public var userInventoryCode = ""
@@ -113,7 +113,7 @@ open class OcaDeviceManager: OcaManager {
     propertyID: OcaPropertyID("3.12"),
     getMethodID: OcaMethodID("3.17"),
     setMethodID: OcaMethodID("3.18"),
-    ocp2Name: "Message",
+    ocp2GetName: "Message",
     ocp2SetName: "Text"
   )
   public var message = ""
@@ -127,7 +127,7 @@ open class OcaDeviceManager: OcaManager {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.14"),
     getMethodID: OcaMethodID("3.20"),
-    ocp2Name: "ID"
+    ocp2GetName: "ID"
   )
   public var deviceRevisionID = ""
 
@@ -146,7 +146,7 @@ open class OcaDeviceManager: OcaManager {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.17"),
     getMethodID: OcaMethodID("3.23"),
-    ocp2Name: "State"
+    ocp2GetName: "State"
   )
   public var operationalState = OcaDeviceOperationalState()
 
@@ -154,7 +154,7 @@ open class OcaDeviceManager: OcaManager {
     propertyID: OcaPropertyID("3.18"),
     getMethodID: OcaMethodID("3.24"),
     setMethodID: OcaMethodID("3.25"),
-    ocp2Name: "Enabled",
+    ocp2GetName: "Enabled",
     ocp2SetName: "Enabled"
   )
   public var loggingEnabled = false
@@ -162,7 +162,7 @@ open class OcaDeviceManager: OcaManager {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.19"),
     getMethodID: OcaMethodID("3.26"),
-    ocp2Name: "ONo"
+    ocp2GetName: "ONo"
   )
   public var mostRecentPatchDatasetONo: OcaONo = OcaInvalidONo
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Managers/DeviceManager.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Managers/DeviceManager.swift
@@ -57,7 +57,8 @@ open class OcaDeviceManager: OcaManager {
     propertyID: OcaPropertyID("3.4"),
     getMethodID: OcaMethodID("3.4"),
     setMethodID: OcaMethodID("3.5"),
-    ocp2Name: "Name"
+    ocp2Name: "Name",
+    ocp2SetName: "Name"
   )
   public var deviceName = ""
 
@@ -72,7 +73,8 @@ open class OcaDeviceManager: OcaManager {
     propertyID: OcaPropertyID("3.6"),
     getMethodID: OcaMethodID("3.7"),
     setMethodID: OcaMethodID("3.8"),
-    ocp2Name: "Role"
+    ocp2Name: "Role",
+    ocp2SetName: "Role"
   )
   public var deviceRole = ""
 
@@ -80,7 +82,8 @@ open class OcaDeviceManager: OcaManager {
     propertyID: OcaPropertyID("3.7"),
     getMethodID: OcaMethodID("3.9"),
     setMethodID: OcaMethodID("3.10"),
-    ocp2Name: "Code"
+    ocp2Name: "Code",
+    ocp2SetName: "Code"
   )
   public var userInventoryCode = ""
 
@@ -109,7 +112,9 @@ open class OcaDeviceManager: OcaManager {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.12"),
     getMethodID: OcaMethodID("3.17"),
-    setMethodID: OcaMethodID("3.18")
+    setMethodID: OcaMethodID("3.18"),
+    ocp2Name: "Message",
+    ocp2SetName: "Text"
   )
   public var message = ""
 
@@ -149,7 +154,8 @@ open class OcaDeviceManager: OcaManager {
     propertyID: OcaPropertyID("3.18"),
     getMethodID: OcaMethodID("3.24"),
     setMethodID: OcaMethodID("3.25"),
-    ocp2Name: "Enabled"
+    ocp2Name: "Enabled",
+    ocp2SetName: "Enabled"
   )
   public var loggingEnabled = false
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Managers/DeviceTimeManager.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Managers/DeviceTimeManager.swift
@@ -32,7 +32,8 @@ open class OcaDeviceTimeManager: OcaManager {
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.1"),
-    getMethodID: OcaMethodID("3.3")
+    getMethodID: OcaMethodID("3.3"),
+    ocp2Name: "TimeSourceONos"
   )
   public var timeSources = [OcaTimeSource]()
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Managers/DeviceTimeManager.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Managers/DeviceTimeManager.swift
@@ -33,7 +33,7 @@ open class OcaDeviceTimeManager: OcaManager {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.1"),
     getMethodID: OcaMethodID("3.3"),
-    ocp2Name: "TimeSourceONos"
+    ocp2GetName: "TimeSourceONos"
   )
   public var timeSources = [OcaTimeSource]()
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Managers/MediaClockManager.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Managers/MediaClockManager.swift
@@ -23,14 +23,14 @@ open class OcaMediaClockManager: OcaManager {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.1"),
     getMethodID: OcaMethodID("3.2"),
-    ocp2Name: "MediaClockTypes"
+    ocp2GetName: "MediaClockTypes"
   )
   public var clockTypesSupported = [OcaMediaClockType]()
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.3"),
     getMethodID: OcaMethodID("3.3"),
-    ocp2Name: "Clocks"
+    ocp2GetName: "Clocks"
   )
   public var clock3s = [OcaMediaClock3]()
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Managers/MediaClockManager.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Managers/MediaClockManager.swift
@@ -22,13 +22,15 @@ open class OcaMediaClockManager: OcaManager {
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.1"),
-    getMethodID: OcaMethodID("3.2")
+    getMethodID: OcaMethodID("3.2"),
+    ocp2Name: "MediaClockTypes"
   )
   public var clockTypesSupported = [OcaMediaClockType]()
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.3"),
-    getMethodID: OcaMethodID("3.3")
+    getMethodID: OcaMethodID("3.3"),
+    ocp2Name: "Clocks"
   )
   public var clock3s = [OcaMediaClock3]()
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Managers/NetworkManager.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Managers/NetworkManager.swift
@@ -35,13 +35,15 @@ open class OcaNetworkManager: OcaManager {
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.5"),
-    getMethodID: OcaMethodID("3.5")
+    getMethodID: OcaMethodID("3.5"),
+    ocp2Name: "ONos"
   )
   public var networkInterfaces = [OcaNetworkInterface]()
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.6"),
-    getMethodID: OcaMethodID("3.6")
+    getMethodID: OcaMethodID("3.6"),
+    ocp2Name: "ONos"
   )
   public var networkApplications = [OcaNetworkApplication]()
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Managers/NetworkManager.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Managers/NetworkManager.swift
@@ -36,14 +36,14 @@ open class OcaNetworkManager: OcaManager {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.5"),
     getMethodID: OcaMethodID("3.5"),
-    ocp2Name: "ONos"
+    ocp2GetName: "ONos"
   )
   public var networkInterfaces = [OcaNetworkInterface]()
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.6"),
     getMethodID: OcaMethodID("3.6"),
-    ocp2Name: "ONos"
+    ocp2GetName: "ONos"
   )
   public var networkApplications = [OcaNetworkApplication]()
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Managers/SubscriptionManager.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Managers/SubscriptionManager.swift
@@ -272,7 +272,7 @@ public class OcaSubscriptionManager: OcaManager {
     _ command: Ocp1Command,
     from controller: any OcaController
   ) async throws -> Ocp1Response {
-    if command.parameters.format == .ocp2, Self.ev1MethodIDs.contains(command.methodID) {
+    if controller.controlProtocol != .ocp1, Self.ev1MethodIDs.contains(command.methodID) {
       throw Ocp1Error.status(.notImplemented)
     }
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Managers/SubscriptionManager.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Managers/SubscriptionManager.swift
@@ -262,10 +262,19 @@ public class OcaSubscriptionManager: OcaManager {
     state = .normal
   }
 
+  /// EV1 subscription methods; OCP.2 supports only EV2 (AES70-4 6.3.6.1)
+  private static let ev1MethodIDs: Set<OcaMethodID> = [
+    OcaMethodID("3.1"), OcaMethodID("3.2"), OcaMethodID("3.5"), OcaMethodID("3.6"),
+  ]
+
   override open func handleCommand(
     _ command: Ocp1Command,
     from controller: any OcaController
   ) async throws -> Ocp1Response {
+    if command.parameters.format == .ocp2, Self.ev1MethodIDs.contains(command.methodID) {
+      throw Ocp1Error.status(.notImplemented)
+    }
+
     switch command.methodID {
     case OcaMethodID("3.1"):
       let subscription: SwiftOCA.OcaSubscriptionManager

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Managers/SubscriptionManager.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Managers/SubscriptionManager.swift
@@ -253,13 +253,14 @@ public class OcaSubscriptionManager: OcaManager {
       emitterONo: objectNumber,
       eventID: SwiftOCA.OcaSubscriptionManager.SynchronizeStateEventID
     )
-    let parameters: Data = try Ocp1Encoder()
-      .encode(
-        OcaObjectListEventData(objectList: Array(objectsChangedWhilstNotificationsDisabled))
-      )
-    try await deviceDelegate?.notifySubscribers(event, parameters: parameters)
+    let parameters = OcaObjectListEventData(
+      objectList: Array(objectsChangedWhilstNotificationsDisabled)
+    )
     objectsChangedWhilstNotificationsDisabled.removeAll()
+    // notifications must be back on before SynchronizeState is emitted: while they are
+    // off the event saying what changed is itself queued as another change, not sent
     state = .normal
+    try await deviceDelegate?.notifySubscribers(event, eventData: parameters)
   }
 
   /// EV1 subscription methods; OCP.2 supports only EV2 (AES70-4 6.3.6.1)

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Networks/MediaTransportApplication.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Networks/MediaTransportApplication.swift
@@ -301,7 +301,10 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, OcaPortsRepresen
       try await delete(port: portID)
       return Ocp1Response()
     case OcaMethodID("3.4"):
-      return try await controller.encodeResponse(handleGetPortName(command, from: controller))
+      return try await controller.encodeResponse(
+        handleGetPortName(command, from: controller),
+        name: "Name"
+      )
     case OcaMethodID("3.5"):
       let params: OcaSetPortNameParameters = try decodeCommand(command)
       try await handleSetPortName(
@@ -318,33 +321,39 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, OcaPortsRepresen
       try await handleDeletePortClockMapEntry(command, from: controller)
       return Ocp1Response()
     case OcaMethodID("3.10"):
-      return try await controller.encodeResponse(handleGetPortClockMapEntry(command, from: controller))
+      return try await controller.encodeResponse(
+        handleGetPortClockMapEntry(command, from: controller),
+        name: "Entry"
+      )
     case OcaMethodID("3.11"):
       try decodeNullCommand(command)
       try await ensureReadable(by: controller, command: command)
-      return try controller.encodeResponse(Parameters.MaxEndpointCounts(
-        maxInputEndpoints: maxInputEndpoints,
-        maxOutputEndpoints: maxOutputEndpoints
-      ))
+      return try controller.encodeResponse(
+        Parameters.MaxEndpointCounts(
+          maxInputEndpoints: maxInputEndpoints,
+          maxOutputEndpoints: maxOutputEndpoints
+        ),
+        names: ["MaxInputCount", "MaxOutputCount"]
+      )
     case OcaMethodID("3.17"):
       let id: OcaID16 = try decodeCommand(command)
       try await ensureReadable(by: controller, command: command)
       guard let capability = mediaStreamModeCapabilities.first(where: { $0.id == id }) else {
         throw Ocp1Error.status(.parameterOutOfRange)
       }
-      return try controller.encodeResponse(capability)
+      return try controller.encodeResponse(capability, name: "Capability")
     case OcaMethodID("3.22"):
       let id: OcaMediaStreamEndpointID = try decodeCommand(command)
       try await ensureReadable(by: controller, command: command)
-      return try controller.encodeResponse(endpoint(id))
+      return try controller.encodeResponse(endpoint(id), name: "Endpoint")
     case OcaMethodID("3.24"):
       let id: OcaMediaStreamEndpointID = try decodeCommand(command)
       try await ensureReadable(by: controller, command: command)
-      return try controller.encodeResponse(endpointStatus(id))
+      return try controller.encodeResponse(endpointStatus(id), name: "Status")
     case OcaMethodID("3.25"):
       let endpoint: OcaMediaStreamEndpoint = try decodeCommand(command)
       try await ensureWritable(by: controller, command: command)
-      return try await controller.encodeResponse(add(endpoint: endpoint))
+      return try await controller.encodeResponse(add(endpoint: endpoint), name: "Endpoint")
     case OcaMethodID("3.26"):
       let id: OcaMediaStreamEndpointID = try decodeCommand(command)
       try await ensureWritable(by: controller, command: command)
@@ -390,7 +399,7 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, OcaPortsRepresen
     case OcaMethodID("3.35"):
       let id: OcaMediaStreamEndpointID = try decodeCommand(command)
       try await ensureReadable(by: controller, command: command)
-      return try controller.encodeResponse(endpointCounterSet(id))
+      return try controller.encodeResponse(endpointCounterSet(id), name: "CounterSet")
     case OcaMethodID("3.36"):
       let parameters: Parameters.EndpointCounterParameters = try decodeCommand(command)
       try await ensureReadable(by: controller, command: command)
@@ -399,7 +408,7 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, OcaPortsRepresen
       else {
         throw Ocp1Error.status(.parameterOutOfRange)
       }
-      return try controller.encodeResponse(counter)
+      return try controller.encodeResponse(counter, name: "Counter")
     case OcaMethodID("3.37"):
       let parameters: Parameters.EndpointCounterNotifierParameters = try decodeCommand(command)
       try await ensureWritable(by: controller, command: command)

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Networks/MediaTransportApplication.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Networks/MediaTransportApplication.swift
@@ -30,7 +30,7 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, OcaPortsRepresen
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.1"),
     getMethodID: OcaMethodID("3.3"),
-    ocp2Name: "OcaPorts"
+    ocp2GetName: "OcaPorts"
   )
   public var ports = [OcaPort]()
 
@@ -38,7 +38,7 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, OcaPortsRepresen
     propertyID: OcaPropertyID("3.2"),
     getMethodID: OcaMethodID("3.6"),
     setMethodID: OcaMethodID("3.7"),
-    ocp2Name: "Map",
+    ocp2GetName: "Map",
     ocp2SetName: "Map"
   )
   public var portClockMap = OcaMap<OcaPortID, OcaPortClockMapEntry>()
@@ -52,14 +52,14 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, OcaPortsRepresen
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.5"),
     getMethodID: OcaMethodID("3.12"),
-    ocp2Name: "Value"
+    ocp2GetName: "Value"
   )
   public var maxPortsPerChannel: OcaUint16 = 0
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.6"),
     getMethodID: OcaMethodID("3.13"),
-    ocp2Name: "Value"
+    ocp2GetName: "Value"
   )
   public var maxChannelsPerEndpoint: OcaUint16 = 0
 
@@ -67,7 +67,7 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, OcaPortsRepresen
     propertyID: OcaPropertyID("3.7"),
     getMethodID: OcaMethodID("3.15"),
     setMethodID: OcaMethodID("3.16"),
-    ocp2Name: "Capabilities",
+    ocp2GetName: "Capabilities",
     ocp2SetName: "Capabilities"
   )
   public var mediaStreamModeCapabilities = [OcaMediaStreamModeCapability]()
@@ -76,7 +76,7 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, OcaPortsRepresen
     propertyID: OcaPropertyID("3.8"),
     getMethodID: OcaMethodID("3.18"),
     setMethodID: OcaMethodID("3.19"),
-    ocp2Name: "Parameters",
+    ocp2GetName: "Parameters",
     ocp2SetName: "Parameters"
   )
   public var transportTimingParameters = OcaMediaTransportTimingParameters()
@@ -85,7 +85,7 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, OcaPortsRepresen
     propertyID: OcaPropertyID("3.9"),
     getMethodID: OcaMethodID("3.20"),
     setMethodID: OcaMethodID("3.14"),
-    ocp2Name: "Limits",
+    ocp2GetName: "Limits",
     ocp2SetName: "Limits"
   )
   public var alignmentLevelLimits = OcaInterval<OcaDBFS>(min: -20.0, max: -20.0)
@@ -99,14 +99,14 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, OcaPortsRepresen
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.11"),
     getMethodID: OcaMethodID("3.23"),
-    ocp2Name: "Statuses"
+    ocp2GetName: "Statuses"
   )
   public var endpointStatuses = OcaMediaStreamEndpointStatusMap()
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.12"),
     getMethodID: OcaMethodID("3.34"),
-    ocp2Name: "Sets"
+    ocp2GetName: "Sets"
   )
   public var endpointCounterSets = OcaMap<OcaID16, OcaCounterSet>()
 
@@ -114,7 +114,7 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, OcaPortsRepresen
     propertyID: OcaPropertyID("3.13"),
     getMethodID: OcaMethodID("3.40"),
     setMethodID: OcaMethodID("3.41"),
-    ocp2Name: "ONos",
+    ocp2GetName: "ONos",
     ocp2SetName: "ONos"
   )
   public var transportSessionControlAgentONos = [OcaONo]()

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Networks/MediaTransportApplication.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Networks/MediaTransportApplication.swift
@@ -38,7 +38,8 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, OcaPortsRepresen
     propertyID: OcaPropertyID("3.2"),
     getMethodID: OcaMethodID("3.6"),
     setMethodID: OcaMethodID("3.7"),
-    ocp2Name: "Map"
+    ocp2Name: "Map",
+    ocp2SetName: "Map"
   )
   public var portClockMap = OcaMap<OcaPortID, OcaPortClockMapEntry>()
 
@@ -66,7 +67,8 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, OcaPortsRepresen
     propertyID: OcaPropertyID("3.7"),
     getMethodID: OcaMethodID("3.15"),
     setMethodID: OcaMethodID("3.16"),
-    ocp2Name: "Capabilities"
+    ocp2Name: "Capabilities",
+    ocp2SetName: "Capabilities"
   )
   public var mediaStreamModeCapabilities = [OcaMediaStreamModeCapability]()
 
@@ -74,7 +76,8 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, OcaPortsRepresen
     propertyID: OcaPropertyID("3.8"),
     getMethodID: OcaMethodID("3.18"),
     setMethodID: OcaMethodID("3.19"),
-    ocp2Name: "Parameters"
+    ocp2Name: "Parameters",
+    ocp2SetName: "Parameters"
   )
   public var transportTimingParameters = OcaMediaTransportTimingParameters()
 
@@ -82,7 +85,8 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, OcaPortsRepresen
     propertyID: OcaPropertyID("3.9"),
     getMethodID: OcaMethodID("3.20"),
     setMethodID: OcaMethodID("3.14"),
-    ocp2Name: "Limits"
+    ocp2Name: "Limits",
+    ocp2SetName: "Limits"
   )
   public var alignmentLevelLimits = OcaInterval<OcaDBFS>(min: -20.0, max: -20.0)
 
@@ -110,7 +114,8 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, OcaPortsRepresen
     propertyID: OcaPropertyID("3.13"),
     getMethodID: OcaMethodID("3.40"),
     setMethodID: OcaMethodID("3.41"),
-    ocp2Name: "ONos"
+    ocp2Name: "ONos",
+    ocp2SetName: "ONos"
   )
   public var transportSessionControlAgentONos = [OcaONo]()
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Networks/MediaTransportApplication.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Networks/MediaTransportApplication.swift
@@ -29,14 +29,16 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, OcaPortsRepresen
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.1"),
-    getMethodID: OcaMethodID("3.3")
+    getMethodID: OcaMethodID("3.3"),
+    ocp2Name: "OcaPorts"
   )
   public var ports = [OcaPort]()
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.2"),
     getMethodID: OcaMethodID("3.6"),
-    setMethodID: OcaMethodID("3.7")
+    setMethodID: OcaMethodID("3.7"),
+    ocp2Name: "Map"
   )
   public var portClockMap = OcaMap<OcaPortID, OcaPortClockMapEntry>()
 
@@ -48,34 +50,39 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, OcaPortsRepresen
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.5"),
-    getMethodID: OcaMethodID("3.12")
+    getMethodID: OcaMethodID("3.12"),
+    ocp2Name: "Value"
   )
   public var maxPortsPerChannel: OcaUint16 = 0
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.6"),
-    getMethodID: OcaMethodID("3.13")
+    getMethodID: OcaMethodID("3.13"),
+    ocp2Name: "Value"
   )
   public var maxChannelsPerEndpoint: OcaUint16 = 0
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.7"),
     getMethodID: OcaMethodID("3.15"),
-    setMethodID: OcaMethodID("3.16")
+    setMethodID: OcaMethodID("3.16"),
+    ocp2Name: "Capabilities"
   )
   public var mediaStreamModeCapabilities = [OcaMediaStreamModeCapability]()
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.8"),
     getMethodID: OcaMethodID("3.18"),
-    setMethodID: OcaMethodID("3.19")
+    setMethodID: OcaMethodID("3.19"),
+    ocp2Name: "Parameters"
   )
   public var transportTimingParameters = OcaMediaTransportTimingParameters()
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.9"),
     getMethodID: OcaMethodID("3.20"),
-    setMethodID: OcaMethodID("3.14")
+    setMethodID: OcaMethodID("3.14"),
+    ocp2Name: "Limits"
   )
   public var alignmentLevelLimits = OcaInterval<OcaDBFS>(min: -20.0, max: -20.0)
 
@@ -87,20 +94,23 @@ open class OcaMediaTransportApplication: OcaNetworkApplication, OcaPortsRepresen
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.11"),
-    getMethodID: OcaMethodID("3.23")
+    getMethodID: OcaMethodID("3.23"),
+    ocp2Name: "Statuses"
   )
   public var endpointStatuses = OcaMediaStreamEndpointStatusMap()
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.12"),
-    getMethodID: OcaMethodID("3.34")
+    getMethodID: OcaMethodID("3.34"),
+    ocp2Name: "Sets"
   )
   public var endpointCounterSets = OcaMap<OcaID16, OcaCounterSet>()
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.13"),
     getMethodID: OcaMethodID("3.40"),
-    setMethodID: OcaMethodID("3.41")
+    setMethodID: OcaMethodID("3.41"),
+    ocp2Name: "ONos"
   )
   public var transportSessionControlAgentONos = [OcaONo]()
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Networks/NetworkApplication.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Networks/NetworkApplication.swift
@@ -41,20 +41,23 @@ open class OcaNetworkApplication: OcaRoot, OcaOwnable, OcaLabelRepresentable,
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("2.3"),
     getMethodID: OcaMethodID("2.5"),
-    setMethodID: OcaMethodID("2.6")
+    setMethodID: OcaMethodID("2.6"),
+    ocp2Name: "Assignments"
   )
   public var networkInterfaceAssignments = [OcaNetworkInterfaceAssignment]()
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("2.4"),
-    getMethodID: OcaMethodID("2.7")
+    getMethodID: OcaMethodID("2.7"),
+    ocp2Name: "Identifier"
   )
   public var adaptationIdentifier: OcaAdaptationIdentifier = ""
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("2.5"),
     getMethodID: OcaMethodID("2.8"),
-    setMethodID: OcaMethodID("2.9")
+    setMethodID: OcaMethodID("2.9"),
+    ocp2Name: "Data"
   )
   public var adaptationData: OcaAdaptationData = OcaBlob()
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Networks/NetworkApplication.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Networks/NetworkApplication.swift
@@ -42,7 +42,8 @@ open class OcaNetworkApplication: OcaRoot, OcaOwnable, OcaLabelRepresentable,
     propertyID: OcaPropertyID("2.3"),
     getMethodID: OcaMethodID("2.5"),
     setMethodID: OcaMethodID("2.6"),
-    ocp2Name: "Assignments"
+    ocp2Name: "Assignments",
+    ocp2SetName: "Assignments"
   )
   public var networkInterfaceAssignments = [OcaNetworkInterfaceAssignment]()
 
@@ -57,7 +58,8 @@ open class OcaNetworkApplication: OcaRoot, OcaOwnable, OcaLabelRepresentable,
     propertyID: OcaPropertyID("2.5"),
     getMethodID: OcaMethodID("2.8"),
     setMethodID: OcaMethodID("2.9"),
-    ocp2Name: "Data"
+    ocp2Name: "Data",
+    ocp2SetName: "Data"
   )
   public var adaptationData: OcaAdaptationData = OcaBlob()
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Networks/NetworkApplication.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Networks/NetworkApplication.swift
@@ -42,7 +42,7 @@ open class OcaNetworkApplication: OcaRoot, OcaOwnable, OcaLabelRepresentable,
     propertyID: OcaPropertyID("2.3"),
     getMethodID: OcaMethodID("2.5"),
     setMethodID: OcaMethodID("2.6"),
-    ocp2Name: "Assignments",
+    ocp2GetName: "Assignments",
     ocp2SetName: "Assignments"
   )
   public var networkInterfaceAssignments = [OcaNetworkInterfaceAssignment]()
@@ -50,7 +50,7 @@ open class OcaNetworkApplication: OcaRoot, OcaOwnable, OcaLabelRepresentable,
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("2.4"),
     getMethodID: OcaMethodID("2.7"),
-    ocp2Name: "Identifier"
+    ocp2GetName: "Identifier"
   )
   public var adaptationIdentifier: OcaAdaptationIdentifier = ""
 
@@ -58,7 +58,7 @@ open class OcaNetworkApplication: OcaRoot, OcaOwnable, OcaLabelRepresentable,
     propertyID: OcaPropertyID("2.5"),
     getMethodID: OcaMethodID("2.8"),
     setMethodID: OcaMethodID("2.9"),
-    ocp2Name: "Data",
+    ocp2GetName: "Data",
     ocp2SetName: "Data"
   )
   public var adaptationData: OcaAdaptationData = OcaBlob()

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Networks/NetworkApplication.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Networks/NetworkApplication.swift
@@ -87,7 +87,7 @@ open class OcaNetworkApplication: OcaRoot, OcaOwnable, OcaLabelRepresentable,
     case OcaMethodID("2.11"):
       let id: OcaID16 = try decodeCommand(command)
       try await ensureReadable(by: controller, command: command)
-      return try controller.encodeResponse(counter(id: id))
+      return try controller.encodeResponse(counter(id: id), name: "Counter")
     case OcaMethodID("2.12"):
       let parameters: OcaCounterNotifierParameters = try decodeCommand(command)
       try await ensureWritable(by: controller, command: command)

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Networks/NetworkInterface.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Networks/NetworkInterface.swift
@@ -136,7 +136,7 @@ open class OcaNetworkInterface: OcaRoot, OcaOwnable, OcaLabelRepresentable,
     case OcaMethodID("2.21"):
       let id: OcaID16 = try decodeCommand(command)
       try await ensureReadable(by: controller, command: command)
-      return try controller.encodeResponse(counter(id: id))
+      return try controller.encodeResponse(counter(id: id), name: "Counter")
     case OcaMethodID("2.22"):
       let parameters: OcaCounterNotifierParameters = try decodeCommand(command)
       try await ensureWritable(by: controller, command: command)

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Networks/NetworkInterface.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Networks/NetworkInterface.swift
@@ -48,7 +48,9 @@ open class OcaNetworkInterface: OcaRoot, OcaOwnable, OcaLabelRepresentable,
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("2.4"),
     getMethodID: OcaMethodID("2.7"),
-    setMethodID: OcaMethodID("2.8")
+    setMethodID: OcaMethodID("2.8"),
+    ocp2Name: "Name",
+    ocp2SetName: "Identifier"
   )
   public var systemIOInterfaceName = ""
 
@@ -56,7 +58,8 @@ open class OcaNetworkInterface: OcaRoot, OcaOwnable, OcaLabelRepresentable,
     propertyID: OcaPropertyID("2.5"),
     getMethodID: OcaMethodID("2.9"),
     setMethodID: OcaMethodID("2.10"),
-    ocp2Name: "Id"
+    ocp2Name: "Id",
+    ocp2SetName: "Id"
   )
   public var groupID: OcaUint16 = 0
 
@@ -85,7 +88,8 @@ open class OcaNetworkInterface: OcaRoot, OcaOwnable, OcaLabelRepresentable,
     propertyID: OcaPropertyID("2.9"),
     getMethodID: OcaMethodID("2.15"),
     setMethodID: OcaMethodID("2.16"),
-    ocp2Name: "Settings"
+    ocp2Name: "Settings",
+    ocp2SetName: "Settings"
   )
   public var requestedAdaptationData: OcaAdaptationData = OcaBlob()
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Networks/NetworkInterface.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Networks/NetworkInterface.swift
@@ -49,7 +49,7 @@ open class OcaNetworkInterface: OcaRoot, OcaOwnable, OcaLabelRepresentable,
     propertyID: OcaPropertyID("2.4"),
     getMethodID: OcaMethodID("2.7"),
     setMethodID: OcaMethodID("2.8"),
-    ocp2Name: "Name",
+    ocp2GetName: "Name",
     ocp2SetName: "Identifier"
   )
   public var systemIOInterfaceName = ""
@@ -58,7 +58,7 @@ open class OcaNetworkInterface: OcaRoot, OcaOwnable, OcaLabelRepresentable,
     propertyID: OcaPropertyID("2.5"),
     getMethodID: OcaMethodID("2.9"),
     setMethodID: OcaMethodID("2.10"),
-    ocp2Name: "Id",
+    ocp2GetName: "Id",
     ocp2SetName: "Id"
   )
   public var groupID: OcaUint16 = 0
@@ -73,14 +73,14 @@ open class OcaNetworkInterface: OcaRoot, OcaOwnable, OcaLabelRepresentable,
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("2.7"),
     getMethodID: OcaMethodID("2.13"),
-    ocp2Name: "Identifier"
+    ocp2GetName: "Identifier"
   )
   public var adaptationIdentifier: OcaAdaptationIdentifier = ""
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("2.8"),
     getMethodID: OcaMethodID("2.14"),
-    ocp2Name: "Settings"
+    ocp2GetName: "Settings"
   )
   public var currentAdaptationData: OcaAdaptationData = OcaBlob()
 
@@ -88,7 +88,7 @@ open class OcaNetworkInterface: OcaRoot, OcaOwnable, OcaLabelRepresentable,
     propertyID: OcaPropertyID("2.9"),
     getMethodID: OcaMethodID("2.15"),
     setMethodID: OcaMethodID("2.16"),
-    ocp2Name: "Settings",
+    ocp2GetName: "Settings",
     ocp2SetName: "Settings"
   )
   public var requestedAdaptationData: OcaAdaptationData = OcaBlob()
@@ -96,7 +96,7 @@ open class OcaNetworkInterface: OcaRoot, OcaOwnable, OcaLabelRepresentable,
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("2.10"),
     getMethodID: OcaMethodID("2.17"),
-    ocp2Name: "Pending"
+    ocp2GetName: "Pending"
   )
   public var networkSettingPending = false
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Networks/NetworkInterface.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Networks/NetworkInterface.swift
@@ -55,7 +55,8 @@ open class OcaNetworkInterface: OcaRoot, OcaOwnable, OcaLabelRepresentable,
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("2.5"),
     getMethodID: OcaMethodID("2.9"),
-    setMethodID: OcaMethodID("2.10")
+    setMethodID: OcaMethodID("2.10"),
+    ocp2Name: "Id"
   )
   public var groupID: OcaUint16 = 0
 
@@ -68,26 +69,30 @@ open class OcaNetworkInterface: OcaRoot, OcaOwnable, OcaLabelRepresentable,
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("2.7"),
-    getMethodID: OcaMethodID("2.13")
+    getMethodID: OcaMethodID("2.13"),
+    ocp2Name: "Identifier"
   )
   public var adaptationIdentifier: OcaAdaptationIdentifier = ""
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("2.8"),
-    getMethodID: OcaMethodID("2.14")
+    getMethodID: OcaMethodID("2.14"),
+    ocp2Name: "Settings"
   )
   public var currentAdaptationData: OcaAdaptationData = OcaBlob()
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("2.9"),
     getMethodID: OcaMethodID("2.15"),
-    setMethodID: OcaMethodID("2.16")
+    setMethodID: OcaMethodID("2.16"),
+    ocp2Name: "Settings"
   )
   public var requestedAdaptationData: OcaAdaptationData = OcaBlob()
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("2.10"),
-    getMethodID: OcaMethodID("2.17")
+    getMethodID: OcaMethodID("2.17"),
+    ocp2Name: "Pending"
   )
   public var networkSettingPending = false
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Root+Commands.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Root+Commands.swift
@@ -14,9 +14,18 @@
 // limitations under the License.
 //
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 @_spi(SwiftOCAPrivate)
 import SwiftOCA
 
+/// The format a command arrived in, and so the format its response must take. Bound
+/// by `OcaDevice.handleCommand` around dispatch so the per-class `handleCommand`
+/// overrides need not know which protocol the controller speaks. `responseNames`
+/// names an OCP.2 response's parameters (see `Ocp2Encoder.encodeParameters`).
 public extension OcaRoot {
   private nonisolated static func _logUnexpectedParameterCount(
     _ command: Ocp1Command,
@@ -32,13 +41,28 @@ public extension OcaRoot {
   nonisolated static func decodeCommand<U: Decodable>(
     _ command: Ocp1Command
   ) throws -> U {
-    let responseParameterCount = _ocp1ParameterCount(type: U.self)
-    let response = try Ocp1Decoder().decode(U.self, from: command.parameters.parameterData)
-    if command.parameters.parameterCount != responseParameterCount {
-      _logUnexpectedParameterCount(command, expected: responseParameterCount)
-      throw Ocp1Error.status(.parameterOutOfRange)
+    switch command.parameters.format {
+    case .ocp1:
+      let responseParameterCount = _ocp1ParameterCount(type: U.self)
+      let response = try Ocp1Decoder().decode(U.self, from: command.parameters.parameterData)
+      if command.parameters.parameterCount != responseParameterCount {
+        _logUnexpectedParameterCount(command, expected: responseParameterCount)
+        throw Ocp1Error.status(.parameterOutOfRange)
+      }
+      return response
+    case .ocp2:
+      #if NonEmbeddedBuild
+      do {
+        return try Ocp2Decoder().decodeParameters(U.self, from: command.parameters.parameterData)
+      } catch let error as Ocp1Error {
+        throw error
+      } catch {
+        throw Ocp1Error.status(.parameterError)
+      }
+      #else
+      throw Ocp1Error.unsupportedControlProtocol
+      #endif
     }
-    return response
   }
 
   final nonisolated func decodeCommand<U: Decodable>(
@@ -67,23 +91,40 @@ public extension OcaRoot {
 }
 
 public extension OcaController {
-  /// Encodes a response in the protocol this controller speaks. `names` names the
-  /// response's parameters, for a protocol that names them; OCP.1 does not.
+  /// Encodes a response in the protocol this controller speaks. On OCP.2 the
+  /// parameters are named by `names`, else derived from the value's field names; a
+  /// scalar without a name goes out as `Ocp2Naming.unnamedParameter`.
   nonisolated func encodeResponse<T: Encodable>(
     _ parameters: T,
     names: [String]? = nil,
     statusCode: OcaStatus = .ok
   ) throws -> Ocp1Response {
-    let parameterCount = _ocp1ParameterCount(type: T.self)
-    let encoder = Ocp1Encoder()
-    let parameters = try Ocp1Parameters(
-      parameterCount: parameterCount,
-      parameterData: encoder.encode(parameters)
-    )
-    return Ocp1Response(statusCode: statusCode, parameters: parameters)
+    switch controlProtocol {
+    case .ocp1:
+      let parameterCount = _ocp1ParameterCount(type: T.self)
+      let encoder = Ocp1Encoder()
+      let parameters = try Ocp1Parameters(
+        parameterCount: parameterCount,
+        parameterData: encoder.encode(parameters)
+      )
+      return Ocp1Response(statusCode: statusCode, parameters: parameters)
+    case .ocp2:
+      #if NonEmbeddedBuild
+      let object = try Ocp2Encoder().encodeParameters(
+        parameters,
+        parameterNames: names
+      )
+      let parameters = try Ocp1Parameters(
+        ocp2ParameterData: object.isEmpty ? Data() : Ocp2JSON.serialize(object)
+      )
+      return Ocp1Response(statusCode: statusCode, parameters: parameters)
+      #else
+      throw Ocp1Error.unsupportedControlProtocol
+      #endif
+    }
   }
 
-  /// A single-parameter response whose name, for a protocol that names it, is `name`.
+  /// A single-parameter response whose OCP.2 name is `name`.
   nonisolated func encodeResponse(
     _ parameter: some Encodable,
     name: String,

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Root+Commands.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Root+Commands.swift
@@ -53,7 +53,7 @@ public extension OcaRoot {
     case .ocp2:
       #if NonEmbeddedBuild
       do {
-        return try Ocp2Decoder().decodeParameters(U.self, from: command.parameters.parameterData)
+        return try Ocp2Decoder().decodeParameters(U.self, from: command.parameters.ocp2Parameters)
       } catch let error as Ocp1Error {
         throw error
       } catch {
@@ -114,10 +114,7 @@ public extension OcaController {
         parameters,
         parameterNames: names
       )
-      let parameters = try Ocp1Parameters(
-        ocp2ParameterData: object.isEmpty ? Data() : Ocp2JSON.serialize(object)
-      )
-      return Ocp1Response(statusCode: statusCode, parameters: parameters)
+      return Ocp1Response(statusCode: statusCode, parameters: Ocp1Parameters(ocp2Parameters: object))
       #else
       throw Ocp1Error.unsupportedControlProtocol
       #endif

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Root.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Root.swift
@@ -193,7 +193,11 @@ open class OcaRoot: CustomStringConvertible, Codable, Sendable, _OcaObjectKeyPat
     case .getter:
       try decodeNullCommand(command)
       try await ensureReadable(by: controller, command: command)
-      return try await property.getResponse(for: controller, names: nil)
+      // name the response's parameters after the property
+      return try await property.getResponse(
+        for: controller,
+        names: property.responseNames(propertyName: method.2)
+      )
     case .setter:
       try await ensureWritable(by: controller, command: command)
       try await property.set(object: self, command: command)
@@ -218,7 +222,7 @@ open class OcaRoot: CustomStringConvertible, Codable, Sendable, _OcaObjectKeyPat
       return try controller.encodeResponse(response)
     case OcaMethodID("1.2"):
       try decodeNullCommand(command)
-      return try controller.encodeResponse(lockable, name: "lockable")
+      return try controller.encodeResponse(lockable, name: "Lockable")
     case OcaMethodID("1.3"):
       try decodeNullCommand(command)
       try await lockNoReadWrite(controller: controller)
@@ -583,7 +587,8 @@ private final class OcaDevicePropertyKeyPathCache: Sendable {
 
   private struct CacheEntry: Sendable {
     let keyPaths: [String: AnyKeyPath]
-    let methods: [OcaMethodID: (AccessorType, AnyKeyPath)]
+    /// accessor kind, key path, and the property's Swift name
+    let methods: [OcaMethodID: (AccessorType, AnyKeyPath, String)]
 
     private init(keyPaths: [String: AnyKeyPath], object: some OcaRoot) {
       self.keyPaths = keyPaths
@@ -592,10 +597,10 @@ private final class OcaDevicePropertyKeyPathCache: Sendable {
           return
         }
         if let getMethodID = value.getMethodID {
-          $0[getMethodID] = (.getter, $1.value)
+          $0[getMethodID] = (.getter, $1.value, $1.key)
         }
         if let setMethodID = value.setMethodID {
-          $0[setMethodID] = (.setter, $1.value)
+          $0[setMethodID] = (.setter, $1.value, $1.key)
         }
       }
     }
@@ -633,7 +638,7 @@ private final class OcaDevicePropertyKeyPathCache: Sendable {
   fileprivate func lookupMethod(
     _ methodID: OcaMethodID,
     for object: some OcaRoot
-  ) -> (AccessorType, AnyKeyPath)? {
+  ) -> (AccessorType, AnyKeyPath, String)? {
     cacheEntry(for: object).methods[methodID]
   }
 }

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/Delay.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/Delay.swift
@@ -27,7 +27,7 @@ open class OcaDelay: OcaActuator {
     propertyID: OcaPropertyID("4.1"),
     getMethodID: OcaMethodID("4.1"),
     setMethodID: OcaMethodID("4.2"),
-    ocp2Name: "Time",
+    ocp2GetName: "Time",
     ocp2SetName: "Time"
   )
   public var delayTime = OcaBoundedPropertyValue<OcaTimeInterval>(value: 0, in: 0...1)
@@ -42,7 +42,7 @@ open class OcaDelayExtended: OcaDelay {
     propertyID: OcaPropertyID("5.1"),
     getMethodID: OcaMethodID("5.1"),
     setMethodID: OcaMethodID("5.2"),
-    ocp2Name: "Value",
+    ocp2GetName: "Value",
     ocp2SetName: "Value"
   )
   public var delayValue = OcaBoundedPropertyValue<OcaDelayValue>(

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/Delay.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/Delay.swift
@@ -37,7 +37,8 @@ open class OcaDelayExtended: OcaDelay {
   @OcaBoundedDeviceProperty(
     propertyID: OcaPropertyID("5.1"),
     getMethodID: OcaMethodID("5.1"),
-    setMethodID: OcaMethodID("5.2")
+    setMethodID: OcaMethodID("5.2"),
+    ocp2Name: "Value"
   )
   public var delayValue = OcaBoundedPropertyValue<OcaDelayValue>(
     value: OcaDelayValue(delayValue: 0, delayUnit: .time),

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/Delay.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/Delay.swift
@@ -21,10 +21,14 @@ open class OcaDelay: OcaActuator {
   override open class var classVersion: OcaClassVersionNumber { 3 }
 
   /// delay in seconds
+  // the model names the setter's parameter `delayTime` where its getter says `Time`;
+  // OcaDelayExtended is self-consistent, so the difference is with the committee
   @OcaBoundedDeviceProperty(
     propertyID: OcaPropertyID("4.1"),
     getMethodID: OcaMethodID("4.1"),
-    setMethodID: OcaMethodID("4.2")
+    setMethodID: OcaMethodID("4.2"),
+    ocp2Name: "Time",
+    ocp2SetName: "Time"
   )
   public var delayTime = OcaBoundedPropertyValue<OcaTimeInterval>(value: 0, in: 0...1)
 }
@@ -38,7 +42,8 @@ open class OcaDelayExtended: OcaDelay {
     propertyID: OcaPropertyID("5.1"),
     getMethodID: OcaMethodID("5.1"),
     setMethodID: OcaMethodID("5.2"),
-    ocp2Name: "Value"
+    ocp2Name: "Value",
+    ocp2SetName: "Value"
   )
   public var delayValue = OcaBoundedPropertyValue<OcaDelayValue>(
     value: OcaDelayValue(delayValue: 0, delayUnit: .time),

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/Dynamics.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/Dynamics.swift
@@ -345,14 +345,14 @@ open class OcaDynamicsCurve: OcaActuator {
       try await ensureReadable(by: controller, command: command)
       return try controller.encodeResponse(
         _float32ListParameters(slopes, in: slopeRange),
-        names: ["Slopes", "minSlope", "maxSlope"]
+        names: ["Slopes", "MinSlope", "MaxSlope"]
       )
     case OcaMethodID("4.7"):
       try decodeNullCommand(command)
       try await ensureReadable(by: controller, command: command)
       return try controller.encodeResponse(
         _float32ListParameters(kneeParameters, in: kneeParameterRange),
-        names: ["Parameters", "minParameter", "maxParameter"]
+        names: ["Parameters", "MinParameter", "MaxParameter"]
       )
     case OcaMethodID("4.13"):
       let parameters: SwiftOCA.OcaDynamicsCurve.SetMultipleParameters =

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/Dynamics.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/Dynamics.swift
@@ -32,7 +32,7 @@ open class OcaDynamics: OcaActuator {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.2"),
-    ocp2Name: "Gain"
+    ocp2GetName: "Gain"
   )
   public var dynamicGain: OcaDB = 0.0
 
@@ -40,7 +40,7 @@ open class OcaDynamics: OcaActuator {
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.3"),
     setMethodID: OcaMethodID("4.4"),
-    ocp2Name: "Func",
+    ocp2GetName: "Func",
     ocp2SetName: "Func"
   )
   public var function: OcaDynamicsFunction = .none
@@ -64,7 +64,7 @@ open class OcaDynamics: OcaActuator {
     propertyID: OcaPropertyID("4.6"),
     getMethodID: OcaMethodID("4.9"),
     setMethodID: OcaMethodID("4.10"),
-    ocp2Name: "Units",
+    ocp2GetName: "Units",
     ocp2SetName: "Units"
   )
   public var thresholdPresentationUnits: OcaPresentationUnit = .dBu
@@ -73,7 +73,7 @@ open class OcaDynamics: OcaActuator {
     propertyID: OcaPropertyID("4.7"),
     getMethodID: OcaMethodID("4.11"),
     setMethodID: OcaMethodID("4.12"),
-    ocp2Name: "Law",
+    ocp2GetName: "Law",
     ocp2SetName: "Law"
   )
   public var detectorLaw: OcaLevelDetectionLaw = .none
@@ -82,7 +82,7 @@ open class OcaDynamics: OcaActuator {
     propertyID: OcaPropertyID("4.8"),
     getMethodID: OcaMethodID("4.13"),
     setMethodID: OcaMethodID("4.14"),
-    ocp2Name: "Time",
+    ocp2GetName: "Time",
     ocp2SetName: "Time"
   )
   public var attackTime = OcaBoundedPropertyValue<OcaTimeInterval>(value: 0, in: 0...1)
@@ -91,7 +91,7 @@ open class OcaDynamics: OcaActuator {
     propertyID: OcaPropertyID("4.9"),
     getMethodID: OcaMethodID("4.15"),
     setMethodID: OcaMethodID("4.16"),
-    ocp2Name: "Time",
+    ocp2GetName: "Time",
     ocp2SetName: "Time"
   )
   public var releaseTime = OcaBoundedPropertyValue<OcaTimeInterval>(value: 0, in: 0...1)
@@ -100,7 +100,7 @@ open class OcaDynamics: OcaActuator {
     propertyID: OcaPropertyID("4.10"),
     getMethodID: OcaMethodID("4.17"),
     setMethodID: OcaMethodID("4.18"),
-    ocp2Name: "Time",
+    ocp2GetName: "Time",
     ocp2SetName: "Time"
   )
   public var holdTime = OcaBoundedPropertyValue<OcaTimeInterval>(value: 0, in: 0...1)
@@ -109,7 +109,7 @@ open class OcaDynamics: OcaActuator {
     propertyID: OcaPropertyID("4.11"),
     getMethodID: OcaMethodID("4.21"),
     setMethodID: OcaMethodID("4.22"),
-    ocp2Name: "Limit",
+    ocp2GetName: "Limit",
     ocp2SetName: "Limit"
   )
   public var dynamicGainCeiling = OcaBoundedPropertyValue<OcaDB>(
@@ -121,7 +121,7 @@ open class OcaDynamics: OcaActuator {
     propertyID: OcaPropertyID("4.12"),
     getMethodID: OcaMethodID("4.19"),
     setMethodID: OcaMethodID("4.20"),
-    ocp2Name: "Limit",
+    ocp2GetName: "Limit",
     ocp2SetName: "Limit"
   )
   public var dynamicGainFloor = OcaBoundedPropertyValue<OcaDB>(
@@ -134,7 +134,7 @@ open class OcaDynamics: OcaActuator {
     propertyID: OcaPropertyID("4.13"),
     getMethodID: OcaMethodID("4.23"),
     setMethodID: OcaMethodID("4.24"),
-    ocp2Name: "Parameter",
+    ocp2GetName: "Parameter",
     ocp2SetName: "Parameter"
   )
   public var kneeParameter = OcaBoundedPropertyValue<OcaFloat32>(value: 0, in: 0...1)
@@ -210,7 +210,7 @@ open class OcaDynamicsDetector: OcaActuator {
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.3"),
     setMethodID: OcaMethodID("4.4"),
-    ocp2Name: "Time",
+    ocp2GetName: "Time",
     ocp2SetName: "Time"
   )
   public var attackTime = OcaBoundedPropertyValue<OcaTimeInterval>(value: 0, in: 0...1)
@@ -219,7 +219,7 @@ open class OcaDynamicsDetector: OcaActuator {
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.5"),
     setMethodID: OcaMethodID("4.6"),
-    ocp2Name: "Time",
+    ocp2GetName: "Time",
     ocp2SetName: "Time"
   )
   public var releaseTime = OcaBoundedPropertyValue<OcaTimeInterval>(value: 0, in: 0...1)
@@ -228,7 +228,7 @@ open class OcaDynamicsDetector: OcaActuator {
     propertyID: OcaPropertyID("4.4"),
     getMethodID: OcaMethodID("4.7"),
     setMethodID: OcaMethodID("4.8"),
-    ocp2Name: "Time",
+    ocp2GetName: "Time",
     ocp2SetName: "Time"
   )
   public var holdTime = OcaBoundedPropertyValue<OcaTimeInterval>(value: 0, in: 0...1)
@@ -279,7 +279,7 @@ open class OcaDynamicsCurve: OcaActuator {
     propertyID: OcaPropertyID("4.1"),
     getMethodID: OcaMethodID("4.1"),
     setMethodID: OcaMethodID("4.2"),
-    ocp2Name: "NSegments",
+    ocp2GetName: "NSegments",
     ocp2SetName: "NSegments"
   )
   public var nSegments = OcaBoundedPropertyValue<OcaUint8>(value: 1, in: 1...8)
@@ -289,7 +289,7 @@ open class OcaDynamicsCurve: OcaActuator {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("4.2"),
     setMethodID: OcaMethodID("4.4"),
-    ocp2Name: "Threshold",
+    ocp2GetName: "Threshold",
     ocp2SetName: "Threshold"
   )
   public var thresholds: OcaList<OcaDBr> = []
@@ -299,7 +299,7 @@ open class OcaDynamicsCurve: OcaActuator {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("4.3"),
     setMethodID: OcaMethodID("4.6"),
-    ocp2Name: "Slope",
+    ocp2GetName: "Slope",
     ocp2SetName: "Slope"
   )
   public var slopes: OcaList<OcaFloat32> = []
@@ -309,7 +309,7 @@ open class OcaDynamicsCurve: OcaActuator {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("4.4"),
     setMethodID: OcaMethodID("4.8"),
-    ocp2Name: "Parameters",
+    ocp2GetName: "Parameters",
     ocp2SetName: "Parameters"
   )
   public var kneeParameters: OcaList<OcaFloat32> = []
@@ -318,7 +318,7 @@ open class OcaDynamicsCurve: OcaActuator {
     propertyID: OcaPropertyID("4.5"),
     getMethodID: OcaMethodID("4.11"),
     setMethodID: OcaMethodID("4.12"),
-    ocp2Name: "Gain",
+    ocp2GetName: "Gain",
     ocp2SetName: "Gain"
   )
   public var dynamicGainFloor = OcaBoundedPropertyValue<OcaDB>(
@@ -330,7 +330,7 @@ open class OcaDynamicsCurve: OcaActuator {
     propertyID: OcaPropertyID("4.6"),
     getMethodID: OcaMethodID("4.9"),
     setMethodID: OcaMethodID("4.10"),
-    ocp2Name: "Gain",
+    ocp2GetName: "Gain",
     ocp2SetName: "Gain"
   )
   public var dynamicGainCeiling = OcaBoundedPropertyValue<OcaDB>(

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/Dynamics.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/Dynamics.swift
@@ -31,14 +31,16 @@ open class OcaDynamics: OcaActuator {
   /// the instantaneous gain of the dynamics element
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("4.2"),
-    getMethodID: OcaMethodID("4.2")
+    getMethodID: OcaMethodID("4.2"),
+    ocp2Name: "Gain"
   )
   public var dynamicGain: OcaDB = 0.0
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.3"),
-    setMethodID: OcaMethodID("4.4")
+    setMethodID: OcaMethodID("4.4"),
+    ocp2Name: "Func"
   )
   public var function: OcaDynamicsFunction = .none
 
@@ -60,42 +62,48 @@ open class OcaDynamics: OcaActuator {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("4.6"),
     getMethodID: OcaMethodID("4.9"),
-    setMethodID: OcaMethodID("4.10")
+    setMethodID: OcaMethodID("4.10"),
+    ocp2Name: "Units"
   )
   public var thresholdPresentationUnits: OcaPresentationUnit = .dBu
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("4.7"),
     getMethodID: OcaMethodID("4.11"),
-    setMethodID: OcaMethodID("4.12")
+    setMethodID: OcaMethodID("4.12"),
+    ocp2Name: "Law"
   )
   public var detectorLaw: OcaLevelDetectionLaw = .none
 
   @OcaBoundedDeviceProperty(
     propertyID: OcaPropertyID("4.8"),
     getMethodID: OcaMethodID("4.13"),
-    setMethodID: OcaMethodID("4.14")
+    setMethodID: OcaMethodID("4.14"),
+    ocp2Name: "Time"
   )
   public var attackTime = OcaBoundedPropertyValue<OcaTimeInterval>(value: 0, in: 0...1)
 
   @OcaBoundedDeviceProperty(
     propertyID: OcaPropertyID("4.9"),
     getMethodID: OcaMethodID("4.15"),
-    setMethodID: OcaMethodID("4.16")
+    setMethodID: OcaMethodID("4.16"),
+    ocp2Name: "Time"
   )
   public var releaseTime = OcaBoundedPropertyValue<OcaTimeInterval>(value: 0, in: 0...1)
 
   @OcaBoundedDeviceProperty(
     propertyID: OcaPropertyID("4.10"),
     getMethodID: OcaMethodID("4.17"),
-    setMethodID: OcaMethodID("4.18")
+    setMethodID: OcaMethodID("4.18"),
+    ocp2Name: "Time"
   )
   public var holdTime = OcaBoundedPropertyValue<OcaTimeInterval>(value: 0, in: 0...1)
 
   @OcaBoundedDeviceProperty(
     propertyID: OcaPropertyID("4.11"),
     getMethodID: OcaMethodID("4.21"),
-    setMethodID: OcaMethodID("4.22")
+    setMethodID: OcaMethodID("4.22"),
+    ocp2Name: "Limit"
   )
   public var dynamicGainCeiling = OcaBoundedPropertyValue<OcaDB>(
     value: 0.0,
@@ -105,7 +113,8 @@ open class OcaDynamics: OcaActuator {
   @OcaBoundedDeviceProperty(
     propertyID: OcaPropertyID("4.12"),
     getMethodID: OcaMethodID("4.19"),
-    setMethodID: OcaMethodID("4.20")
+    setMethodID: OcaMethodID("4.20"),
+    ocp2Name: "Limit"
   )
   public var dynamicGainFloor = OcaBoundedPropertyValue<OcaDB>(
     value: -144.0,
@@ -116,7 +125,8 @@ open class OcaDynamics: OcaActuator {
   @OcaBoundedDeviceProperty(
     propertyID: OcaPropertyID("4.13"),
     getMethodID: OcaMethodID("4.23"),
-    setMethodID: OcaMethodID("4.24")
+    setMethodID: OcaMethodID("4.24"),
+    ocp2Name: "Parameter"
   )
   public var kneeParameter = OcaBoundedPropertyValue<OcaFloat32>(value: 0, in: 0...1)
 
@@ -190,21 +200,24 @@ open class OcaDynamicsDetector: OcaActuator {
   @OcaBoundedDeviceProperty(
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.3"),
-    setMethodID: OcaMethodID("4.4")
+    setMethodID: OcaMethodID("4.4"),
+    ocp2Name: "Time"
   )
   public var attackTime = OcaBoundedPropertyValue<OcaTimeInterval>(value: 0, in: 0...1)
 
   @OcaBoundedDeviceProperty(
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.5"),
-    setMethodID: OcaMethodID("4.6")
+    setMethodID: OcaMethodID("4.6"),
+    ocp2Name: "Time"
   )
   public var releaseTime = OcaBoundedPropertyValue<OcaTimeInterval>(value: 0, in: 0...1)
 
   @OcaBoundedDeviceProperty(
     propertyID: OcaPropertyID("4.4"),
     getMethodID: OcaMethodID("4.7"),
-    setMethodID: OcaMethodID("4.8")
+    setMethodID: OcaMethodID("4.8"),
+    ocp2Name: "Time"
   )
   public var holdTime = OcaBoundedPropertyValue<OcaTimeInterval>(value: 0, in: 0...1)
 
@@ -259,7 +272,8 @@ open class OcaDynamicsCurve: OcaActuator {
   /// from GetThresholds() are scalar rather than per-element
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("4.2"),
-    setMethodID: OcaMethodID("4.4")
+    setMethodID: OcaMethodID("4.4"),
+    ocp2Name: "Threshold"
   )
   public var thresholds: OcaList<OcaDBr> = []
 
@@ -267,7 +281,8 @@ open class OcaDynamicsCurve: OcaActuator {
   /// limits alongside the value
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("4.3"),
-    setMethodID: OcaMethodID("4.6")
+    setMethodID: OcaMethodID("4.6"),
+    ocp2Name: "Slope"
   )
   public var slopes: OcaList<OcaFloat32> = []
 
@@ -275,14 +290,16 @@ open class OcaDynamicsCurve: OcaActuator {
   /// per-element limits alongside the value
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("4.4"),
-    setMethodID: OcaMethodID("4.8")
+    setMethodID: OcaMethodID("4.8"),
+    ocp2Name: "Parameters"
   )
   public var kneeParameters: OcaList<OcaFloat32> = []
 
   @OcaBoundedDeviceProperty(
     propertyID: OcaPropertyID("4.5"),
     getMethodID: OcaMethodID("4.11"),
-    setMethodID: OcaMethodID("4.12")
+    setMethodID: OcaMethodID("4.12"),
+    ocp2Name: "Gain"
   )
   public var dynamicGainFloor = OcaBoundedPropertyValue<OcaDB>(
     value: -144.0,
@@ -292,7 +309,8 @@ open class OcaDynamicsCurve: OcaActuator {
   @OcaBoundedDeviceProperty(
     propertyID: OcaPropertyID("4.6"),
     getMethodID: OcaMethodID("4.9"),
-    setMethodID: OcaMethodID("4.10")
+    setMethodID: OcaMethodID("4.10"),
+    ocp2Name: "Gain"
   )
   public var dynamicGainCeiling = OcaBoundedPropertyValue<OcaDB>(
     value: 0.0,

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/Dynamics.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/Dynamics.swift
@@ -40,7 +40,8 @@ open class OcaDynamics: OcaActuator {
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.3"),
     setMethodID: OcaMethodID("4.4"),
-    ocp2Name: "Func"
+    ocp2Name: "Func",
+    ocp2SetName: "Func"
   )
   public var function: OcaDynamicsFunction = .none
 
@@ -63,7 +64,8 @@ open class OcaDynamics: OcaActuator {
     propertyID: OcaPropertyID("4.6"),
     getMethodID: OcaMethodID("4.9"),
     setMethodID: OcaMethodID("4.10"),
-    ocp2Name: "Units"
+    ocp2Name: "Units",
+    ocp2SetName: "Units"
   )
   public var thresholdPresentationUnits: OcaPresentationUnit = .dBu
 
@@ -71,7 +73,8 @@ open class OcaDynamics: OcaActuator {
     propertyID: OcaPropertyID("4.7"),
     getMethodID: OcaMethodID("4.11"),
     setMethodID: OcaMethodID("4.12"),
-    ocp2Name: "Law"
+    ocp2Name: "Law",
+    ocp2SetName: "Law"
   )
   public var detectorLaw: OcaLevelDetectionLaw = .none
 
@@ -79,7 +82,8 @@ open class OcaDynamics: OcaActuator {
     propertyID: OcaPropertyID("4.8"),
     getMethodID: OcaMethodID("4.13"),
     setMethodID: OcaMethodID("4.14"),
-    ocp2Name: "Time"
+    ocp2Name: "Time",
+    ocp2SetName: "Time"
   )
   public var attackTime = OcaBoundedPropertyValue<OcaTimeInterval>(value: 0, in: 0...1)
 
@@ -87,7 +91,8 @@ open class OcaDynamics: OcaActuator {
     propertyID: OcaPropertyID("4.9"),
     getMethodID: OcaMethodID("4.15"),
     setMethodID: OcaMethodID("4.16"),
-    ocp2Name: "Time"
+    ocp2Name: "Time",
+    ocp2SetName: "Time"
   )
   public var releaseTime = OcaBoundedPropertyValue<OcaTimeInterval>(value: 0, in: 0...1)
 
@@ -95,7 +100,8 @@ open class OcaDynamics: OcaActuator {
     propertyID: OcaPropertyID("4.10"),
     getMethodID: OcaMethodID("4.17"),
     setMethodID: OcaMethodID("4.18"),
-    ocp2Name: "Time"
+    ocp2Name: "Time",
+    ocp2SetName: "Time"
   )
   public var holdTime = OcaBoundedPropertyValue<OcaTimeInterval>(value: 0, in: 0...1)
 
@@ -103,7 +109,8 @@ open class OcaDynamics: OcaActuator {
     propertyID: OcaPropertyID("4.11"),
     getMethodID: OcaMethodID("4.21"),
     setMethodID: OcaMethodID("4.22"),
-    ocp2Name: "Limit"
+    ocp2Name: "Limit",
+    ocp2SetName: "Limit"
   )
   public var dynamicGainCeiling = OcaBoundedPropertyValue<OcaDB>(
     value: 0.0,
@@ -114,7 +121,8 @@ open class OcaDynamics: OcaActuator {
     propertyID: OcaPropertyID("4.12"),
     getMethodID: OcaMethodID("4.19"),
     setMethodID: OcaMethodID("4.20"),
-    ocp2Name: "Limit"
+    ocp2Name: "Limit",
+    ocp2SetName: "Limit"
   )
   public var dynamicGainFloor = OcaBoundedPropertyValue<OcaDB>(
     value: -144.0,
@@ -126,7 +134,8 @@ open class OcaDynamics: OcaActuator {
     propertyID: OcaPropertyID("4.13"),
     getMethodID: OcaMethodID("4.23"),
     setMethodID: OcaMethodID("4.24"),
-    ocp2Name: "Parameter"
+    ocp2Name: "Parameter",
+    ocp2SetName: "Parameter"
   )
   public var kneeParameter = OcaBoundedPropertyValue<OcaFloat32>(value: 0, in: 0...1)
 
@@ -201,7 +210,8 @@ open class OcaDynamicsDetector: OcaActuator {
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.3"),
     setMethodID: OcaMethodID("4.4"),
-    ocp2Name: "Time"
+    ocp2Name: "Time",
+    ocp2SetName: "Time"
   )
   public var attackTime = OcaBoundedPropertyValue<OcaTimeInterval>(value: 0, in: 0...1)
 
@@ -209,7 +219,8 @@ open class OcaDynamicsDetector: OcaActuator {
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.5"),
     setMethodID: OcaMethodID("4.6"),
-    ocp2Name: "Time"
+    ocp2Name: "Time",
+    ocp2SetName: "Time"
   )
   public var releaseTime = OcaBoundedPropertyValue<OcaTimeInterval>(value: 0, in: 0...1)
 
@@ -217,7 +228,8 @@ open class OcaDynamicsDetector: OcaActuator {
     propertyID: OcaPropertyID("4.4"),
     getMethodID: OcaMethodID("4.7"),
     setMethodID: OcaMethodID("4.8"),
-    ocp2Name: "Time"
+    ocp2Name: "Time",
+    ocp2SetName: "Time"
   )
   public var holdTime = OcaBoundedPropertyValue<OcaTimeInterval>(value: 0, in: 0...1)
 
@@ -261,10 +273,14 @@ open class OcaDynamicsCurve: OcaActuator {
   override open class var classVersion: OcaClassVersionNumber { 3 }
 
   /// the curve is composed of (n + 1) straight line segments joined by (n) knees
+  // the model names this setter's parameter `Slope`, copied from the slope methods,
+  // and the getter's bounds `minN`/`maxN`; both are with the committee
   @OcaBoundedDeviceProperty(
     propertyID: OcaPropertyID("4.1"),
     getMethodID: OcaMethodID("4.1"),
-    setMethodID: OcaMethodID("4.2")
+    setMethodID: OcaMethodID("4.2"),
+    ocp2Name: "NSegments",
+    ocp2SetName: "NSegments"
   )
   public var nSegments = OcaBoundedPropertyValue<OcaUint8>(value: 1, in: 1...8)
 
@@ -273,7 +289,8 @@ open class OcaDynamicsCurve: OcaActuator {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("4.2"),
     setMethodID: OcaMethodID("4.4"),
-    ocp2Name: "Threshold"
+    ocp2Name: "Threshold",
+    ocp2SetName: "Threshold"
   )
   public var thresholds: OcaList<OcaDBr> = []
 
@@ -282,7 +299,8 @@ open class OcaDynamicsCurve: OcaActuator {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("4.3"),
     setMethodID: OcaMethodID("4.6"),
-    ocp2Name: "Slope"
+    ocp2Name: "Slope",
+    ocp2SetName: "Slope"
   )
   public var slopes: OcaList<OcaFloat32> = []
 
@@ -291,7 +309,8 @@ open class OcaDynamicsCurve: OcaActuator {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("4.4"),
     setMethodID: OcaMethodID("4.8"),
-    ocp2Name: "Parameters"
+    ocp2Name: "Parameters",
+    ocp2SetName: "Parameters"
   )
   public var kneeParameters: OcaList<OcaFloat32> = []
 
@@ -299,7 +318,8 @@ open class OcaDynamicsCurve: OcaActuator {
     propertyID: OcaPropertyID("4.5"),
     getMethodID: OcaMethodID("4.11"),
     setMethodID: OcaMethodID("4.12"),
-    ocp2Name: "Gain"
+    ocp2Name: "Gain",
+    ocp2SetName: "Gain"
   )
   public var dynamicGainFloor = OcaBoundedPropertyValue<OcaDB>(
     value: -144.0,
@@ -310,7 +330,8 @@ open class OcaDynamicsCurve: OcaActuator {
     propertyID: OcaPropertyID("4.6"),
     getMethodID: OcaMethodID("4.9"),
     setMethodID: OcaMethodID("4.10"),
-    ocp2Name: "Gain"
+    ocp2Name: "Gain",
+    ocp2SetName: "Gain"
   )
   public var dynamicGainCeiling = OcaBoundedPropertyValue<OcaDB>(
     value: 0.0,

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/Filters.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/Filters.swift
@@ -109,7 +109,7 @@ open class OcaFilterParametric: OcaActuator {
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.3"),
     setMethodID: OcaMethodID("4.4"),
-    ocp2Name: "Type",
+    ocp2GetName: "Type",
     ocp2SetName: "Type"
   )
   public var shape: OcaParametricEQShape = .none
@@ -119,7 +119,7 @@ open class OcaFilterParametric: OcaActuator {
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.5"),
     setMethodID: OcaMethodID("4.6"),
-    ocp2Name: "Width",
+    ocp2GetName: "Width",
     ocp2SetName: "Width"
   )
   public var widthParameter = OcaBoundedPropertyValue<OcaFloat32>(value: 1, in: 0.1...100)
@@ -128,7 +128,7 @@ open class OcaFilterParametric: OcaActuator {
     propertyID: OcaPropertyID("4.4"),
     getMethodID: OcaMethodID("4.7"),
     setMethodID: OcaMethodID("4.8"),
-    ocp2Name: "Gain",
+    ocp2GetName: "Gain",
     ocp2SetName: "Gain"
   )
   public var inBandGain = OcaBoundedPropertyValue<OcaDB>(value: 0.0, in: -144.0...20.0)
@@ -138,7 +138,7 @@ open class OcaFilterParametric: OcaActuator {
     propertyID: OcaPropertyID("4.5"),
     getMethodID: OcaMethodID("4.9"),
     setMethodID: OcaMethodID("4.10"),
-    ocp2Name: "Shape",
+    ocp2GetName: "Shape",
     ocp2SetName: "Shape"
   )
   public var shapeParameter = OcaBoundedPropertyValue<OcaFloat32>(value: 0, in: 0...1)
@@ -203,7 +203,7 @@ open class OcaFilterPolynomial: OcaActuator {
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.3"),
     setMethodID: OcaMethodID("4.4"),
-    ocp2Name: "Rate",
+    ocp2GetName: "Rate",
     ocp2SetName: "Rate"
   )
   public var sampleRate = OcaBoundedPropertyValue<OcaFrequency>(
@@ -215,7 +215,7 @@ open class OcaFilterPolynomial: OcaActuator {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("4.4"),
     getMethodID: OcaMethodID("4.5"),
-    ocp2Name: "Order"
+    ocp2GetName: "Order"
   )
   public var maxOrder: OcaUint8 = 0
 
@@ -272,7 +272,7 @@ open class OcaFilterFIR: OcaActuator {
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.4"),
     setMethodID: OcaMethodID("4.5"),
-    ocp2Name: "Rate",
+    ocp2GetName: "Rate",
     ocp2SetName: "Rate"
   )
   public var sampleRate = OcaBoundedPropertyValue<OcaFrequency>(
@@ -297,7 +297,7 @@ open class OcaFilterArbitraryCurve: OcaActuator {
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.3"),
     setMethodID: OcaMethodID("4.4"),
-    ocp2Name: "Rate",
+    ocp2GetName: "Rate",
     ocp2SetName: "Rate"
   )
   public var sampleRate = OcaBoundedPropertyValue<OcaFrequency>(
@@ -309,7 +309,7 @@ open class OcaFilterArbitraryCurve: OcaActuator {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.5"),
-    ocp2Name: "Min"
+    ocp2GetName: "Min"
   )
   public var tfMinLength: OcaUint16 = 0
 
@@ -317,7 +317,7 @@ open class OcaFilterArbitraryCurve: OcaActuator {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("4.4"),
     getMethodID: OcaMethodID("4.6"),
-    ocp2Name: "Max"
+    ocp2GetName: "Max"
   )
   public var tfMaxLength: OcaUint16 = 0
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/Filters.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/Filters.swift
@@ -109,7 +109,8 @@ open class OcaFilterParametric: OcaActuator {
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.3"),
     setMethodID: OcaMethodID("4.4"),
-    ocp2Name: "Type"
+    ocp2Name: "Type",
+    ocp2SetName: "Type"
   )
   public var shape: OcaParametricEQShape = .none
 
@@ -118,7 +119,8 @@ open class OcaFilterParametric: OcaActuator {
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.5"),
     setMethodID: OcaMethodID("4.6"),
-    ocp2Name: "Width"
+    ocp2Name: "Width",
+    ocp2SetName: "Width"
   )
   public var widthParameter = OcaBoundedPropertyValue<OcaFloat32>(value: 1, in: 0.1...100)
 
@@ -126,7 +128,8 @@ open class OcaFilterParametric: OcaActuator {
     propertyID: OcaPropertyID("4.4"),
     getMethodID: OcaMethodID("4.7"),
     setMethodID: OcaMethodID("4.8"),
-    ocp2Name: "Gain"
+    ocp2Name: "Gain",
+    ocp2SetName: "Gain"
   )
   public var inBandGain = OcaBoundedPropertyValue<OcaDB>(value: 0.0, in: -144.0...20.0)
 
@@ -135,7 +138,8 @@ open class OcaFilterParametric: OcaActuator {
     propertyID: OcaPropertyID("4.5"),
     getMethodID: OcaMethodID("4.9"),
     setMethodID: OcaMethodID("4.10"),
-    ocp2Name: "Shape"
+    ocp2Name: "Shape",
+    ocp2SetName: "Shape"
   )
   public var shapeParameter = OcaBoundedPropertyValue<OcaFloat32>(value: 0, in: 0...1)
 
@@ -199,7 +203,8 @@ open class OcaFilterPolynomial: OcaActuator {
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.3"),
     setMethodID: OcaMethodID("4.4"),
-    ocp2Name: "Rate"
+    ocp2Name: "Rate",
+    ocp2SetName: "Rate"
   )
   public var sampleRate = OcaBoundedPropertyValue<OcaFrequency>(
     value: 48000,
@@ -267,7 +272,8 @@ open class OcaFilterFIR: OcaActuator {
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.4"),
     setMethodID: OcaMethodID("4.5"),
-    ocp2Name: "Rate"
+    ocp2Name: "Rate",
+    ocp2SetName: "Rate"
   )
   public var sampleRate = OcaBoundedPropertyValue<OcaFrequency>(
     value: 48000,
@@ -291,7 +297,8 @@ open class OcaFilterArbitraryCurve: OcaActuator {
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.3"),
     setMethodID: OcaMethodID("4.4"),
-    ocp2Name: "Rate"
+    ocp2Name: "Rate",
+    ocp2SetName: "Rate"
   )
   public var sampleRate = OcaBoundedPropertyValue<OcaFrequency>(
     value: 48000,

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/Filters.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/Filters.swift
@@ -108,7 +108,8 @@ open class OcaFilterParametric: OcaActuator {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.3"),
-    setMethodID: OcaMethodID("4.4")
+    setMethodID: OcaMethodID("4.4"),
+    ocp2Name: "Type"
   )
   public var shape: OcaParametricEQShape = .none
 
@@ -116,14 +117,16 @@ open class OcaFilterParametric: OcaActuator {
   @OcaBoundedDeviceProperty(
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.5"),
-    setMethodID: OcaMethodID("4.6")
+    setMethodID: OcaMethodID("4.6"),
+    ocp2Name: "Width"
   )
   public var widthParameter = OcaBoundedPropertyValue<OcaFloat32>(value: 1, in: 0.1...100)
 
   @OcaBoundedDeviceProperty(
     propertyID: OcaPropertyID("4.4"),
     getMethodID: OcaMethodID("4.7"),
-    setMethodID: OcaMethodID("4.8")
+    setMethodID: OcaMethodID("4.8"),
+    ocp2Name: "Gain"
   )
   public var inBandGain = OcaBoundedPropertyValue<OcaDB>(value: 0.0, in: -144.0...20.0)
 
@@ -131,7 +134,8 @@ open class OcaFilterParametric: OcaActuator {
   @OcaBoundedDeviceProperty(
     propertyID: OcaPropertyID("4.5"),
     getMethodID: OcaMethodID("4.9"),
-    setMethodID: OcaMethodID("4.10")
+    setMethodID: OcaMethodID("4.10"),
+    ocp2Name: "Shape"
   )
   public var shapeParameter = OcaBoundedPropertyValue<OcaFloat32>(value: 0, in: 0...1)
 
@@ -194,7 +198,8 @@ open class OcaFilterPolynomial: OcaActuator {
   @OcaBoundedDeviceProperty(
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.3"),
-    setMethodID: OcaMethodID("4.4")
+    setMethodID: OcaMethodID("4.4"),
+    ocp2Name: "Rate"
   )
   public var sampleRate = OcaBoundedPropertyValue<OcaFrequency>(
     value: 48000,
@@ -204,7 +209,8 @@ open class OcaFilterPolynomial: OcaActuator {
   /// the maximum number of elements of ``a`` and ``b``
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("4.4"),
-    getMethodID: OcaMethodID("4.5")
+    getMethodID: OcaMethodID("4.5"),
+    ocp2Name: "Order"
   )
   public var maxOrder: OcaUint8 = 0
 
@@ -260,7 +266,8 @@ open class OcaFilterFIR: OcaActuator {
   @OcaBoundedDeviceProperty(
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.4"),
-    setMethodID: OcaMethodID("4.5")
+    setMethodID: OcaMethodID("4.5"),
+    ocp2Name: "Rate"
   )
   public var sampleRate = OcaBoundedPropertyValue<OcaFrequency>(
     value: 48000,
@@ -283,7 +290,8 @@ open class OcaFilterArbitraryCurve: OcaActuator {
   @OcaBoundedDeviceProperty(
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.3"),
-    setMethodID: OcaMethodID("4.4")
+    setMethodID: OcaMethodID("4.4"),
+    ocp2Name: "Rate"
   )
   public var sampleRate = OcaBoundedPropertyValue<OcaFrequency>(
     value: 48000,
@@ -293,14 +301,16 @@ open class OcaFilterArbitraryCurve: OcaActuator {
   /// minimum number of points the transfer function must specify
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("4.3"),
-    getMethodID: OcaMethodID("4.5")
+    getMethodID: OcaMethodID("4.5"),
+    ocp2Name: "Min"
   )
   public var tfMinLength: OcaUint16 = 0
 
   /// maximum number of points the transfer function may specify
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("4.4"),
-    getMethodID: OcaMethodID("4.6")
+    getMethodID: OcaMethodID("4.6"),
+    ocp2Name: "Max"
   )
   public var tfMaxLength: OcaUint16 = 0
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/PanBalance.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/PanBalance.swift
@@ -29,7 +29,8 @@ open class OcaPanBalance: OcaActuator {
   @OcaBoundedDeviceProperty(
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.3"),
-    setMethodID: OcaMethodID("4.4")
+    setMethodID: OcaMethodID("4.4"),
+    ocp2Name: "Gain"
   )
   public var midpointGain = OcaBoundedPropertyValue<OcaFloat32>(value: 0.0, in: 0.0...0.0)
 }

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/PanBalance.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/PanBalance.swift
@@ -30,7 +30,7 @@ open class OcaPanBalance: OcaActuator {
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.3"),
     setMethodID: OcaMethodID("4.4"),
-    ocp2Name: "Gain",
+    ocp2GetName: "Gain",
     ocp2SetName: "Gain"
   )
   public var midpointGain = OcaBoundedPropertyValue<OcaFloat32>(value: 0.0, in: 0.0...0.0)

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/PanBalance.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/PanBalance.swift
@@ -30,7 +30,8 @@ open class OcaPanBalance: OcaActuator {
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.3"),
     setMethodID: OcaMethodID("4.4"),
-    ocp2Name: "Gain"
+    ocp2Name: "Gain",
+    ocp2SetName: "Gain"
   )
   public var midpointGain = OcaBoundedPropertyValue<OcaFloat32>(value: 0.0, in: 0.0...0.0)
 }

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/SamplingRateConverter.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/SamplingRateConverter.swift
@@ -23,7 +23,7 @@ open class OcaSamplingRateConverter: OcaActuator {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("4.1"),
     getMethodID: OcaMethodID("4.1"),
-    ocp2Name: "SrcType"
+    ocp2GetName: "SrcType"
   )
   public var type: OcaSamplingRateConverterType = .none
 }

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/SamplingRateConverter.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/SamplingRateConverter.swift
@@ -22,7 +22,8 @@ open class OcaSamplingRateConverter: OcaActuator {
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("4.1"),
-    getMethodID: OcaMethodID("4.1")
+    getMethodID: OcaMethodID("4.1"),
+    ocp2Name: "SrcType"
   )
   public var type: OcaSamplingRateConverterType = .none
 }

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/SignalGenerator.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/SignalGenerator.swift
@@ -26,7 +26,7 @@ open class OcaSignalGenerator: OcaActuator {
     propertyID: OcaPropertyID("4.1"),
     getMethodID: OcaMethodID("4.1"),
     setMethodID: OcaMethodID("4.2"),
-    ocp2Name: "Frequency",
+    ocp2GetName: "Frequency",
     ocp2SetName: "Frequency"
   )
   public var frequency1 = OcaBoundedPropertyValue<OcaFrequency>(value: 1000, in: 10...20000)
@@ -36,7 +36,7 @@ open class OcaSignalGenerator: OcaActuator {
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.3"),
     setMethodID: OcaMethodID("4.4"),
-    ocp2Name: "Frequency",
+    ocp2GetName: "Frequency",
     ocp2SetName: "Frequency"
   )
   public var frequency2 = OcaBoundedPropertyValue<OcaFrequency>(value: 20000, in: 10...20000)

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/SignalGenerator.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/SignalGenerator.swift
@@ -25,7 +25,8 @@ open class OcaSignalGenerator: OcaActuator {
   @OcaBoundedDeviceProperty(
     propertyID: OcaPropertyID("4.1"),
     getMethodID: OcaMethodID("4.1"),
-    setMethodID: OcaMethodID("4.2")
+    setMethodID: OcaMethodID("4.2"),
+    ocp2Name: "Frequency"
   )
   public var frequency1 = OcaBoundedPropertyValue<OcaFrequency>(value: 1000, in: 10...20000)
 
@@ -33,7 +34,8 @@ open class OcaSignalGenerator: OcaActuator {
   @OcaBoundedDeviceProperty(
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.3"),
-    setMethodID: OcaMethodID("4.4")
+    setMethodID: OcaMethodID("4.4"),
+    ocp2Name: "Frequency"
   )
   public var frequency2 = OcaBoundedPropertyValue<OcaFrequency>(value: 20000, in: 10...20000)
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/SignalGenerator.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/SignalGenerator.swift
@@ -26,7 +26,8 @@ open class OcaSignalGenerator: OcaActuator {
     propertyID: OcaPropertyID("4.1"),
     getMethodID: OcaMethodID("4.1"),
     setMethodID: OcaMethodID("4.2"),
-    ocp2Name: "Frequency"
+    ocp2Name: "Frequency",
+    ocp2SetName: "Frequency"
   )
   public var frequency1 = OcaBoundedPropertyValue<OcaFrequency>(value: 1000, in: 10...20000)
 
@@ -35,7 +36,8 @@ open class OcaSignalGenerator: OcaActuator {
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.3"),
     setMethodID: OcaMethodID("4.4"),
-    ocp2Name: "Frequency"
+    ocp2Name: "Frequency",
+    ocp2SetName: "Frequency"
   )
   public var frequency2 = OcaBoundedPropertyValue<OcaFrequency>(value: 20000, in: 10...20000)
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/Switch.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/Switch.swift
@@ -30,7 +30,8 @@ open class OcaSwitch: OcaActuator {
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.5"),
     setMethodID: OcaMethodID("4.6"),
-    ocp2Name: "Names"
+    ocp2Name: "Names",
+    ocp2SetName: "Names"
   )
   public var positionNames = [OcaString]()
 
@@ -38,7 +39,8 @@ open class OcaSwitch: OcaActuator {
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.9"),
     setMethodID: OcaMethodID("4.10"),
-    ocp2Name: "Flags"
+    ocp2Name: "Flags",
+    ocp2SetName: "Flags"
   )
   public var positionEnableds = [OcaBoolean]()
 }

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/Switch.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/Switch.swift
@@ -30,7 +30,7 @@ open class OcaSwitch: OcaActuator {
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.5"),
     setMethodID: OcaMethodID("4.6"),
-    ocp2Name: "Names",
+    ocp2GetName: "Names",
     ocp2SetName: "Names"
   )
   public var positionNames = [OcaString]()
@@ -39,7 +39,7 @@ open class OcaSwitch: OcaActuator {
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.9"),
     setMethodID: OcaMethodID("4.10"),
-    ocp2Name: "Flags",
+    ocp2GetName: "Flags",
     ocp2SetName: "Flags"
   )
   public var positionEnableds = [OcaBoolean]()

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/Switch.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Actuators/Switch.swift
@@ -29,14 +29,16 @@ open class OcaSwitch: OcaActuator {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.5"),
-    setMethodID: OcaMethodID("4.6")
+    setMethodID: OcaMethodID("4.6"),
+    ocp2Name: "Names"
   )
   public var positionNames = [OcaString]()
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("4.3"),
     getMethodID: OcaMethodID("4.9"),
-    setMethodID: OcaMethodID("4.10")
+    setMethodID: OcaMethodID("4.10"),
+    ocp2Name: "Flags"
   )
   public var positionEnableds = [OcaBoolean]()
 }

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/BlocksAndMatrices/Block.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/BlocksAndMatrices/Block.swift
@@ -138,7 +138,8 @@ open class OcaBlock<ActionObject: OcaRoot>: OcaWorker, OcaBlockContainer {
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.3"),
-    getMethodID: OcaMethodID("3.9")
+    getMethodID: OcaMethodID("3.9"),
+    ocp2Name: "Members"
   )
   public var signalPaths = OcaMap<OcaUint16, OcaSignalPath>()
 
@@ -159,7 +160,8 @@ open class OcaBlock<ActionObject: OcaRoot>: OcaWorker, OcaBlockContainer {
   /// zero to keep SwiftOCA clients happy
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.4"),
-    getMethodID: OcaMethodID("3.11")
+    getMethodID: OcaMethodID("3.11"),
+    ocp2Name: "Identifier"
   )
   public var mostRecentParamSetIdentifier: OcaLibVolIdentifier = .init(
     library: OcaInvalidONo,
@@ -186,7 +188,8 @@ open class OcaBlock<ActionObject: OcaRoot>: OcaWorker, OcaBlockContainer {
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.9"),
-    getMethodID: OcaMethodID("3.22")
+    getMethodID: OcaMethodID("3.22"),
+    ocp2Name: "ONo"
   )
   public var mostRecentParamDatasetONo: OcaONo = OcaInvalidONo
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/BlocksAndMatrices/Block.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/BlocksAndMatrices/Block.swift
@@ -139,7 +139,7 @@ open class OcaBlock<ActionObject: OcaRoot>: OcaWorker, OcaBlockContainer {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.3"),
     getMethodID: OcaMethodID("3.9"),
-    ocp2Name: "Members"
+    ocp2GetName: "Members"
   )
   public var signalPaths = OcaMap<OcaUint16, OcaSignalPath>()
 
@@ -161,7 +161,7 @@ open class OcaBlock<ActionObject: OcaRoot>: OcaWorker, OcaBlockContainer {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.4"),
     getMethodID: OcaMethodID("3.11"),
-    ocp2Name: "Identifier"
+    ocp2GetName: "Identifier"
   )
   public var mostRecentParamSetIdentifier: OcaLibVolIdentifier = .init(
     library: OcaInvalidONo,
@@ -189,7 +189,7 @@ open class OcaBlock<ActionObject: OcaRoot>: OcaWorker, OcaBlockContainer {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.9"),
     getMethodID: OcaMethodID("3.22"),
-    ocp2Name: "ONo"
+    ocp2GetName: "ONo"
   )
   public var mostRecentParamDatasetONo: OcaONo = OcaInvalidONo
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/BlocksAndMatrices/Matrix.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/BlocksAndMatrices/Matrix.swift
@@ -355,7 +355,8 @@ open class OcaMatrix<Member: OcaRoot>: OcaWorker {
     propertyID: OcaPropertyID("3.7"),
     getMethodID: OcaMethodID("3.11"),
     setMethodID: OcaMethodID("3.12"),
-    ocp2Name: "Ports"
+    ocp2Name: "Ports",
+    ocp2SetName: "Ports"
   )
   public var portsPerRow: OcaUint8 = 0
 
@@ -363,7 +364,8 @@ open class OcaMatrix<Member: OcaRoot>: OcaWorker {
     propertyID: OcaPropertyID("3.8"),
     getMethodID: OcaMethodID("3.13"),
     setMethodID: OcaMethodID("3.14"),
-    ocp2Name: "Ports"
+    ocp2Name: "Ports",
+    ocp2SetName: "Ports"
   )
   public var portsPerColumn: OcaUint8 = 0
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/BlocksAndMatrices/Matrix.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/BlocksAndMatrices/Matrix.swift
@@ -354,14 +354,16 @@ open class OcaMatrix<Member: OcaRoot>: OcaWorker {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.7"),
     getMethodID: OcaMethodID("3.11"),
-    setMethodID: OcaMethodID("3.12")
+    setMethodID: OcaMethodID("3.12"),
+    ocp2Name: "Ports"
   )
   public var portsPerRow: OcaUint8 = 0
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("3.8"),
     getMethodID: OcaMethodID("3.13"),
-    setMethodID: OcaMethodID("3.14")
+    setMethodID: OcaMethodID("3.14"),
+    ocp2Name: "Ports"
   )
   public var portsPerColumn: OcaUint8 = 0
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/BlocksAndMatrices/Matrix.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/BlocksAndMatrices/Matrix.swift
@@ -399,13 +399,13 @@ open class OcaMatrix<Member: OcaRoot>: OcaWorker {
     case OcaMethodID("3.5"):
       try decodeNullCommand(command)
       try await ensureReadable(by: controller, command: command)
-      return try controller.encodeResponse(memberObjectNumbers, name: "members")
+      return try controller.encodeResponse(memberObjectNumbers, name: "Members")
     case OcaMethodID("3.7"):
       let coordinates: OcaVector2D<OcaMatrixCoordinate> = try decodeCommand(command)
       try await ensureReadable(by: controller, command: command)
       let objectNumber = members[Int(coordinates.x), Int(coordinates.y)]?
         .objectNumber ?? OcaInvalidONo
-      return try controller.encodeResponse(objectNumber, name: "memberONo")
+      return try controller.encodeResponse(objectNumber, name: "MemberONo")
     case OcaMethodID("3.8"):
       let parameters: SwiftOCA.OcaMatrix.SetMemberParameters = try decodeCommand(command)
       try await ensureWritable(by: controller, command: command)

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/BlocksAndMatrices/Matrix.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/BlocksAndMatrices/Matrix.swift
@@ -355,7 +355,7 @@ open class OcaMatrix<Member: OcaRoot>: OcaWorker {
     propertyID: OcaPropertyID("3.7"),
     getMethodID: OcaMethodID("3.11"),
     setMethodID: OcaMethodID("3.12"),
-    ocp2Name: "Ports",
+    ocp2GetName: "Ports",
     ocp2SetName: "Ports"
   )
   public var portsPerRow: OcaUint8 = 0
@@ -364,7 +364,7 @@ open class OcaMatrix<Member: OcaRoot>: OcaWorker {
     propertyID: OcaPropertyID("3.8"),
     getMethodID: OcaMethodID("3.13"),
     setMethodID: OcaMethodID("3.14"),
-    ocp2Name: "Ports",
+    ocp2GetName: "Ports",
     ocp2SetName: "Ports"
   )
   public var portsPerColumn: OcaUint8 = 0

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Sensors/LevelSensor.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Sensors/LevelSensor.swift
@@ -61,7 +61,7 @@ open class OcaLevelSensor: OcaSensor {
     bytes.reserveCapacity(9)
     parameters.encode(into: &bytes)
 
-    try await deviceDelegate.notifySubscribers(event, parameters: Data(bytes))
+    try await deviceDelegate.notifySubscribers(event, parameters: Data(bytes), value: parameters)
   }
 
   // for API compatibility, but prefer to use update(reading:) to set value

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Sensors/LevelSensor.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Sensors/LevelSensor.swift
@@ -39,7 +39,7 @@ open class OcaLevelSensor: OcaSensor {
       try decodeNullCommand(command)
       try await ensureReadable(by: controller, command: command)
       let value = OcaBoundedPropertyValue<OcaDB>(value: _value, in: _range)
-      return try controller.encodeResponse(value, names: ["Reading", "minReading", "maxReading"])
+      return try controller.encodeResponse(value, names: Ocp2Naming.boundedWireNames("Reading"))
     default:
       return try await super.handleCommand(command, from: controller)
     }

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Sensors/StateSensor.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Sensors/StateSensor.swift
@@ -26,7 +26,7 @@ open class OcaStateSensor: OcaSensor {
   @OcaBoundedDeviceProperty(
     propertyID: OcaPropertyID("4.1"),
     getMethodID: OcaMethodID("4.1"),
-    ocp2Name: "State"
+    ocp2GetName: "State"
   )
   public var reading = OcaBoundedPropertyValue<OcaUint16>(value: 0, in: 0...0)
 
@@ -35,7 +35,7 @@ open class OcaStateSensor: OcaSensor {
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.2"),
     setMethodID: OcaMethodID("4.3"),
-    ocp2Name: "Names",
+    ocp2GetName: "Names",
     ocp2SetName: "Names"
   )
   public var stateNames: OcaList<OcaString> = []

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Sensors/StateSensor.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Sensors/StateSensor.swift
@@ -25,7 +25,8 @@ open class OcaStateSensor: OcaSensor {
   /// value of this property inclusive
   @OcaBoundedDeviceProperty(
     propertyID: OcaPropertyID("4.1"),
-    getMethodID: OcaMethodID("4.1")
+    getMethodID: OcaMethodID("4.1"),
+    ocp2Name: "State"
   )
   public var reading = OcaBoundedPropertyValue<OcaUint16>(value: 0, in: 0...0)
 
@@ -33,7 +34,8 @@ open class OcaStateSensor: OcaSensor {
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.2"),
-    setMethodID: OcaMethodID("4.3")
+    setMethodID: OcaMethodID("4.3"),
+    ocp2Name: "Names"
   )
   public var stateNames: OcaList<OcaString> = []
 }

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Sensors/StateSensor.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Sensors/StateSensor.swift
@@ -35,7 +35,8 @@ open class OcaStateSensor: OcaSensor {
     propertyID: OcaPropertyID("4.2"),
     getMethodID: OcaMethodID("4.2"),
     setMethodID: OcaMethodID("4.3"),
-    ocp2Name: "Names"
+    ocp2Name: "Names",
+    ocp2SetName: "Names"
   )
   public var stateNames: OcaList<OcaString> = []
 }

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Worker.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Worker.swift
@@ -62,7 +62,8 @@ open class OcaWorker: OcaRoot, OcaOwnable, OcaPortsRepresentable, OcaPortClockMa
     propertyID: OcaPropertyID("2.6"),
     getMethodID: OcaMethodID("2.14"),
     setMethodID: OcaMethodID("2.15"),
-    ocp2Name: "Map"
+    ocp2Name: "Map",
+    ocp2SetName: "Map"
   )
   public var portClockMap: OcaMap<OcaPortID, OcaPortClockMapEntry> = [:]
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Worker.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Worker.swift
@@ -33,7 +33,7 @@ open class OcaWorker: OcaRoot, OcaOwnable, OcaPortsRepresentable, OcaPortClockMa
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("2.2"),
     getMethodID: OcaMethodID("2.5"),
-    ocp2Name: "OcaPorts"
+    ocp2GetName: "OcaPorts"
   )
   public var ports = [OcaPort]()
 
@@ -62,7 +62,7 @@ open class OcaWorker: OcaRoot, OcaOwnable, OcaPortsRepresentable, OcaPortClockMa
     propertyID: OcaPropertyID("2.6"),
     getMethodID: OcaMethodID("2.14"),
     setMethodID: OcaMethodID("2.15"),
-    ocp2Name: "Map",
+    ocp2GetName: "Map",
     ocp2SetName: "Map"
   )
   public var portClockMap: OcaMap<OcaPortID, OcaPortClockMapEntry> = [:]

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Worker.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Worker.swift
@@ -32,7 +32,8 @@ open class OcaWorker: OcaRoot, OcaOwnable, OcaPortsRepresentable, OcaPortClockMa
 
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("2.2"),
-    getMethodID: OcaMethodID("2.5")
+    getMethodID: OcaMethodID("2.5"),
+    ocp2Name: "OcaPorts"
   )
   public var ports = [OcaPort]()
 
@@ -60,7 +61,8 @@ open class OcaWorker: OcaRoot, OcaOwnable, OcaPortsRepresentable, OcaPortClockMa
   @OcaDeviceProperty(
     propertyID: OcaPropertyID("2.6"),
     getMethodID: OcaMethodID("2.14"),
-    setMethodID: OcaMethodID("2.15")
+    setMethodID: OcaMethodID("2.15"),
+    ocp2Name: "Map"
   )
   public var portClockMap: OcaMap<OcaPortID, OcaPortClockMapEntry> = [:]
 

--- a/Sources/SwiftOCADevice/OCC/PropertyTypes/BoundedDeviceProperty.swift
+++ b/Sources/SwiftOCADevice/OCC/PropertyTypes/BoundedDeviceProperty.swift
@@ -55,7 +55,7 @@ public struct OcaBoundedDeviceProperty<
     propertyID: OcaPropertyID,
     getMethodID: OcaMethodID? = nil,
     setMethodID: OcaMethodID? = nil,
-    ocp2Name: String? = nil,
+    ocp2GetName: String? = nil,
     ocp2SetName: String? = nil
   ) {
     storage = OcaDeviceProperty(
@@ -63,12 +63,12 @@ public struct OcaBoundedDeviceProperty<
       propertyID: propertyID,
       getMethodID: getMethodID,
       setMethodID: setMethodID,
-      ocp2Name: ocp2Name,
+      ocp2GetName: ocp2GetName,
       ocp2SetName: ocp2SetName
     )
   }
 
-  public var ocp2Name: String? { storage.ocp2Name }
+  public var ocp2GetName: String? { storage.ocp2GetName }
   public var ocp2SetName: String? { storage.ocp2SetName }
 
   func getResponse(for controller: any OcaController, names: [String]?) async throws
@@ -79,7 +79,7 @@ public struct OcaBoundedDeviceProperty<
 
   /// `Gain`, `minGain`, `maxGain`
   func responseNames(propertyName: String) -> [String] {
-    Ocp2Naming.boundedWireNames(wireName(propertyName: propertyName))
+    Ocp2Naming.boundedWireNames(getName(propertyName: propertyName))
   }
 
   #if NonEmbeddedBuild

--- a/Sources/SwiftOCADevice/OCC/PropertyTypes/BoundedDeviceProperty.swift
+++ b/Sources/SwiftOCADevice/OCC/PropertyTypes/BoundedDeviceProperty.swift
@@ -55,18 +55,21 @@ public struct OcaBoundedDeviceProperty<
     propertyID: OcaPropertyID,
     getMethodID: OcaMethodID? = nil,
     setMethodID: OcaMethodID? = nil,
-    ocp2Name: String? = nil
+    ocp2Name: String? = nil,
+    ocp2SetName: String? = nil
   ) {
     storage = OcaDeviceProperty(
       wrappedValue: wrappedValue,
       propertyID: propertyID,
       getMethodID: getMethodID,
       setMethodID: setMethodID,
-      ocp2Name: ocp2Name
+      ocp2Name: ocp2Name,
+      ocp2SetName: ocp2SetName
     )
   }
 
   public var ocp2Name: String? { storage.ocp2Name }
+  public var ocp2SetName: String? { storage.ocp2SetName }
 
   func getResponse(for controller: any OcaController, names: [String]?) async throws
     -> Ocp1Response

--- a/Sources/SwiftOCADevice/OCC/PropertyTypes/BoundedDeviceProperty.swift
+++ b/Sources/SwiftOCADevice/OCC/PropertyTypes/BoundedDeviceProperty.swift
@@ -54,20 +54,29 @@ public struct OcaBoundedDeviceProperty<
     wrappedValue: OcaBoundedPropertyValue<Value>,
     propertyID: OcaPropertyID,
     getMethodID: OcaMethodID? = nil,
-    setMethodID: OcaMethodID? = nil
+    setMethodID: OcaMethodID? = nil,
+    ocp2Name: String? = nil
   ) {
     storage = OcaDeviceProperty(
       wrappedValue: wrappedValue,
       propertyID: propertyID,
       getMethodID: getMethodID,
-      setMethodID: setMethodID
+      setMethodID: setMethodID,
+      ocp2Name: ocp2Name
     )
   }
+
+  public var ocp2Name: String? { storage.ocp2Name }
 
   func getResponse(for controller: any OcaController, names: [String]?) async throws
     -> Ocp1Response
   {
     try await storage.getResponse(for: controller, names: names)
+  }
+
+  /// `Gain`, `minGain`, `maxGain`
+  func responseNames(propertyName: String) -> [String] {
+    Ocp2Naming.boundedWireNames(wireName(propertyName: propertyName))
   }
 
   #if NonEmbeddedBuild

--- a/Sources/SwiftOCADevice/OCC/PropertyTypes/DeviceProperty.swift
+++ b/Sources/SwiftOCADevice/OCC/PropertyTypes/DeviceProperty.swift
@@ -40,6 +40,10 @@ protocol OcaDevicePropertyRepresentable: Sendable {
   /// property name upper-cased; `nil` derives it.
   var ocp2Name: String? { get }
 
+  /// The AES70-2A name of the setter's parameter, where the model names it differently
+  /// from the getter's response; `nil` uses `ocp2Name`.
+  var ocp2SetName: String? { get }
+
   /// OCP.2 names for the getter's response parameters, given the property's Swift name
   func responseNames(propertyName: String) -> [String]
 
@@ -61,10 +65,17 @@ extension OcaDevicePropertyRepresentable {
   }
 
   var ocp2Name: String? { nil }
+  var ocp2SetName: String? { nil }
 
   /// The property's OCP.2 wire name given its Swift name.
   func wireName(propertyName: String) -> String {
     ocp2Name ?? Ocp2Naming.wireName(propertyName)
+  }
+
+  /// The name the setter's parameter carries, which the model sometimes spells
+  /// differently from the getter's response.
+  func setName(propertyName: String) -> String {
+    ocp2SetName ?? wireName(propertyName: propertyName)
   }
 
   func responseNames(propertyName: String) -> [String] {
@@ -114,6 +125,10 @@ public struct OcaDeviceProperty<Value: Codable & Sendable>: OcaDevicePropertyRep
   /// property name upper-cased (the model's `Name` for `deviceName`).
   public let ocp2Name: String?
 
+  /// The AES70-2A name of the setter's parameter, where the model names it differently
+  /// from the getter's response; `nil` uses `ocp2Name`.
+  public let ocp2SetName: String?
+
   /// Placeholder only
   public var wrappedValue: Value {
     get { subject.value }
@@ -129,26 +144,30 @@ public struct OcaDeviceProperty<Value: Codable & Sendable>: OcaDevicePropertyRep
     propertyID: OcaPropertyID,
     getMethodID: OcaMethodID? = nil,
     setMethodID: OcaMethodID? = nil,
-    ocp2Name: String? = nil
+    ocp2Name: String? = nil,
+    ocp2SetName: String? = nil
   ) {
     subject = AsyncCurrentValueSubject(wrappedValue)
     self.propertyID = propertyID
     self.getMethodID = getMethodID
     self.setMethodID = setMethodID
     self.ocp2Name = ocp2Name
+    self.ocp2SetName = ocp2SetName
   }
 
   public init(
     propertyID: OcaPropertyID,
     getMethodID: OcaMethodID? = nil,
     setMethodID: OcaMethodID? = nil,
-    ocp2Name: String? = nil
+    ocp2Name: String? = nil,
+    ocp2SetName: String? = nil
   ) where Value: ExpressibleByNilLiteral {
     subject = AsyncCurrentValueSubject(nil)
     self.propertyID = propertyID
     self.getMethodID = getMethodID
     self.setMethodID = setMethodID
     self.ocp2Name = ocp2Name
+    self.ocp2SetName = ocp2SetName
   }
 
   func get() -> Value {

--- a/Sources/SwiftOCADevice/OCC/PropertyTypes/DeviceProperty.swift
+++ b/Sources/SwiftOCADevice/OCC/PropertyTypes/DeviceProperty.swift
@@ -36,6 +36,13 @@ protocol OcaDevicePropertyRepresentable: Sendable {
   func getResponse(for controller: any OcaController, names: [String]?) async throws
     -> Ocp1Response
 
+  /// The AES70-2A name of the accessor parameter where it differs from the Swift
+  /// property name upper-cased; `nil` derives it.
+  var ocp2Name: String? { get }
+
+  /// OCP.2 names for the getter's response parameters, given the property's Swift name
+  func responseNames(propertyName: String) -> [String]
+
   /// setters take an object so that subscribers can be notified
 
   func set(object: OcaRoot, command: Ocp1Command) async throws
@@ -51,6 +58,17 @@ protocol OcaDevicePropertyRepresentable: Sendable {
 extension OcaDevicePropertyRepresentable {
   func finish() {
     subject.send(.finished)
+  }
+
+  var ocp2Name: String? { nil }
+
+  /// The property's OCP.2 wire name given its Swift name.
+  func wireName(propertyName: String) -> String {
+    ocp2Name ?? Ocp2Naming.wireName(propertyName)
+  }
+
+  func responseNames(propertyName: String) -> [String] {
+    [wireName(propertyName: propertyName)]
   }
 
   var async: AnyAsyncSequence<Value> {
@@ -92,6 +110,10 @@ public struct OcaDeviceProperty<Value: Codable & Sendable>: OcaDevicePropertyRep
   /// The OCA set method ID, if present
   public let setMethodID: OcaMethodID?
 
+  /// The AES70-2A name of the accessor parameter, where it differs from the Swift
+  /// property name upper-cased (the model's `Name` for `deviceName`).
+  public let ocp2Name: String?
+
   /// Placeholder only
   public var wrappedValue: Value {
     get { subject.value }
@@ -106,23 +128,27 @@ public struct OcaDeviceProperty<Value: Codable & Sendable>: OcaDevicePropertyRep
     wrappedValue: Value,
     propertyID: OcaPropertyID,
     getMethodID: OcaMethodID? = nil,
-    setMethodID: OcaMethodID? = nil
+    setMethodID: OcaMethodID? = nil,
+    ocp2Name: String? = nil
   ) {
     subject = AsyncCurrentValueSubject(wrappedValue)
     self.propertyID = propertyID
     self.getMethodID = getMethodID
     self.setMethodID = setMethodID
+    self.ocp2Name = ocp2Name
   }
 
   public init(
     propertyID: OcaPropertyID,
     getMethodID: OcaMethodID? = nil,
-    setMethodID: OcaMethodID? = nil
+    setMethodID: OcaMethodID? = nil,
+    ocp2Name: String? = nil
   ) where Value: ExpressibleByNilLiteral {
     subject = AsyncCurrentValueSubject(nil)
     self.propertyID = propertyID
     self.getMethodID = getMethodID
     self.setMethodID = setMethodID
+    self.ocp2Name = ocp2Name
   }
 
   func get() -> Value {

--- a/Sources/SwiftOCADevice/OCC/PropertyTypes/DeviceProperty.swift
+++ b/Sources/SwiftOCADevice/OCC/PropertyTypes/DeviceProperty.swift
@@ -38,10 +38,10 @@ protocol OcaDevicePropertyRepresentable: Sendable {
 
   /// The AES70-2A name of the accessor parameter where it differs from the Swift
   /// property name upper-cased; `nil` derives it.
-  var ocp2Name: String? { get }
+  var ocp2GetName: String? { get }
 
   /// The AES70-2A name of the setter's parameter, where the model names it differently
-  /// from the getter's response; `nil` uses `ocp2Name`.
+  /// from the getter's response; `nil` uses `ocp2GetName`.
   var ocp2SetName: String? { get }
 
   /// OCP.2 names for the getter's response parameters, given the property's Swift name
@@ -64,22 +64,22 @@ extension OcaDevicePropertyRepresentable {
     subject.send(.finished)
   }
 
-  var ocp2Name: String? { nil }
+  var ocp2GetName: String? { nil }
   var ocp2SetName: String? { nil }
 
-  /// The property's OCP.2 wire name given its Swift name.
-  func wireName(propertyName: String) -> String {
-    ocp2Name ?? Ocp2Naming.wireName(propertyName)
+  /// The property's OCP.2 getter name given its Swift name.
+  func getName(propertyName: String) -> String {
+    ocp2GetName ?? Ocp2Naming.wireName(propertyName)
   }
 
   /// The name the setter's parameter carries, which the model sometimes spells
   /// differently from the getter's response.
   func setName(propertyName: String) -> String {
-    ocp2SetName ?? wireName(propertyName: propertyName)
+    ocp2SetName ?? getName(propertyName: propertyName)
   }
 
   func responseNames(propertyName: String) -> [String] {
-    [wireName(propertyName: propertyName)]
+    [getName(propertyName: propertyName)]
   }
 
   var async: AnyAsyncSequence<Value> {
@@ -123,10 +123,10 @@ public struct OcaDeviceProperty<Value: Codable & Sendable>: OcaDevicePropertyRep
 
   /// The AES70-2A name of the accessor parameter, where it differs from the Swift
   /// property name upper-cased (the model's `Name` for `deviceName`).
-  public let ocp2Name: String?
+  public let ocp2GetName: String?
 
   /// The AES70-2A name of the setter's parameter, where the model names it differently
-  /// from the getter's response; `nil` uses `ocp2Name`.
+  /// from the getter's response; `nil` uses `ocp2GetName`.
   public let ocp2SetName: String?
 
   /// Placeholder only
@@ -144,14 +144,14 @@ public struct OcaDeviceProperty<Value: Codable & Sendable>: OcaDevicePropertyRep
     propertyID: OcaPropertyID,
     getMethodID: OcaMethodID? = nil,
     setMethodID: OcaMethodID? = nil,
-    ocp2Name: String? = nil,
+    ocp2GetName: String? = nil,
     ocp2SetName: String? = nil
   ) {
     subject = AsyncCurrentValueSubject(wrappedValue)
     self.propertyID = propertyID
     self.getMethodID = getMethodID
     self.setMethodID = setMethodID
-    self.ocp2Name = ocp2Name
+    self.ocp2GetName = ocp2GetName
     self.ocp2SetName = ocp2SetName
   }
 
@@ -159,14 +159,14 @@ public struct OcaDeviceProperty<Value: Codable & Sendable>: OcaDevicePropertyRep
     propertyID: OcaPropertyID,
     getMethodID: OcaMethodID? = nil,
     setMethodID: OcaMethodID? = nil,
-    ocp2Name: String? = nil,
+    ocp2GetName: String? = nil,
     ocp2SetName: String? = nil
   ) where Value: ExpressibleByNilLiteral {
     subject = AsyncCurrentValueSubject(nil)
     self.propertyID = propertyID
     self.getMethodID = getMethodID
     self.setMethodID = setMethodID
-    self.ocp2Name = ocp2Name
+    self.ocp2GetName = ocp2GetName
     self.ocp2SetName = ocp2SetName
   }
 

--- a/Sources/SwiftOCADevice/OCC/PropertyTypes/VectorDeviceProperty.swift
+++ b/Sources/SwiftOCADevice/OCC/PropertyTypes/VectorDeviceProperty.swift
@@ -59,20 +59,20 @@ public struct OcaVectorDeviceProperty<
     yPropertyID: OcaPropertyID,
     getMethodID: OcaMethodID? = nil,
     setMethodID: OcaMethodID? = nil,
-    ocp2Name: String? = nil
+    ocp2GetName: String? = nil
   ) {
     storage = OcaDeviceProperty(
       wrappedValue: wrappedValue,
       propertyID: xPropertyID,
       getMethodID: getMethodID,
       setMethodID: setMethodID,
-      ocp2Name: ocp2Name
+      ocp2GetName: ocp2GetName
     )
 
     self.yPropertyID = yPropertyID
   }
 
-  public var ocp2Name: String? { storage.ocp2Name }
+  public var ocp2GetName: String? { storage.ocp2GetName }
 
   /// A vector's getter returns one record with two fields, so it supplies no explicit
   /// names: the encoder derives `X` and `Y` from the record. A single name would be

--- a/Sources/SwiftOCADevice/OCC/PropertyTypes/VectorDeviceProperty.swift
+++ b/Sources/SwiftOCADevice/OCC/PropertyTypes/VectorDeviceProperty.swift
@@ -58,16 +58,28 @@ public struct OcaVectorDeviceProperty<
     xPropertyID: OcaPropertyID,
     yPropertyID: OcaPropertyID,
     getMethodID: OcaMethodID? = nil,
-    setMethodID: OcaMethodID? = nil
+    setMethodID: OcaMethodID? = nil,
+    ocp2Name: String? = nil
   ) {
     storage = OcaDeviceProperty(
       wrappedValue: wrappedValue,
       propertyID: xPropertyID,
       getMethodID: getMethodID,
-      setMethodID: setMethodID
+      setMethodID: setMethodID,
+      ocp2Name: ocp2Name
     )
 
     self.yPropertyID = yPropertyID
+  }
+
+  public var ocp2Name: String? { storage.ocp2Name }
+
+  /// A vector's getter returns one record with two fields, so it supplies no explicit
+  /// names: the encoder derives `X` and `Y` from the record. A single name would be
+  /// assigned to the first field and the second derived, which matches neither the
+  /// model nor what this library's own controller asks for.
+  func responseNames(propertyName: String) -> [String] {
+    []
   }
 
   func getResponse(for controller: any OcaController, names: [String]?) async throws

--- a/Sources/SwiftOCADevice/OCP.1/Backend/CF/Ocp1CFController.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/CF/Ocp1CFController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2024-2025 PADL Software Pty Ltd
+// Copyright (c) 2024-2026 PADL Software Pty Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.
@@ -92,6 +92,7 @@ package actor Ocp1CFStreamController: Ocp1CFControllerPrivate, CustomStringConve
   package var lastMessageReceivedTime = ContinuousClock.recentPast
   package var lastMessageSentTime = ContinuousClock.recentPast
   package weak var endpoint: Ocp1CFStreamDeviceEndpoint?
+  package let controlProtocol: OcaControlProtocol
 
   package var messages: AnyAsyncSequence<Ocp1MessageList> {
     _messages.eraseToAnyAsyncSequence()
@@ -116,6 +117,7 @@ package actor Ocp1CFStreamController: Ocp1CFControllerPrivate, CustomStringConve
     socket: _CFSocketWrapper,
     notificationSocket: _CFSocketWrapper
   ) async {
+    controlProtocol = endpoint.controlProtocol
     _socket = .init(socket)
     self.notificationSocket = notificationSocket
     peerAddress = socket.peerAddress!
@@ -125,10 +127,11 @@ package actor Ocp1CFStreamController: Ocp1CFControllerPrivate, CustomStringConve
       throwing: Error.self
     )
 
+    let isJson = endpoint.controlProtocol != .ocp1
     if peerAddress.family == AF_LOCAL {
-      connectionPrefix = OcaLocalConnectionPrefix
+      connectionPrefix = isJson ? OcaJsonLocalConnectionPrefix : OcaLocalConnectionPrefix
     } else {
-      connectionPrefix = OcaTcpConnectionPrefix
+      connectionPrefix = isJson ? OcaJsonTcpConnectionPrefix : OcaTcpConnectionPrefix
     }
 
     receiveMessageTask = Task { [weak self] in
@@ -222,7 +225,9 @@ private extension Ocp1NetworkAddress {
 package actor Ocp1CFDatagramController: Ocp1CFControllerPrivate, Ocp1ControllerDatagramSemantics {
   package nonisolated var flags: OcaControllerFlags { .supportsLocking }
 
-  package nonisolated var connectionPrefix: String { OcaUdpConnectionPrefix }
+  package nonisolated var connectionPrefix: String {
+    controlProtocol == .ocp1 ? OcaUdpConnectionPrefix : OcaJsonUdpConnectionPrefix
+  }
 
   package var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()
   let peerAddress: AnySocketAddress
@@ -233,6 +238,7 @@ package actor Ocp1CFDatagramController: Ocp1CFControllerPrivate, Ocp1ControllerD
 
   package private(set) var isOpen: Bool = false
   package weak var endpoint: Ocp1CFDatagramDeviceEndpoint?
+  package let controlProtocol: OcaControlProtocol
 
   package var messages: AnyAsyncSequence<Ocp1MessageList> {
     AsyncEmptySequence<Ocp1MessageList>().eraseToAnyAsyncSequence()
@@ -243,6 +249,7 @@ package actor Ocp1CFDatagramController: Ocp1CFControllerPrivate, Ocp1ControllerD
     peerAddress: any SocketAddress
   ) {
     self.endpoint = endpoint
+    controlProtocol = endpoint.controlProtocol
     self.peerAddress = AnySocketAddress(peerAddress)
   }
 

--- a/Sources/SwiftOCADevice/OCP.1/Backend/CF/Ocp1CFController.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/CF/Ocp1CFController.swift
@@ -127,11 +127,16 @@ package actor Ocp1CFStreamController: Ocp1CFControllerPrivate, CustomStringConve
       throwing: Error.self
     )
 
-    let isJson = endpoint.controlProtocol != .ocp1
-    if peerAddress.family == AF_LOCAL {
-      connectionPrefix = isJson ? OcaJsonLocalConnectionPrefix : OcaLocalConnectionPrefix
+    connectionPrefix = if peerAddress.family == AF_LOCAL {
+      endpoint.controlProtocol.connectionPrefix(
+        ocp1: OcaLocalConnectionPrefix,
+        ocp2: OcaJsonLocalConnectionPrefix
+      )
     } else {
-      connectionPrefix = isJson ? OcaJsonTcpConnectionPrefix : OcaTcpConnectionPrefix
+      endpoint.controlProtocol.connectionPrefix(
+        ocp1: OcaTcpConnectionPrefix,
+        ocp2: OcaJsonTcpConnectionPrefix
+      )
     }
 
     receiveMessageTask = Task { [weak self] in
@@ -226,7 +231,7 @@ package actor Ocp1CFDatagramController: Ocp1CFControllerPrivate, Ocp1ControllerD
   package nonisolated var flags: OcaControllerFlags { .supportsLocking }
 
   package nonisolated var connectionPrefix: String {
-    controlProtocol == .ocp1 ? OcaUdpConnectionPrefix : OcaJsonUdpConnectionPrefix
+    controlProtocol.connectionPrefix(ocp1: OcaUdpConnectionPrefix, ocp2: OcaJsonUdpConnectionPrefix)
   }
 
   package var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()

--- a/Sources/SwiftOCADevice/OCP.1/Backend/CF/Ocp1CFDeviceEndpoint.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/CF/Ocp1CFDeviceEndpoint.swift
@@ -272,7 +272,7 @@ public class Ocp1CFDatagramDeviceEndpoint: Ocp1CFDeviceEndpoint,
 
   #if canImport(dnssd)
   override public nonisolated var serviceType: OcaNetworkAdvertisingServiceType {
-    .udp
+    OcaNetworkAdvertisingServiceType.udp.withControlProtocol(controlProtocol)
   }
   #endif
 

--- a/Sources/SwiftOCADevice/OCP.1/Backend/DatagramProxy/DatagramProxyController.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/DatagramProxy/DatagramProxyController.swift
@@ -38,6 +38,7 @@ package actor DatagramProxyController<T: DatagramProxyPeerIdentifier>: Ocp1Contr
 
   package private(set) var isOpen: Bool = false
   package weak var endpoint: DatagramProxyDeviceEndpoint<T>?
+  package let controlProtocol: OcaControlProtocol
 
   package var messages: AnyAsyncSequence<Ocp1MessageList> {
     AsyncEmptySequence<Ocp1MessageList>().eraseToAnyAsyncSequence()
@@ -46,6 +47,7 @@ package actor DatagramProxyController<T: DatagramProxyPeerIdentifier>: Ocp1Contr
   init(with peerID: T, endpoint: DatagramProxyDeviceEndpoint<T>) {
     self.peerID = peerID
     self.endpoint = endpoint
+    controlProtocol = endpoint.controlProtocol
     heartbeatTime = endpoint.timeout
   }
 

--- a/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingFoxController.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingFoxController.swift
@@ -69,9 +69,10 @@ package actor Ocp1FlyingFoxController: Ocp1ControllerInternal, CustomStringConve
     self.controlProtocol = controlProtocol
     let usesTextFrames = controlProtocol.webSocketUsesTextFrames
     _usesTextFrames = usesTextFrames
-    _connectionPrefix = usesTextFrames
-      ? OcaJsonWebSocketTcpConnectionPrefix
-      : OcaWebSocketTcpConnectionPrefix
+    _connectionPrefix = controlProtocol.connectionPrefix(
+      ocp1: OcaWebSocketTcpConnectionPrefix,
+      ocp2: OcaJsonWebSocketTcpConnectionPrefix
+    )
     let maximumPduSize = endpoint?.maximumPduSize ?? OcaControlProtocol.defaultMaximumPduSize
     _messages = AsyncThrowingStream { continuation in
       let task = Task { [inputStream] in

--- a/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingFoxController.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingFoxController.swift
@@ -28,8 +28,16 @@ import SwiftOCA
 
 /// A remote WebSocket endpoint
 package actor Ocp1FlyingFoxController: Ocp1ControllerInternal, CustomStringConvertible {
-  package nonisolated var flags: OcaControllerFlags { .supportsLocking }
-  package nonisolated var connectionPrefix: String { OcaWebSocketTcpConnectionPrefix }
+  package nonisolated var flags: OcaControllerFlags {
+    .supportsLocking
+  }
+
+  package nonisolated var connectionPrefix: String {
+    _connectionPrefix
+  }
+
+  private nonisolated let _connectionPrefix: String
+  private nonisolated let _usesTextFrames: Bool
 
   package var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()
 
@@ -37,6 +45,7 @@ package actor Ocp1FlyingFoxController: Ocp1ControllerInternal, CustomStringConve
   private let outputStream: AsyncStream<WSMessage>.Continuation
   package var endpoint: Ocp1FlyingFoxDeviceEndpoint?
   package nonisolated let identifier: String
+  package let controlProtocol: OcaControlProtocol
 
   package var keepAliveTask: Task<(), Error>?
   package let writeQueue: Ocp1WriteQueue? = Ocp1WriteQueue()
@@ -49,6 +58,7 @@ package actor Ocp1FlyingFoxController: Ocp1ControllerInternal, CustomStringConve
 
   init(
     endpoint: Ocp1FlyingFoxDeviceEndpoint?,
+    controlProtocol: OcaControlProtocol,
     identifier: String,
     inputStream: AsyncStream<WSMessage>,
     outputStream: AsyncStream<WSMessage>.Continuation
@@ -56,24 +66,78 @@ package actor Ocp1FlyingFoxController: Ocp1ControllerInternal, CustomStringConve
     self.outputStream = outputStream
     self.endpoint = endpoint
     self.identifier = identifier
+    self.controlProtocol = controlProtocol
+    let usesTextFrames = controlProtocol.webSocketUsesTextFrames
+    _usesTextFrames = usesTextFrames
+    _connectionPrefix = usesTextFrames
+      ? OcaJsonWebSocketTcpConnectionPrefix
+      : OcaWebSocketTcpConnectionPrefix
+    let maximumPduSize = endpoint?.maximumPduSize ?? OcaControlProtocol.defaultMaximumPduSize
     _messages = AsyncThrowingStream { continuation in
       let task = Task { [inputStream] in
-        do {
-          for await message in inputStream {
-            guard case let .data(data) = message else {
-              throw Ocp1Error.invalidMessageType
-            }
-
-            try continuation.yield(Ocp1MessageList(messagePduData: data))
-          }
-
-          continuation.finish()
-        } catch {
+        // consecutive frame payloads are a byte stream (AES70-4 10.4.3.4.4), so
+        // one reader spans frames; OCP.1 keeps one PDU per binary frame
+        let reader = controlProtocol.makeReader(
+          isMessageOriented: !usesTextFrames,
+          maximumPduSize: maximumPduSize
+        )
+        nonisolated(unsafe) var frames = inputStream.makeAsyncIterator()
+        /// AES70-4 10.4.3.4.4: a binary frame closes with 1003, a malformed message
+        /// with 1007; an over-long one with 1009. Each failure sends one close frame.
+        func fail(_ code: WSCloseCode, _ error: Error) {
+          outputStream.yield(.close(code))
           continuation.finish(throwing: error)
+        }
+        while true {
+          let pdu: Data
+          do {
+            // one frame per read, whatever is asked for: WebSocket is message-oriented
+            pdu = try await reader.nextPdu(read: { _, _ in
+              try await Self.nextFrame(&frames, text: usesTextFrames)
+            })
+          } catch Ocp1Error.notConnected {
+            continuation.finish()
+            return
+          } catch Ocp1Error.invalidMessageType {
+            fail(.unsupportedData, Ocp1Error.invalidMessageType)
+            return
+          } catch Ocp1Error.invalidPduSize {
+            fail(.messageTooBig, Ocp1Error.invalidPduSize)
+            return
+          } catch {
+            continuation.finish(throwing: error)
+            return
+          }
+          do {
+            try continuation.yield(Ocp1MessageList(messagePduData: pdu, controlProtocol: controlProtocol))
+          } catch {
+            fail(usesTextFrames ? .invalidFramePayload : .protocolError, error)
+            return
+          }
         }
       }
 
       continuation.onTermination = { @Sendable _ in task.cancel() }
+    }
+  }
+
+  /// The next frame's payload, requiring text frames on OCP.2 and binary on OCP.1.
+  private static func nextFrame(
+    _ frames: inout AsyncStream<WSMessage>.AsyncIterator,
+    text: Bool
+  ) async throws -> Data {
+    guard let message = await frames.next() else {
+      throw Ocp1Error.notConnected
+    }
+    switch message {
+    case let .data(data) where !text:
+      return data
+    case let .text(string) where text:
+      return Data(string.utf8)
+    case .close:
+      throw Ocp1Error.notConnected
+    default:
+      throw Ocp1Error.invalidMessageType
     }
   }
 
@@ -84,7 +148,11 @@ package actor Ocp1FlyingFoxController: Ocp1ControllerInternal, CustomStringConve
   }
 
   package func sendOcp1EncodedData(_ data: Data) async throws {
-    outputStream.yield(.data(data))
+    if _usesTextFrames {
+      outputStream.yield(.text(String(decoding: data, as: UTF8.self)))
+    } else {
+      outputStream.yield(.data(data))
+    }
   }
 
   package func close() async {

--- a/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingFoxDeviceEndpoint.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingFoxDeviceEndpoint.swift
@@ -177,6 +177,8 @@ public final class Ocp1FlyingFoxDeviceEndpoint: OcaDeviceEndpointPrivate,
     let routes = Dictionary(grouping: self.paths, by: \.value).mapValues { $0.map(\.key) }
     for (path, sharing) in routes {
       await httpServer.appendRoute(HTTPRoute("GET \(path)")) { [weak self] request in
+        // FlyingFox keeps only the last of a repeated header, so a subprotocol
+        // offered on a second Sec-WebSocket-Protocol line is not seen
         let offered = request.headers[Self.webSocketProtocolHeader]?
           .split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) } ?? []
         let controlProtocol = Self.controlProtocol(offering: offered, among: sharing)

--- a/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingFoxDeviceEndpoint.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingFoxDeviceEndpoint.swift
@@ -50,6 +50,10 @@ public final class Ocp1FlyingFoxDeviceEndpoint: OcaDeviceEndpointPrivate,
   package let timeout: Duration
   package let device: OcaDevice
   package let logger: Logger
+  /// The HTTP path each control protocol is served on, advertised as its service's `path`
+  /// TXT record when it is not `/` (AES70-4 Table 5). Protocols sharing a path are told
+  /// apart by the WebSocket subprotocol the client offers.
+  public nonisolated let paths: [OcaControlProtocol: String]
   package nonisolated(unsafe) var enableMessageTracing = false
 
   private(set) var httpServer: HTTPServer!
@@ -64,9 +68,15 @@ public final class Ocp1FlyingFoxDeviceEndpoint: OcaDeviceEndpointPrivate,
     package weak var endpoint: Ocp1FlyingFoxDeviceEndpoint?
     /// the peer the WebSocket upgrade came from, for logging
     private let identifier: String
+    package let controlProtocol: OcaControlProtocol
 
-    init(_ endpoint: Ocp1FlyingFoxDeviceEndpoint?, peer: HTTPRequest.Address?) {
+    init(
+      _ endpoint: Ocp1FlyingFoxDeviceEndpoint?,
+      controlProtocol: OcaControlProtocol,
+      peer: HTTPRequest.Address?
+    ) {
       self.endpoint = endpoint
+      self.controlProtocol = controlProtocol
       identifier = switch peer {
       case let .ip4(address, port), let .ip6(address, port):
         "\(address):\(port)"
@@ -83,6 +93,7 @@ public final class Ocp1FlyingFoxDeviceEndpoint: OcaDeviceEndpointPrivate,
       AsyncStream<WSMessage> { continuation in
         let controller = Ocp1FlyingFoxController(
           endpoint: endpoint,
+          controlProtocol: controlProtocol,
           identifier: identifier,
           inputStream: client,
           outputStream: continuation
@@ -98,10 +109,15 @@ public final class Ocp1FlyingFoxDeviceEndpoint: OcaDeviceEndpointPrivate,
     }
   }
 
+  /// Serves each of `controlProtocols` at its path in `paths`, or at `/`. Protocols
+  /// sharing a path are told apart by the subprotocol the client offers: `AES70-OCP.2`
+  /// for OCP.2, none for OCP.1.
   public convenience init(
     address: Data,
     timeout: Duration = OcaDevice.DefaultTimeout,
     device: OcaDevice = OcaDevice.shared,
+    controlProtocols: Set<OcaControlProtocol> = [.ocp1],
+    paths: [OcaControlProtocol: String] = [:],
     logger: Logger = Logger(label: "com.padl.SwiftOCADevice.Ocp1FlyingFoxDeviceEndpoint")
   ) async throws {
     var storage = sockaddr_storage()
@@ -110,18 +126,32 @@ public final class Ocp1FlyingFoxDeviceEndpoint: OcaDeviceEndpointPrivate,
         memcpy(dst.baseAddress!, src.baseAddress!, src.count)
       }
     }
-    try await self.init(address: storage, timeout: timeout, device: device, logger: logger)
+    try await self.init(
+      address: storage,
+      timeout: timeout,
+      device: device,
+      controlProtocols: controlProtocols,
+      paths: paths,
+      logger: logger
+    )
   }
 
   private init(
     address: sockaddr_storage,
     timeout: Duration = OcaDevice.DefaultTimeout,
     device: OcaDevice = OcaDevice.shared,
+    controlProtocols: Set<OcaControlProtocol> = [.ocp1],
+    paths: [OcaControlProtocol: String] = [:],
     logger: Logger = Logger(label: "com.padl.SwiftOCADevice.Ocp1FlyingFoxDeviceEndpoint")
   ) async throws {
+    guard !controlProtocols.isEmpty else { throw Ocp1Error.unsupportedControlProtocol }
     self.device = device
     self.address = address
     self.timeout = timeout
+    self.paths = Dictionary(uniqueKeysWithValues: controlProtocols.map { controlProtocol in
+      let path = paths[controlProtocol] ?? "/"
+      return (controlProtocol, path.hasPrefix("/") ? path : "/" + path)
+    })
     self.logger = logger
 
     // FIXME: API impedance mismatch
@@ -143,14 +173,31 @@ public final class Ocp1FlyingFoxDeviceEndpoint: OcaDeviceEndpointPrivate,
       timeout: timeout.timeInterval
     )
 
-    await httpServer.appendRoute("GET /") { [weak self] request in
-      // one handler per upgrade, so the controller knows its peer
-      try await WebSocketHTTPHandler.webSocket(Handler(self, peer: request.remoteAddress))
-        .handleRequest(request)
+    // one route per path; the protocols sharing it are told apart by the subprotocol
+    let routes = Dictionary(grouping: self.paths, by: \.value).mapValues { $0.map(\.key) }
+    for (path, sharing) in routes {
+      await httpServer.appendRoute(HTTPRoute("GET \(path)")) { [weak self] request in
+        let offered = request.headers[Self.webSocketProtocolHeader]?
+          .split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) } ?? []
+        let controlProtocol = Self.controlProtocol(offering: offered, among: sharing)
+        // one handler per upgrade, so the controller knows its peer
+        var response = try await WebSocketHTTPHandler
+          .webSocket(Handler(self, controlProtocol: controlProtocol, peer: request.remoteAddress))
+          .handleRequest(request)
+        // RFC 6455 4.2.2: echo the subprotocol we speak if the client offered it
+        if let subprotocol = controlProtocol.webSocketSubprotocol,
+           response.statusCode == .switchingProtocols, offered.contains(subprotocol)
+        {
+          response.headers[Self.webSocketProtocolHeader] = subprotocol
+        }
+        return response
+      }
     }
 
     try await device.add(endpoint: self)
   }
+
+  nonisolated static let webSocketProtocolHeader = HTTPHeader("Sec-WebSocket-Protocol")
 
   public nonisolated var description: String {
     "\(type(of: self))(address: \(address._presentationAddress), timeout: \(timeout))"
@@ -169,8 +216,44 @@ public final class Ocp1FlyingFoxDeviceEndpoint: OcaDeviceEndpointPrivate,
     }
   }
 
+  /// The protocols served, in `OcaControlProtocol` order.
+  public nonisolated var controlProtocols: [OcaControlProtocol] {
+    OcaControlProtocol.allCases.filter { paths[$0] != nil }
+  }
+
+  /// The protocol a WebSocket upgrade on a shared path speaks: the one whose subprotocol
+  /// the client offered, else the one with none (OCP.1), else the first, as a client need
+  /// not offer a subprotocol at all.
+  nonisolated static func controlProtocol(
+    offering offered: [String],
+    among sharing: [OcaControlProtocol]
+  ) -> OcaControlProtocol {
+    let sharing = OcaControlProtocol.allCases.filter(sharing.contains)
+    return sharing.first { $0.webSocketSubprotocol.map(offered.contains) ?? false }
+      ?? sharing.first { $0.webSocketSubprotocol == nil }
+      ?? sharing[0]
+  }
+
+  /// The first protocol's service; `advertisedServices` has one per protocol.
   public nonisolated var serviceType: OcaNetworkAdvertisingServiceType {
-    .tcpWebSocket
+    advertisedServices[0].serviceType
+  }
+
+  public nonisolated var txtRecordAdditions: [(String, String)] {
+    advertisedServices[0].txtRecordAdditions
+  }
+
+  public nonisolated var advertisedServices: [(
+    serviceType: OcaNetworkAdvertisingServiceType,
+    txtRecordAdditions: [(String, String)]
+  )] {
+    controlProtocols.map { controlProtocol in
+      let path = paths[controlProtocol]!
+      return (
+        OcaNetworkAdvertisingServiceType.tcpWebSocket.withControlProtocol(controlProtocol),
+        path == "/" ? [] : [("path", path)]
+      )
+    }
   }
 
   public nonisolated var port: UInt16 {

--- a/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingSocksDatagramController.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingSocksDatagramController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023-2024 PADL Software Pty Ltd
+// Copyright (c) 2023-2026 PADL Software Pty Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.
@@ -33,7 +33,9 @@ import Glibc
 /// A remote controller
 package actor Ocp1FlyingSocksDatagramController: Ocp1ControllerInternal {
   package nonisolated var flags: OcaControllerFlags { .supportsLocking }
-  package nonisolated var connectionPrefix: String { OcaUdpConnectionPrefix }
+  package nonisolated var connectionPrefix: String {
+    controlProtocol == .ocp1 ? OcaUdpConnectionPrefix : OcaJsonUdpConnectionPrefix
+  }
 
   package var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()
   let peerAddress: any SocketAddress
@@ -46,6 +48,7 @@ package actor Ocp1FlyingSocksDatagramController: Ocp1ControllerInternal {
 
   package private(set) var isOpen: Bool = false
   package weak var endpoint: Ocp1FlyingSocksDatagramDeviceEndpoint?
+  package let controlProtocol: OcaControlProtocol
 
   package var messages: AnyAsyncSequence<Ocp1MessageList> {
     AsyncEmptySequence<Ocp1MessageList>().eraseToAnyAsyncSequence()
@@ -58,6 +61,7 @@ package actor Ocp1FlyingSocksDatagramController: Ocp1ControllerInternal {
     localAddress: (any SocketAddress)?
   ) {
     self.endpoint = endpoint
+    controlProtocol = endpoint.controlProtocol
     self.peerAddress = peerAddress
     self.interfaceIndex = interfaceIndex
     self.localAddress = localAddress

--- a/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingSocksDatagramController.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingSocksDatagramController.swift
@@ -34,7 +34,7 @@ import Glibc
 package actor Ocp1FlyingSocksDatagramController: Ocp1ControllerInternal {
   package nonisolated var flags: OcaControllerFlags { .supportsLocking }
   package nonisolated var connectionPrefix: String {
-    controlProtocol == .ocp1 ? OcaUdpConnectionPrefix : OcaJsonUdpConnectionPrefix
+    controlProtocol.connectionPrefix(ocp1: OcaUdpConnectionPrefix, ocp2: OcaJsonUdpConnectionPrefix)
   }
 
   package var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()

--- a/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingSocksDatagramDeviceEndpoint.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingSocksDatagramDeviceEndpoint.swift
@@ -62,6 +62,7 @@ public final class Ocp1FlyingSocksDatagramDeviceEndpoint: OcaDeviceEndpointPriva
   private let address: SocketAddress
   package let timeout: Duration
   package let device: OcaDevice
+  package let controlProtocol: OcaControlProtocol
   package let logger: Logger
   package nonisolated(unsafe) var enableMessageTracing = false
 
@@ -79,21 +80,30 @@ public final class Ocp1FlyingSocksDatagramDeviceEndpoint: OcaDeviceEndpointPriva
     address addressData: Data,
     timeout: Duration = OcaDevice.DefaultTimeout,
     device: OcaDevice = OcaDevice.shared,
+    controlProtocol: OcaControlProtocol = .ocp1,
     logger: Logger = Logger(label: "com.padl.SwiftOCADevice.Ocp1FlyingSocksDatagramDeviceEndpoint")
   ) async throws {
     let address = try FlyingSocks.AnySocketAddress(data: addressData)
-    try await self.init(address: address, timeout: timeout, device: device, logger: logger)
+    try await self.init(
+      address: address,
+      timeout: timeout,
+      device: device,
+      controlProtocol: controlProtocol,
+      logger: logger
+    )
   }
 
   private init(
     address: SocketAddress,
     timeout: Duration = OcaDevice.DefaultTimeout,
     device: OcaDevice = OcaDevice.shared,
+    controlProtocol: OcaControlProtocol = .ocp1,
     logger: Logger = Logger(label: "com.padl.SwiftOCADevice.Ocp1FlyingSocksDatagramDeviceEndpoint")
   ) async throws {
     self.address = address
     self.timeout = timeout
     self.device = device
+    self.controlProtocol = controlProtocol
     self.logger = logger
 
     pool = Self.defaultPool()
@@ -247,7 +257,7 @@ public final class Ocp1FlyingSocksDatagramDeviceEndpoint: OcaDeviceEndpointPriva
   }
 
   public nonisolated var serviceType: OcaNetworkAdvertisingServiceType {
-    .udp
+    OcaNetworkAdvertisingServiceType.udp.withControlProtocol(controlProtocol)
   }
 
   public nonisolated var port: UInt16 {

--- a/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingSocksStreamController.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingSocksStreamController.swift
@@ -54,12 +54,17 @@ package actor Ocp1FlyingSocksStreamController: Ocp1ControllerInternal, CustomStr
   }
 
   init(endpoint: Ocp1FlyingSocksStreamDeviceEndpoint, socket: AsyncSocket) throws {
-    let isJson = endpoint.controlProtocol != .ocp1
     if case .unix = try? socket.socket.sockname() {
-      connectionPrefix = isJson ? OcaJsonLocalConnectionPrefix : OcaLocalConnectionPrefix
+      connectionPrefix = endpoint.controlProtocol.connectionPrefix(
+        ocp1: OcaLocalConnectionPrefix,
+        ocp2: OcaJsonLocalConnectionPrefix
+      )
       flags = [.supportsLocking, .isLocal]
     } else {
-      connectionPrefix = isJson ? OcaJsonTcpConnectionPrefix : OcaTcpConnectionPrefix
+      connectionPrefix = endpoint.controlProtocol.connectionPrefix(
+        ocp1: OcaTcpConnectionPrefix,
+        ocp2: OcaJsonTcpConnectionPrefix
+      )
       flags = .supportsLocking
       try socket.socket.setValue(
         true,

--- a/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingSocksStreamController.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingSocksStreamController.swift
@@ -43,6 +43,7 @@ package actor Ocp1FlyingSocksStreamController: Ocp1ControllerInternal, CustomStr
   package var lastMessageReceivedTime = ContinuousClock.recentPast
   package var lastMessageSentTime = ContinuousClock.recentPast
   package weak var endpoint: Ocp1FlyingSocksStreamDeviceEndpoint?
+  package let controlProtocol: OcaControlProtocol
 
   private let address: String
   private let socket: AsyncSocket
@@ -53,11 +54,12 @@ package actor Ocp1FlyingSocksStreamController: Ocp1ControllerInternal, CustomStr
   }
 
   init(endpoint: Ocp1FlyingSocksStreamDeviceEndpoint, socket: AsyncSocket) throws {
+    let isJson = endpoint.controlProtocol != .ocp1
     if case .unix = try? socket.socket.sockname() {
-      connectionPrefix = OcaLocalConnectionPrefix
+      connectionPrefix = isJson ? OcaJsonLocalConnectionPrefix : OcaLocalConnectionPrefix
       flags = [.supportsLocking, .isLocal]
     } else {
-      connectionPrefix = OcaTcpConnectionPrefix
+      connectionPrefix = isJson ? OcaJsonTcpConnectionPrefix : OcaTcpConnectionPrefix
       flags = .supportsLocking
       try socket.socket.setValue(
         true,
@@ -67,8 +69,14 @@ package actor Ocp1FlyingSocksStreamController: Ocp1ControllerInternal, CustomStr
     }
     address = Self.makeIdentifier(from: socket.socket)
     self.endpoint = endpoint
+    controlProtocol = endpoint.controlProtocol
     self.socket = socket
-    _messages = AsyncThrowingStream.decodingMessages(from: socket.bytes, timeout: endpoint.timeout)
+    _messages = AsyncThrowingStream.decodingMessages(
+      from: socket.bytes,
+      timeout: endpoint.timeout,
+      controlProtocol: endpoint.controlProtocol,
+      maximumPduSize: endpoint.maximumPduSize
+    )
   }
 
   package var heartbeatTime = Duration.seconds(0) {
@@ -160,31 +168,41 @@ private extension AsyncThrowingStream
 {
   static func decodingMessages(
     from bytes: some AsyncBufferedSequence<UInt8>,
-    timeout: Duration
+    timeout: Duration,
+    controlProtocol: OcaControlProtocol,
+    maximumPduSize: Int
   ) -> Self {
+    // one iterator and one reader for the life of the connection: the reader
+    // buffers bytes between PDUs, so neither can be recreated per PDU
+    nonisolated(unsafe) var iterator = bytes.makeAsyncIterator()
+    let reader = controlProtocol.makeReader(isMessageOriented: false, maximumPduSize: maximumPduSize)
     // one timer for every read on the connection, rather than a sleep per message that the
     // runtime would keep for the whole timeout after the message arrived
     let deadlines = DeadlineTimer()
+
     return AsyncThrowingStream<Ocp1MessageList, Error> {
       do {
         return try await deadlines.withThrowingTimeout(of: timeout) {
-          nonisolated(unsafe) var iterator = bytes.makeAsyncIterator()
-          return try await OcaDevice.asyncReceiveMessages { count in
-            var nremain = count
-            var buffer = Data()
-            buffer.reserveCapacity(count)
+          try await OcaDevice.asyncReceiveMessages(
+            reader: reader,
+            controlProtocol: controlProtocol,
+            read: { count, awaitingAllRead in
+              var nremain = count
+              var buffer = Data()
+              buffer.reserveCapacity(count)
 
-            repeat {
-              let read = try await iterator.nextBuffer(suggested: nremain)
-              guard let read, !read.isEmpty else {
-                throw Ocp1Error.notConnected // EOF on zero bytes
-              }
-              buffer += read
-              nremain -= read.count
-            } while nremain > 0
+              repeat {
+                let read = try await iterator.nextBuffer(suggested: nremain)
+                guard let read, !read.isEmpty else {
+                  throw Ocp1Error.notConnected // EOF on zero bytes
+                }
+                buffer += read
+                nremain -= read.count
+              } while awaitingAllRead && nremain > 0
 
-            return buffer
-          }
+              return buffer
+            }
+          )
         }
       } catch Ocp1Error.pduTooShort {
         return nil
@@ -194,14 +212,6 @@ private extension AsyncThrowingStream
         throw error
       }
     }
-  }
-}
-
-extension OcaDevice {
-  static func asyncReceiveMessages(_ read: (Int) async throws -> Data) async throws
-    -> Ocp1MessageList
-  {
-    try await _receiveMessages(read)
   }
 }
 

--- a/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingSocksStreamDeviceEndpoint.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingSocksStreamDeviceEndpoint.swift
@@ -63,6 +63,7 @@ public final class Ocp1FlyingSocksStreamDeviceEndpoint: OcaDeviceEndpointPrivate
   package let timeout: Duration
   package let device: OcaDevice
   package let logger: Logger
+  package let controlProtocol: OcaControlProtocol
   package nonisolated(unsafe) var enableMessageTracing = false
 
   private var _controllers = [Ocp1FlyingSocksStreamController]()
@@ -80,31 +81,47 @@ public final class Ocp1FlyingSocksStreamDeviceEndpoint: OcaDeviceEndpointPrivate
     address addressData: Data,
     timeout: Duration = OcaDevice.DefaultTimeout,
     device: OcaDevice = OcaDevice.shared,
+    controlProtocol: OcaControlProtocol = .ocp1,
     logger: Logger = Logger(label: "com.padl.SwiftOCADevice.Ocp1FlyingSocksStreamDeviceEndpoint")
   ) async throws {
     let address = try FlyingSocks.AnySocketAddress(data: addressData)
-    try await self.init(address: address, timeout: timeout, device: device, logger: logger)
+    try await self.init(
+      address: address,
+      timeout: timeout,
+      device: device,
+      controlProtocol: controlProtocol,
+      logger: logger
+    )
   }
 
   public convenience init(
     path: String,
     timeout: Duration = OcaDevice.DefaultTimeout,
     device: OcaDevice = OcaDevice.shared,
+    controlProtocol: OcaControlProtocol = .ocp1,
     logger: Logger = Logger(label: "com.padl.SwiftOCADevice.Ocp1FlyingSocksStreamDeviceEndpoint")
   ) async throws {
     let address = sockaddr_un.unix(path: path).makeStorage()
-    try await self.init(address: address, timeout: timeout, device: device, logger: logger)
+    try await self.init(
+      address: address,
+      timeout: timeout,
+      device: device,
+      controlProtocol: controlProtocol,
+      logger: logger
+    )
   }
 
   private init(
     address: some SocketAddress,
     timeout: Duration = OcaDevice.DefaultTimeout,
     device: OcaDevice = OcaDevice.shared,
+    controlProtocol: OcaControlProtocol = .ocp1,
     logger: Logger = Logger(label: "com.padl.SwiftOCADevice.Ocp1FlyingSocksStreamDeviceEndpoint")
   ) async throws {
     self.address = address
     self.timeout = timeout
     self.device = device
+    self.controlProtocol = controlProtocol
     self.logger = logger
 
     pool = Self.defaultPool()
@@ -251,7 +268,7 @@ public final class Ocp1FlyingSocksStreamDeviceEndpoint: OcaDeviceEndpointPrivate
   }
 
   public nonisolated var serviceType: OcaNetworkAdvertisingServiceType {
-    .tcp
+    OcaNetworkAdvertisingServiceType.tcp.withControlProtocol(controlProtocol)
   }
 
   public nonisolated var port: UInt16 {

--- a/Sources/SwiftOCADevice/OCP.1/Backend/IORing/Ocp1IORingController.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/IORing/Ocp1IORingController.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 PADL Software Pty Ltd
+// Copyright (c) 2023-2026 PADL Software Pty Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.
@@ -85,6 +85,7 @@ package actor Ocp1IORingStreamController: Ocp1IORingControllerPrivate, CustomStr
   package var lastMessageReceivedTime = ContinuousClock.recentPast
   package var lastMessageSentTime = ContinuousClock.recentPast
   package weak var endpoint: Ocp1IORingStreamDeviceEndpoint?
+  package let controlProtocol: OcaControlProtocol
 
   package var messages: AnyAsyncSequence<Ocp1MessageList> {
     _messages.eraseToAnyAsyncSequence()
@@ -112,6 +113,7 @@ package actor Ocp1IORingStreamController: Ocp1IORingControllerPrivate, CustomStr
     _socket = .init(socket)
     self.notificationSocket = notificationSocket
     self.endpoint = endpoint
+    controlProtocol = endpoint.controlProtocol
 
     (_messages, _messagesContinuation) = AsyncThrowingStream.makeStream(
       of: Ocp1MessageList.self,
@@ -119,20 +121,26 @@ package actor Ocp1IORingStreamController: Ocp1IORingControllerPrivate, CustomStr
     )
 
     peerAddress = try AnySocketAddress(socket.peerAddress)
+    let isJson = endpoint.controlProtocol != .ocp1
     if peerAddress.family == AF_LOCAL {
-      connectionPrefix = OcaLocalConnectionPrefix
+      connectionPrefix = isJson ? OcaJsonLocalConnectionPrefix : OcaLocalConnectionPrefix
     } else {
-      connectionPrefix = OcaTcpConnectionPrefix
+      connectionPrefix = isJson ? OcaJsonTcpConnectionPrefix : OcaTcpConnectionPrefix
     }
 
+    let controlProtocol = endpoint.controlProtocol
+    let maximumPduSize = endpoint.maximumPduSize
     receiveMessageTask = Task { [weak self] in
+      // one reader for the life of the connection: it buffers bytes between PDUs
+      let reader = controlProtocol.makeReader(isMessageOriented: false, maximumPduSize: maximumPduSize)
       do {
         repeat {
           guard !Task.isCancelled, let socket = self?.socket else { break }
-          let messages = try await OcaDevice.receiveMessages { try await Data(socket.read(
-            count: $0,
-            awaitingAllRead: true
-          )) }
+          let messages = try await OcaDevice.asyncReceiveMessages(
+            reader: reader,
+            controlProtocol: controlProtocol,
+            read: { try await Data(socket.read(count: $0, awaitingAllRead: $1)) }
+          )
           self?._messagesContinuation.yield(messages)
         } while true
       } catch {
@@ -224,9 +232,16 @@ private extension Ocp1NetworkAddress {
   }
 }
 
-package actor Ocp1IORingDatagramController: Ocp1IORingControllerPrivate, Ocp1ControllerDatagramSemantics {
-  package nonisolated var flags: OcaControllerFlags { .supportsLocking }
-  package nonisolated var connectionPrefix: String { OcaUdpConnectionPrefix }
+package actor Ocp1IORingDatagramController: Ocp1IORingControllerPrivate,
+  Ocp1ControllerDatagramSemantics
+{
+  package nonisolated var flags: OcaControllerFlags {
+    .supportsLocking
+  }
+
+  package nonisolated var connectionPrefix: String {
+    controlProtocol == .ocp1 ? OcaUdpConnectionPrefix : OcaJsonUdpConnectionPrefix
+  }
 
   package var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()
   let peerAddress: AnySocketAddress
@@ -237,6 +252,7 @@ package actor Ocp1IORingDatagramController: Ocp1IORingControllerPrivate, Ocp1Con
 
   package private(set) var isOpen: Bool = false
   package weak var endpoint: Ocp1IORingDatagramDeviceEndpoint?
+  package let controlProtocol: OcaControlProtocol
 
   package var messages: AnyAsyncSequence<Ocp1MessageList> {
     AsyncEmptySequence<Ocp1MessageList>().eraseToAnyAsyncSequence()
@@ -247,6 +263,7 @@ package actor Ocp1IORingDatagramController: Ocp1IORingControllerPrivate, Ocp1Con
     peerAddress: AnySocketAddress
   ) {
     self.endpoint = endpoint
+    controlProtocol = endpoint.controlProtocol
     self.peerAddress = peerAddress
   }
 

--- a/Sources/SwiftOCADevice/OCP.1/Backend/IORing/Ocp1IORingController.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/IORing/Ocp1IORingController.swift
@@ -121,11 +121,16 @@ package actor Ocp1IORingStreamController: Ocp1IORingControllerPrivate, CustomStr
     )
 
     peerAddress = try AnySocketAddress(socket.peerAddress)
-    let isJson = endpoint.controlProtocol != .ocp1
-    if peerAddress.family == AF_LOCAL {
-      connectionPrefix = isJson ? OcaJsonLocalConnectionPrefix : OcaLocalConnectionPrefix
+    connectionPrefix = if peerAddress.family == AF_LOCAL {
+      endpoint.controlProtocol.connectionPrefix(
+        ocp1: OcaLocalConnectionPrefix,
+        ocp2: OcaJsonLocalConnectionPrefix
+      )
     } else {
-      connectionPrefix = isJson ? OcaJsonTcpConnectionPrefix : OcaTcpConnectionPrefix
+      endpoint.controlProtocol.connectionPrefix(
+        ocp1: OcaTcpConnectionPrefix,
+        ocp2: OcaJsonTcpConnectionPrefix
+      )
     }
 
     let controlProtocol = endpoint.controlProtocol
@@ -240,7 +245,7 @@ package actor Ocp1IORingDatagramController: Ocp1IORingControllerPrivate,
   }
 
   package nonisolated var connectionPrefix: String {
-    controlProtocol == .ocp1 ? OcaUdpConnectionPrefix : OcaJsonUdpConnectionPrefix
+    controlProtocol.connectionPrefix(ocp1: OcaUdpConnectionPrefix, ocp2: OcaJsonUdpConnectionPrefix)
   }
 
   package var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()

--- a/Sources/SwiftOCADevice/OCP.1/Backend/IORing/Ocp1IORingDeviceEndpoint.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/IORing/Ocp1IORingDeviceEndpoint.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2023 PADL Software Pty Ltd
+// Copyright (c) 2023-2026 PADL Software Pty Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the License);
 // you may not use this file except in compliance with the License.
@@ -49,6 +49,7 @@ open class Ocp1IORingDeviceEndpoint: OcaBonjourRegistrableDeviceEndpoint,
   package nonisolated let device: OcaDevice
   package nonisolated let logger: Logger
   package nonisolated let ring: IORing
+  package nonisolated let controlProtocol: OcaControlProtocol
   package nonisolated(unsafe) var enableMessageTracing = false
 
   package var socket: Socket?
@@ -64,12 +65,14 @@ open class Ocp1IORingDeviceEndpoint: OcaBonjourRegistrableDeviceEndpoint,
     address: any SocketAddress,
     timeout: Duration = OcaDevice.DefaultTimeout,
     device: OcaDevice = OcaDevice.shared,
+    controlProtocol: OcaControlProtocol = .ocp1,
     logger: Logger = Logger(label: "com.padl.SwiftOCADevice.Ocp1IORingDeviceEndpoint"),
     ring: IORing = .shared
   ) async throws {
     self.address = address
     self.timeout = timeout
     self.device = device
+    self.controlProtocol = controlProtocol
     self.logger = logger
     self.ring = ring
     try await device.add(endpoint: self)
@@ -83,23 +86,37 @@ open class Ocp1IORingDeviceEndpoint: OcaBonjourRegistrableDeviceEndpoint,
     address: Data,
     timeout: Duration = OcaDevice.DefaultTimeout,
     device: OcaDevice = OcaDevice.shared,
+    controlProtocol: OcaControlProtocol = .ocp1,
     logger: Logger = Logger(label: "com.padl.SwiftOCADevice.Ocp1IORingDeviceEndpoint")
   ) async throws {
     let storage = try sockaddr_storage(bytes: Array(address))
-    try await self.init(address: storage, timeout: timeout, device: device, logger: logger)
+    try await self.init(
+      address: storage,
+      timeout: timeout,
+      device: device,
+      controlProtocol: controlProtocol,
+      logger: logger
+    )
   }
 
   public convenience init(
     path: String,
     timeout: Duration = OcaDevice.DefaultTimeout,
     device: OcaDevice = OcaDevice.shared,
+    controlProtocol: OcaControlProtocol = .ocp1,
     logger: Logger = Logger(label: "com.padl.SwiftOCADevice.Ocp1IORingDeviceEndpoint")
   ) async throws {
     let storage = try sockaddr_un(
       family: sa_family_t(AF_LOCAL),
       presentationAddress: path
     )
-    try await self.init(address: storage, timeout: timeout, device: device, logger: logger)
+    try await self.init(
+      address: storage,
+      timeout: timeout,
+      device: device,
+      controlProtocol: controlProtocol,
+      logger: logger
+    )
   }
 
   #if canImport(dnssd)
@@ -138,7 +155,9 @@ open class Ocp1IORingDeviceEndpoint: OcaBonjourRegistrableDeviceEndpoint,
     #if canImport(dnssd)
     _endpointRegistrarTask?.cancel()
     #endif
-    if address.family == AF_LOCAL { try? unlinkDomainSocket() }
+    if address.family == AF_LOCAL {
+      try? unlinkDomainSocket()
+    }
   }
 }
 
@@ -233,7 +252,7 @@ public final class Ocp1IORingStreamDeviceEndpoint: Ocp1IORingDeviceEndpoint,
 
   #if canImport(dnssd)
   override public nonisolated var serviceType: OcaNetworkAdvertisingServiceType {
-    .tcp
+    OcaNetworkAdvertisingServiceType.tcp.withControlProtocol(controlProtocol)
   }
   #endif
 
@@ -263,6 +282,7 @@ public class Ocp1IORingDatagramDeviceEndpoint: Ocp1IORingDeviceEndpoint,
     address: any SocketAddress,
     timeout: Duration = OcaDevice.DefaultTimeout,
     device: OcaDevice = OcaDevice.shared,
+    controlProtocol: OcaControlProtocol = .ocp1,
     logger: Logger = Logger(label: "com.padl.SwiftOCADevice.Ocp1IORingDeviceEndpoint"),
     bufferCount: Int? = nil,
     ring: IORing = .shared
@@ -272,6 +292,7 @@ public class Ocp1IORingDatagramDeviceEndpoint: Ocp1IORingDeviceEndpoint,
       address: address,
       timeout: timeout,
       device: device,
+      controlProtocol: controlProtocol,
       logger: logger,
       ring: ring
     )
@@ -281,6 +302,7 @@ public class Ocp1IORingDatagramDeviceEndpoint: Ocp1IORingDeviceEndpoint,
     address: Data,
     timeout: Duration = OcaDevice.DefaultTimeout,
     device: OcaDevice = OcaDevice.shared,
+    controlProtocol: OcaControlProtocol = .ocp1,
     logger: Logger = Logger(label: "com.padl.SwiftOCADevice.Ocp1IORingDeviceEndpoint"),
     bufferCount: Int? = nil
   ) async throws {
@@ -289,6 +311,7 @@ public class Ocp1IORingDatagramDeviceEndpoint: Ocp1IORingDeviceEndpoint,
       address: storage,
       timeout: timeout,
       device: device,
+      controlProtocol: controlProtocol,
       logger: logger,
       bufferCount: bufferCount
     )
@@ -298,6 +321,7 @@ public class Ocp1IORingDatagramDeviceEndpoint: Ocp1IORingDeviceEndpoint,
     path: String,
     timeout: Duration = OcaDevice.DefaultTimeout,
     device: OcaDevice = OcaDevice.shared,
+    controlProtocol: OcaControlProtocol = .ocp1,
     logger: Logger = Logger(label: "com.padl.SwiftOCADevice.Ocp1IORingDeviceEndpoint"),
     bufferCount: Int? = nil
   ) async throws {
@@ -309,6 +333,7 @@ public class Ocp1IORingDatagramDeviceEndpoint: Ocp1IORingDeviceEndpoint,
       address: storage,
       timeout: timeout,
       device: device,
+      controlProtocol: controlProtocol,
       logger: logger,
       bufferCount: bufferCount
     )
@@ -361,7 +386,9 @@ public class Ocp1IORingDatagramDeviceEndpoint: Ocp1IORingDeviceEndpoint,
             controller = try self.controller(for: AnySocketAddress(bytes: messagePdu.name))
             try await handle(messagePduData: messagePdu.buffer, from: controller)
           } catch {
-            if let controller { await unlockAndRemove(controller: controller) }
+            if let controller {
+              await unlockAndRemove(controller: controller)
+            }
           }
         }
       } catch let error as Errno {
@@ -388,7 +415,9 @@ public class Ocp1IORingDatagramDeviceEndpoint: Ocp1IORingDeviceEndpoint,
       protocol: 0
     )
 
-    if address.family == sa_family_t(AF_INET6) { try socket.setIPv6Only() }
+    if address.family == sa_family_t(AF_INET6) {
+      try socket.setIPv6Only()
+    }
     try socket.bind(to: address)
 
     return socket
@@ -402,7 +431,7 @@ public class Ocp1IORingDatagramDeviceEndpoint: Ocp1IORingDeviceEndpoint,
   }
 
   override public nonisolated var serviceType: OcaNetworkAdvertisingServiceType {
-    .udp
+    OcaNetworkAdvertisingServiceType.udp.withControlProtocol(controlProtocol)
   }
 
   package func add(controller: ControllerType) async {}

--- a/Sources/SwiftOCADevice/OCP.1/Backend/Local/LocalConnection.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/Local/LocalConnection.swift
@@ -40,7 +40,7 @@ public final class OcaLocalConnection: Ocp1Connection {
   }
 
   override public var connectionPrefix: String {
-    OcaLocalConnectionPrefix
+    _connectionPrefix(ocp1: OcaLocalConnectionPrefix, ocp2: OcaJsonLocalConnectionPrefix)
   }
 
   override public var heartbeatTime: Duration {
@@ -53,7 +53,7 @@ public final class OcaLocalConnection: Ocp1Connection {
     endpoint.requestChannel.finish()
   }
 
-  override public func read(_ length: Int) async throws -> Data {
+  override public func read(_ length: Int, awaitingAllRead: Bool) async throws -> Data {
     for await data in endpoint.responseChannel {
       return data
     }

--- a/Sources/SwiftOCADevice/OCP.1/Backend/Local/LocalController.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/Local/LocalController.swift
@@ -40,9 +40,10 @@ package actor OcaLocalController: Ocp1ControllerInternal {
   init(endpoint: OcaLocalDeviceEndpoint) async {
     self.endpoint = endpoint
     controlProtocol = endpoint.controlProtocol
-    _connectionPrefix = endpoint.controlProtocol == .ocp1
-      ? OcaLocalConnectionPrefix
-      : OcaJsonLocalConnectionPrefix
+    _connectionPrefix = endpoint.controlProtocol.connectionPrefix(
+      ocp1: OcaLocalConnectionPrefix,
+      ocp2: OcaJsonLocalConnectionPrefix
+    )
   }
 
   package var messages: AnyAsyncSequence<Ocp1MessageList> {

--- a/Sources/SwiftOCADevice/OCP.1/Backend/Local/LocalController.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/Local/LocalController.swift
@@ -24,7 +24,8 @@ import SwiftOCA
 
 package actor OcaLocalController: Ocp1ControllerInternal {
   package nonisolated var flags: OcaControllerFlags { [.supportsLocking, .isLocal] }
-  package nonisolated var connectionPrefix: String { OcaLocalConnectionPrefix }
+  package nonisolated var connectionPrefix: String { _connectionPrefix }
+  private nonisolated let _connectionPrefix: String
 
   package var lastMessageReceivedTime = ContinuousClock.recentPast
   package var lastMessageSentTime = ContinuousClock.recentPast
@@ -33,15 +34,21 @@ package actor OcaLocalController: Ocp1ControllerInternal {
   package let writeQueue: Ocp1WriteQueue? = nil
 
   package weak var endpoint: OcaLocalDeviceEndpoint?
+  package let controlProtocol: OcaControlProtocol
   package var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()
 
   init(endpoint: OcaLocalDeviceEndpoint) async {
     self.endpoint = endpoint
+    controlProtocol = endpoint.controlProtocol
+    _connectionPrefix = endpoint.controlProtocol == .ocp1
+      ? OcaLocalConnectionPrefix
+      : OcaJsonLocalConnectionPrefix
   }
 
   package var messages: AnyAsyncSequence<Ocp1MessageList> {
-    endpoint!.requestChannel.map { data in
-      try Ocp1MessageList(messagePduData: data)
+    let controlProtocol = endpoint!.controlProtocol
+    return endpoint!.requestChannel.map { data in
+      try Ocp1MessageList(messagePduData: data, controlProtocol: controlProtocol)
     }.eraseToAnyAsyncSequence()
   }
 

--- a/Sources/SwiftOCADevice/OCP.1/Backend/Local/LocalDeviceEndpoint.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/Local/LocalDeviceEndpoint.swift
@@ -31,6 +31,7 @@ public final class OcaLocalDeviceEndpoint: OcaDeviceEndpointPrivate {
   package let timeout: Duration = .zero
   package let device: OcaDevice
   package let logger: Logger
+  package let controlProtocol: OcaControlProtocol
   package nonisolated(unsafe) var enableMessageTracing = false
 
   public var controllers: [OcaController] {
@@ -50,9 +51,11 @@ public final class OcaLocalDeviceEndpoint: OcaDeviceEndpointPrivate {
 
   public init(
     device: OcaDevice = OcaDevice.shared,
+    controlProtocol: OcaControlProtocol = .ocp1,
     logger: Logger = Logger(label: "com.padl.SwiftOCADevice.OcaLocalDeviceEndpoint")
   ) async throws {
     self.device = device
+    self.controlProtocol = controlProtocol
     self.logger = logger
 
     controller = await OcaLocalController(endpoint: self)

--- a/Sources/SwiftOCADevice/OCP.1/Backend/MachPort/Ocp1MachPortController.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/MachPort/Ocp1MachPortController.swift
@@ -39,6 +39,7 @@ package actor Ocp1MachPortController: Ocp1ControllerInternal {
   package let writeQueue: Ocp1WriteQueue? = nil
 
   package weak var endpoint: Ocp1MachPortDeviceEndpoint?
+  package let controlProtocol: OcaControlProtocol
   package var subscriptions = [OcaONo: Set<OcaSubscriptionManagerSubscription>]()
 
   /// our dedicated receive port for this controller session
@@ -56,6 +57,7 @@ package actor Ocp1MachPortController: Ocp1ControllerInternal {
     identifier: String
   ) {
     self.endpoint = endpoint
+    controlProtocol = endpoint.controlProtocol
     self.receiveHandle = receiveHandle
     self.clientSendPort = clientSendPort
     self.identifier = identifier

--- a/Sources/SwiftOCADevice/OCP.1/Backend/Network/Ocp1NWDatagramController.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/Network/Ocp1NWDatagramController.swift
@@ -53,6 +53,7 @@ package actor Ocp1NWDatagramController: Ocp1ControllerInternal,
   package var lastMessageReceivedTime = ContinuousClock.recentPast
   package var lastMessageSentTime = ContinuousClock.recentPast
   package weak var endpoint: Ocp1NWDatagramDeviceEndpoint?
+  package let controlProtocol: OcaControlProtocol
 
   private let connection: NWConnection
   private let _messages: AsyncThrowingStream<Ocp1MessageList, Error>
@@ -71,6 +72,7 @@ package actor Ocp1NWDatagramController: Ocp1ControllerInternal,
 
   init(endpoint: Ocp1NWDatagramDeviceEndpoint, connection: NWConnection) {
     self.endpoint = endpoint
+    controlProtocol = endpoint.controlProtocol
     self.connection = connection
     flags = endpoint.controllerFlags
     connectionPrefix = endpoint.controllerConnectionPrefix

--- a/Sources/SwiftOCADevice/OCP.1/Backend/Network/Ocp1NWDatagramController.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/Network/Ocp1NWDatagramController.swift
@@ -77,7 +77,7 @@ package actor Ocp1NWDatagramController: Ocp1ControllerInternal,
     flags = endpoint.controllerFlags
     connectionPrefix = endpoint.controllerConnectionPrefix
     identifier = Self.makeIdentifier(from: connection)
-    _messages = Self.makeMessagesStream(on: connection)
+    _messages = Self.makeMessagesStream(on: connection, controlProtocol: controlProtocol)
   }
 
   package func sendOcp1EncodedData(_ data: Data) async throws {
@@ -142,13 +142,14 @@ private extension Ocp1NWDatagramController {
   }
 
   /// One whole datagram per element; one datagram may carry multiple
-  /// concatenated OCP.1 PDUs.
+  /// concatenated OCP.1 PDUs, or one newline-terminated OCP.2 PDU.
   static func makeMessagesStream(
-    on connection: NWConnection
+    on connection: NWConnection,
+    controlProtocol: OcaControlProtocol
   ) -> AsyncThrowingStream<Ocp1MessageList, Error> {
     AsyncThrowingStream { () async throws -> Ocp1MessageList? in
       let datagram = try await connection.receiveOneDatagram()
-      return try Ocp1MessageList(messagePduData: datagram)
+      return try Ocp1MessageList(messagePduData: datagram, controlProtocol: controlProtocol)
     }
   }
 }

--- a/Sources/SwiftOCADevice/OCP.1/Backend/Network/Ocp1NWDatagramDeviceEndpoint.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/Network/Ocp1NWDatagramDeviceEndpoint.swift
@@ -43,6 +43,7 @@ open class Ocp1NWDatagramDeviceEndpoint: OcaDeviceEndpointPrivate,
 
   package let timeout: Duration
   package let device: OcaDevice
+  package let controlProtocol: OcaControlProtocol
   package nonisolated let logger: Logger
   package nonisolated(unsafe) var enableMessageTracing = false
 
@@ -82,6 +83,7 @@ open class Ocp1NWDatagramDeviceEndpoint: OcaDeviceEndpointPrivate,
     port: UInt16,
     timeout: Duration = OcaDevice.DefaultTimeout,
     device: OcaDevice = OcaDevice.shared,
+    controlProtocol: OcaControlProtocol = .ocp1,
     logger: Logger = Logger(label: "com.padl.SwiftOCADevice.Ocp1NWDatagramDeviceEndpoint")
   ) async throws {
     guard let nwPort = NWEndpoint.Port(rawValue: port) else {
@@ -90,6 +92,7 @@ open class Ocp1NWDatagramDeviceEndpoint: OcaDeviceEndpointPrivate,
     _port = nwPort
     self.timeout = timeout
     self.device = device
+    self.controlProtocol = controlProtocol
     self.logger = logger
     queue = DispatchQueue(label: "com.padl.SwiftOCADevice.NWListener.udp.\(port)")
     try await device.add(endpoint: self)
@@ -246,11 +249,11 @@ public final class Ocp1NWUDPDeviceEndpoint: Ocp1NWDatagramDeviceEndpoint {
   }
 
   override public nonisolated var controllerConnectionPrefix: String {
-    OcaUdpConnectionPrefix
+    controlProtocol == .ocp1 ? OcaUdpConnectionPrefix : OcaJsonUdpConnectionPrefix
   }
 
   override public nonisolated var serviceType: OcaNetworkAdvertisingServiceType {
-    .udp
+    OcaNetworkAdvertisingServiceType.udp.withControlProtocol(controlProtocol)
   }
 }
 

--- a/Sources/SwiftOCADevice/OCP.1/Backend/Network/Ocp1NWDatagramDeviceEndpoint.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/Network/Ocp1NWDatagramDeviceEndpoint.swift
@@ -249,7 +249,7 @@ public final class Ocp1NWUDPDeviceEndpoint: Ocp1NWDatagramDeviceEndpoint {
   }
 
   override public nonisolated var controllerConnectionPrefix: String {
-    controlProtocol == .ocp1 ? OcaUdpConnectionPrefix : OcaJsonUdpConnectionPrefix
+    controlProtocol.connectionPrefix(ocp1: OcaUdpConnectionPrefix, ocp2: OcaJsonUdpConnectionPrefix)
   }
 
   override public nonisolated var serviceType: OcaNetworkAdvertisingServiceType {

--- a/Sources/SwiftOCADevice/OCP.1/Backend/Network/Ocp1NWStreamController.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/Network/Ocp1NWStreamController.swift
@@ -50,6 +50,7 @@ package actor Ocp1NWStreamController: Ocp1ControllerInternal, CustomStringConver
   package var lastMessageReceivedTime = ContinuousClock.recentPast
   package var lastMessageSentTime = ContinuousClock.recentPast
   package weak var endpoint: Ocp1NWStreamDeviceEndpoint?
+  package let controlProtocol: OcaControlProtocol
 
   private let connection: NWConnection
   private let _messages: AsyncThrowingStream<Ocp1MessageList, Error>
@@ -67,11 +68,17 @@ package actor Ocp1NWStreamController: Ocp1ControllerInternal, CustomStringConver
 
   init(endpoint: Ocp1NWStreamDeviceEndpoint, connection: NWConnection) {
     self.endpoint = endpoint
+    controlProtocol = endpoint.controlProtocol
     self.connection = connection
     flags = endpoint.controllerFlags
     connectionPrefix = endpoint.controllerConnectionPrefix
     identifier = Self.makeIdentifier(from: connection)
-    _messages = Self.makeMessagesStream(on: connection, timeout: endpoint.timeout)
+    _messages = Self.makeMessagesStream(
+      on: connection,
+      timeout: endpoint.timeout,
+      controlProtocol: endpoint.controlProtocol,
+      maximumPduSize: endpoint.maximumPduSize
+    )
   }
 
   package func sendOcp1EncodedData(_ data: Data) async throws {
@@ -135,32 +142,41 @@ private extension Ocp1NWStreamController {
 
   static func makeMessagesStream(
     on connection: NWConnection,
-    timeout: Duration
+    timeout: Duration,
+    controlProtocol: OcaControlProtocol,
+    maximumPduSize: Int
   ) -> AsyncThrowingStream<Ocp1MessageList, Error> {
     // one timer for every read on the connection, rather than a sleep per message that the
     // runtime would keep for the whole timeout after the message arrived
     let deadlines = DeadlineTimer()
+    let reader = controlProtocol.makeReader(isMessageOriented: false, maximumPduSize: maximumPduSize)
     return AsyncThrowingStream { () async throws -> Ocp1MessageList? in
       try await deadlines.withThrowingTimeout(of: timeout) {
-        try await OcaDevice.asyncReceiveMessages { count in
-          try await connection.receiveExactly(count)
-        }
+        try await OcaDevice.asyncReceiveMessages(
+          reader: reader,
+          controlProtocol: controlProtocol,
+          read: { count, awaitingAllRead in
+            try await connection.receive(count, awaitingAllRead: awaitingAllRead)
+          }
+        )
       }
     }
   }
 }
 
 extension NWConnection {
-  /// Maps graceful peer-close to `.notConnected`.
-  fileprivate func receiveExactly(_ count: Int) async throws -> Data {
+  /// Exactly `count` bytes when `awaitingAllRead`, else between 1 and `count` as soon
+  /// as any arrive. Maps graceful peer-close to `.notConnected`.
+  fileprivate func receive(_ count: Int, awaitingAllRead: Bool) async throws -> Data {
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Data, Error>) in
-      receive(minimumIncompleteLength: count, maximumLength: count) { data, _, isComplete, error in
+      receive(
+        minimumIncompleteLength: awaitingAllRead ? count : 1,
+        maximumLength: count
+      ) { data, _, _, error in
         if let error {
           continuation.resume(throwing: error)
-        } else if let data, data.count == count {
+        } else if let data, awaitingAllRead ? data.count == count : !data.isEmpty {
           continuation.resume(returning: data)
-        } else if isComplete {
-          continuation.resume(throwing: Ocp1Error.notConnected)
         } else {
           continuation.resume(throwing: Ocp1Error.notConnected)
         }

--- a/Sources/SwiftOCADevice/OCP.1/Backend/Network/Ocp1NWStreamDeviceEndpoint.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/Network/Ocp1NWStreamDeviceEndpoint.swift
@@ -45,6 +45,7 @@ open class Ocp1NWStreamDeviceEndpoint: OcaDeviceEndpointPrivate,
   package let timeout: Duration
   package let device: OcaDevice
   package nonisolated let logger: Logger
+  package let controlProtocol: OcaControlProtocol
   package nonisolated(unsafe) var enableMessageTracing = false
 
   private let _port: NWEndpoint.Port
@@ -90,6 +91,7 @@ open class Ocp1NWStreamDeviceEndpoint: OcaDeviceEndpointPrivate,
     port: UInt16,
     timeout: Duration = OcaDevice.DefaultTimeout,
     device: OcaDevice = OcaDevice.shared,
+    controlProtocol: OcaControlProtocol = .ocp1,
     logger: Logger = Logger(label: "com.padl.SwiftOCADevice.Ocp1NWStreamDeviceEndpoint")
   ) async throws {
     guard let nwPort = NWEndpoint.Port(rawValue: port) else {
@@ -98,6 +100,7 @@ open class Ocp1NWStreamDeviceEndpoint: OcaDeviceEndpointPrivate,
     _port = nwPort
     self.timeout = timeout
     self.device = device
+    self.controlProtocol = controlProtocol
     self.logger = logger
     queue = DispatchQueue(label: "com.padl.SwiftOCADevice.NWListener.\(port)")
 
@@ -258,11 +261,11 @@ public final class Ocp1NWTCPDeviceEndpoint: Ocp1NWStreamDeviceEndpoint {
   }
 
   override public nonisolated var controllerConnectionPrefix: String {
-    OcaTcpConnectionPrefix
+    controlProtocol == .ocp1 ? OcaTcpConnectionPrefix : OcaJsonTcpConnectionPrefix
   }
 
   override public nonisolated var serviceType: OcaNetworkAdvertisingServiceType {
-    .tcp
+    OcaNetworkAdvertisingServiceType.tcp.withControlProtocol(controlProtocol)
   }
 }
 

--- a/Sources/SwiftOCADevice/OCP.1/Backend/Network/Ocp1NWStreamDeviceEndpoint.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/Network/Ocp1NWStreamDeviceEndpoint.swift
@@ -261,7 +261,7 @@ public final class Ocp1NWTCPDeviceEndpoint: Ocp1NWStreamDeviceEndpoint {
   }
 
   override public nonisolated var controllerConnectionPrefix: String {
-    controlProtocol == .ocp1 ? OcaTcpConnectionPrefix : OcaJsonTcpConnectionPrefix
+    controlProtocol.connectionPrefix(ocp1: OcaTcpConnectionPrefix, ocp2: OcaJsonTcpConnectionPrefix)
   }
 
   override public nonisolated var serviceType: OcaNetworkAdvertisingServiceType {

--- a/Sources/SwiftOCADevice/OCP.1/Ocp1ControllerInternal.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Ocp1ControllerInternal.swift
@@ -38,14 +38,19 @@ package struct Ocp1MessageList: Sendable {
     self.init(responseRequired: messageType == .ocaCmdRrq, messages: messages)
   }
 
+  /// OCP.1 framing; backends that only speak OCP.1 use this.
   package init(messagePduData data: Data) throws {
-    let (messageType, messages) = try Ocp1Connection.decodeOcp1MessagePdu(from: data)
+    try self.init(messagePduData: data, controlProtocol: .ocp1)
+  }
+
+  package init(messagePduData data: Data, controlProtocol: OcaControlProtocol) throws {
+    let (messageType, messages) = try controlProtocol.decodePdu(data)
     self.init(messageType: messageType, messages: messages)
   }
 }
 
-/// OcaControllerPrivate should eventually be merged into OcaController once we are ready to
-/// support out-of-tree endpoints
+// OcaControllerPrivate should eventually be merged into OcaController once we are ready to
+// support out-of-tree endpoints
 
 package protocol Ocp1ControllerInternal: OcaControllerDefaultSubscribing, Actor {
   associatedtype Endpoint: OcaDeviceEndpointPrivate
@@ -94,7 +99,7 @@ package protocol Ocp1ControllerDatagramSemantics: Actor {
   func didOpen()
 }
 
-extension Ocp1ControllerInternal {
+package extension Ocp1ControllerInternal {
   /// handle a single message
   private func _handle<Endpoint: OcaDeviceEndpointPrivate>(
     for endpoint: Endpoint,
@@ -127,6 +132,8 @@ extension Ocp1ControllerInternal {
       heartbeatTime = .seconds(keepAlive.heartBeatTime)
     case let keepAlive as Ocp1KeepAlive2:
       heartbeatTime = .milliseconds(keepAlive.heartBeatTime)
+    case is Ocp2DeviceReset:
+      endpoint.logger.info("device reset requested by \(controller); not supported")
     default:
       endpoint.logger.info("received unknown message \(message)")
       throw Ocp1Error.invalidMessageType
@@ -140,7 +147,7 @@ extension Ocp1ControllerInternal {
   }
 
   /// handle a list of messages
-  package func handle(
+  func handle(
     for endpoint: some OcaDeviceEndpointPrivate,
     messageList: Ocp1MessageList
   ) async throws {
@@ -167,7 +174,7 @@ extension Ocp1ControllerInternal {
   }
 
   /// handle messages until an error
-  package func handle<Endpoint: OcaDeviceEndpointPrivate>(for endpoint: Endpoint) async {
+  func handle<Endpoint: OcaDeviceEndpointPrivate>(for endpoint: Endpoint) async {
     let controller = self as! Endpoint.ControllerType
 
     endpoint.logger.info("controller added", controller: controller)
@@ -203,14 +210,14 @@ extension Ocp1ControllerInternal {
     )
   }
 
-  package func cancelKeepAlive() {
+  func cancelKeepAlive() {
     keepAliveTask?.cancel()
     keepAliveTask = nil
   }
 
   /// Oca-3 notes that both controller and device send `KeepAlive` messages if they haven't
   /// yet received (or sent) another message during `HeartbeatTime`.
-  package func heartbeatTimeDidChange(from oldValue: Duration) {
+  func heartbeatTimeDidChange(from oldValue: Duration) {
     if heartbeatTime == .zero {
       cancelKeepAlive()
     } else if heartbeatTime != oldValue || keepAliveTask == nil {
@@ -248,27 +255,17 @@ extension Ocp1ControllerInternal {
     }
   }
 
-  package func decodeMessages(from messagePduData: Data) throws -> Ocp1MessageList {
-    guard messagePduData.count >= Ocp1Connection.MinimumPduSize,
-          messagePduData[messagePduData.startIndex] == Ocp1SyncValue
-    else {
-      throw Ocp1Error.invalidSyncValue
-    }
-    let pduSize: OcaUint32 = messagePduData.decodeInteger(index: messagePduData.startIndex + 3)
-    guard pduSize >= (Ocp1Connection.MinimumPduSize - 1) else {
-      throw Ocp1Error.invalidPduSize
-    }
-
-    return try Ocp1MessageList(messagePduData: messagePduData)
+  func decodeMessages(from messagePduData: Data) throws -> Ocp1MessageList {
+    try Ocp1MessageList(messagePduData: messagePduData, controlProtocol: controlProtocol)
   }
 
-  package func sendMessages(
+  func sendMessages(
     _ messages: [Ocp1Message],
     type messageType: OcaMessageType
   ) async throws {
     lastMessageSentTime = .now
 
-    let data = try Ocp1Connection.encodeOcp1MessagePdu(messages, type: messageType)
+    let data = try controlProtocol.encodePdu(messages, type: messageType)
     if let writeQueue {
       try await writeQueue.serialised { [self] in
         try await sendOcp1EncodedData(data)
@@ -282,34 +279,38 @@ extension Ocp1ControllerInternal {
 extension OcaDevice {
   package typealias ReadCallback = @Sendable (Int) async throws -> Data
 
+  /// Reads and decodes one PDU. `reader` is owned by the calling receive loop and
+  /// carries buffered bytes from one call to the next on stream transports.
+  static func _receiveMessages(
+    reader: any OcaPduReader,
+    controlProtocol: OcaControlProtocol,
+    read: (_ count: Int, _ awaitingAllRead: Bool) async throws -> Data
+  ) async throws -> Ocp1MessageList {
+    let messagePduData = try await reader.nextPdu(read: read)
+    return try Ocp1MessageList(messagePduData: messagePduData, controlProtocol: controlProtocol)
+  }
+
+  /// OCP.1-only convenience for backends with an exact-length read: OCP.1 always
+  /// awaits all of a read.
   static func _receiveMessages(_ read: (Int) async throws -> Data) async throws -> Ocp1MessageList {
-    var messagePduData = try await read(Ocp1Connection.MinimumPduSize)
-
-    guard messagePduData.count != 0 else {
-      // 0 length on EOF
-      throw Ocp1Error.notConnected
-    }
-
-    guard messagePduData.count >= Ocp1Connection.MinimumPduSize,
-          messagePduData[messagePduData.startIndex] == Ocp1SyncValue
-    else {
-      throw Ocp1Error.invalidSyncValue
-    }
-
-    let pduSize: OcaUint32 = messagePduData.decodeInteger(index: messagePduData.startIndex + 3)
-    guard pduSize >= (Ocp1Connection.MinimumPduSize - 1) else {
-      throw Ocp1Error.invalidPduSize
-    }
-
-    let bytesLeft = Int(pduSize) - (Ocp1Connection.MinimumPduSize - 1)
-    messagePduData += try await read(bytesLeft)
-
-    return try Ocp1MessageList(messagePduData: messagePduData)
+    try await _receiveMessages(
+      reader: Ocp1PduReader(maximumPduSize: Int.max),
+      controlProtocol: .ocp1,
+      read: { count, _ in try await read(count) }
+    )
   }
 
   @concurrent
   package static func receiveMessages(_ read: ReadCallback) async throws -> Ocp1MessageList {
     try await _receiveMessages(read)
+  }
+
+  static func asyncReceiveMessages(
+    reader: any OcaPduReader,
+    controlProtocol: OcaControlProtocol,
+    read: (_ count: Int, _ awaitingAllRead: Bool) async throws -> Data
+  ) async throws -> Ocp1MessageList {
+    try await _receiveMessages(reader: reader, controlProtocol: controlProtocol, read: read)
   }
 }
 
@@ -320,20 +321,20 @@ package protocol Ocp1ControllerInternalLightweightNotifyingInternal: OcaControll
   ) async throws
 }
 
-extension Ocp1ControllerInternalLightweightNotifyingInternal {
-  package func sendMessage(
+package extension Ocp1ControllerInternalLightweightNotifyingInternal {
+  func sendMessage(
     _ message: Ocp1Message,
     type messageType: OcaMessageType,
     to destinationAddress: OcaNetworkAddress
   ) async throws {
-    try await sendOcp1EncodedData(Ocp1Connection.encodeOcp1MessagePdu(
+    try await sendOcp1EncodedData(controlProtocol.encodePdu(
       [message],
       type: messageType
     ), to: destinationAddress)
   }
 }
 
-// https://www.swiftbysundell.com/articles/async-and-concurrent-forEach-and-map/
+/// https://www.swiftbysundell.com/articles/async-and-concurrent-forEach-and-map/
 extension Sequence {
   func asyncForEach(
     _ operation: @Sendable (Element) async throws -> ()

--- a/Sources/SwiftOCASecure/OCP.1/Backend/Ocp1OpenSSLConnection.swift
+++ b/Sources/SwiftOCASecure/OCP.1/Backend/Ocp1OpenSSLConnection.swift
@@ -227,13 +227,18 @@ public final class Ocp1OpenSSLConnection: Ocp1Connection, Ocp1MutableSocketAddre
     try await super.disconnectDevice()
   }
 
-  override public func read(_ length: Int) async throws -> Data {
+  override public func read(_ length: Int, awaitingAllRead: Bool) async throws -> Data {
     guard let socket = _socket.withLock({ $0 }) else {
       throw Ocp1Error.notConnected
     }
     let (read, write) = Self.makeTransportClosures(socket)
     do {
-      return try await _engine.read(length, read: read, write: write)
+      return try await _engine.read(
+        length,
+        awaitingAllRead: awaitingAllRead,
+        read: read,
+        write: write
+      )
     } catch let error as Errno {
       throw error.mappedError
     }

--- a/Sources/SwiftOCASecure/OCP.1/Backend/Ocp1OpenSSLDTLSConnection.swift
+++ b/Sources/SwiftOCASecure/OCP.1/Backend/Ocp1OpenSSLDTLSConnection.swift
@@ -223,7 +223,7 @@ public final class Ocp1OpenSSLDTLSConnection: Ocp1Connection, Ocp1MutableSocketA
     try await super.disconnectDevice()
   }
 
-  override public func read(_ length: Int) async throws -> Data {
+  override public func read(_ length: Int, awaitingAllRead: Bool) async throws -> Data {
     guard let socket = _socket.withLock({ $0 }) else {
       throw Ocp1Error.notConnected
     }

--- a/Sources/SwiftOCASecure/OCP.1/Backend/Ocp1OpenSSLEngine.swift
+++ b/Sources/SwiftOCASecure/OCP.1/Backend/Ocp1OpenSSLEngine.swift
@@ -829,8 +829,11 @@ package actor Ocp1OpenSSLEngine {
     }
   }
 
+  /// Exactly `count` bytes when `awaitingAllRead`, else between 1 and `count` as soon
+  /// as any are decrypted.
   package func read(
     _ count: Int,
+    awaitingAllRead: Bool,
     read networkRead: @Sendable (Int) async throws -> Data,
     write networkWrite: @Sendable (Data) async throws -> Void
   ) async throws -> Data {
@@ -842,7 +845,7 @@ package actor Ocp1OpenSSLEngine {
       var result = Data()
       result.reserveCapacity(count)
       var buffer = [UInt8](repeating: 0, count: count)
-      while result.count < count {
+      while result.count < (awaitingAllRead ? count : 1) {
         let want = count - result.count
         let ret = buffer.withUnsafeMutableBufferPointer { buf -> CInt in
           SSL_read(ssl, buf.baseAddress, CInt(want))

--- a/Sources/SwiftOCASecureDevice/OCP.1/Backend/OpenSSL/Ocp1OpenSSLStreamController.swift
+++ b/Sources/SwiftOCASecureDevice/OCP.1/Backend/OpenSSL/Ocp1OpenSSLStreamController.swift
@@ -106,6 +106,7 @@ package actor Ocp1OpenSSLStreamController: Ocp1ControllerInternal, CustomStringC
           let messages = try await OcaDevice.receiveMessages { count in
             try await engineRef.read(
               count,
+              awaitingAllRead: true,
               read: { c in try await streamRef.read(count: c, awaitingAllRead: false) },
               write: { d in try await streamRef.write(d) }
             )

--- a/Tests/SwiftOCADeviceTests/BackendConnectionTests.swift
+++ b/Tests/SwiftOCADeviceTests/BackendConnectionTests.swift
@@ -432,11 +432,11 @@ extension NWConnectionTests {
     let connection = try await makeNWTCPConnection(port: server.port)
     // the transport alone: connect() would start a monitor reading alongside
     try await connection.connectDevice()
-    let first = try await connection.read(7)
+    let first = try await connection.read(7, awaitingAllRead: true)
     XCTAssertEqual(Array(first), Array(payload[..<7]))
     // a read that took more than asked left nothing for the next, which would wait forever
     guard first.count == 7 else { return }
-    let rest = try await connection.read(13)
+    let rest = try await connection.read(13, awaitingAllRead: true)
     XCTAssertEqual(Array(rest), Array(payload[7...]))
     try await connection.disconnectDevice()
   }

--- a/Tests/SwiftOCADeviceTests/Ocp2DeviceNamingOracleTests.swift
+++ b/Tests/SwiftOCADeviceTests/Ocp2DeviceNamingOracleTests.swift
@@ -127,7 +127,7 @@ final class Ocp2DeviceNamingOracleTests: XCTestCase {
         let setter = lookup(property.setMethodID)
         for (method, expected, sent) in [
           (getter, getter?.outputs, responseNames),
-          (setter, setter?.inputs, [property.wireName(propertyName: swiftName)]),
+          (setter, setter?.inputs, [property.setName(propertyName: swiftName)]),
         ] {
           guard let method, let expected, !expected.isEmpty else { continue }
           checked.insert("\(definingClass)/\(method.methodID)")

--- a/Tests/SwiftOCADeviceTests/Ocp2DeviceNamingOracleTests.swift
+++ b/Tests/SwiftOCADeviceTests/Ocp2DeviceNamingOracleTests.swift
@@ -1,0 +1,161 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if NonEmbeddedBuild
+
+import Foundation
+@testable @_spi(SwiftOCAPrivate) import SwiftOCA
+@testable @_spi(SwiftOCAPrivate) import SwiftOCADevice
+import XCTest
+
+/// The device-side counterpart of `Ocp2NamingOracleTests`: compares the names a device
+/// wrapper puts on a getter's response and expects on a setter's parameter against the
+/// AES70-2 class model, so the two sides cannot drift apart. The model scrape is
+/// duplicated from the client oracle, as the two test targets share no code.
+///
+/// Informational: it prints every deviation and fails only if the model cannot be
+/// read. Point `AES70_2_XMI` at `AES70-2-2023-231218.xmi` to run it; skipped otherwise.
+final class Ocp2DeviceNamingOracleTests: XCTestCase {
+  private struct Method {
+    let classID: String
+    let className: String
+    let methodID: String
+    let name: String
+    let inputs: [String]
+    let outputs: [String]
+  }
+
+  private static func loadModel(from url: URL) throws -> [Method] {
+    let text = try String(contentsOf: url, encoding: .windowsCP1252)
+
+    func matches(_ pattern: String, in string: String, options: NSRegularExpression.Options = []) -> [[String]] {
+      let regex = try! NSRegularExpression(pattern: pattern, options: options)
+      return regex.matches(in: string, range: NSRange(string.startIndex..., in: string)).map { match in
+        (1..<match.numberOfRanges).map { Range(match.range(at: $0), in: string).map { String(string[$0]) } ?? "" }
+      }
+    }
+
+    var methodIDs = [String: String]()
+    for m in matches("<operation xmi:idref=\"([^\"]+)\"[^>]*>.*?<style value=\"([^\"]*)\"", in: text, options: [.dotMatchesLineSeparators]) {
+      if let styleMatch = matches("^\\s*(\\d+)m(\\d+)", in: m[1]).first {
+        methodIDs[m[0]] = "\(Int(styleMatch[0])!).\(Int(styleMatch[1])!)"
+      }
+    }
+
+    var methods = [Method]()
+    let classes = matches(
+      "<packagedElement xmi:type=\"uml:Class\" xmi:id=\"([^\"]+)\" name=\"(Oca[A-Za-z0-9]+)\"[^>]*>(.*?)</packagedElement>",
+      in: text,
+      options: [.dotMatchesLineSeparators]
+    )
+    for cls in classes {
+      guard let classID = matches("name=\"ClassID\".*?<defaultValue[^>]*value=\"([0-9.]+)\"", in: cls[2], options: [.dotMatchesLineSeparators]).first?[0]
+      else { continue }
+      for op in matches("<ownedOperation xmi:id=\"([^\"]+)\" name=\"([^\"]+)\"[^>]*>(.*?)</ownedOperation>", in: cls[2], options: [.dotMatchesLineSeparators]) {
+        guard let methodID = methodIDs[op[0]] else { continue }
+        let params = matches("<ownedParameter [^>]*name=\"([^\"]+)\" direction=\"(in|out|return)\"", in: op[2])
+        methods.append(Method(
+          classID: classID,
+          className: cls[1],
+          methodID: methodID,
+          name: op[1],
+          inputs: params.filter { $0[1] == "in" }.map { $0[0] },
+          outputs: params.filter { $0[1] == "out" }.map { $0[0] }
+        ))
+      }
+    }
+    return methods
+  }
+
+  private static func namesMatch(_ sent: [String], _ expected: [String]) -> Bool {
+    sent.count == expected.count && zip(sent, expected).allSatisfy(Ocp2Naming.matches)
+  }
+
+  /// The names every registered device class puts on the wire, judged against the model.
+  @OcaDevice
+  private static func audit(_ model: [Method]) async throws -> (checked: Int, deviations: Set<String>) {
+    let byClassAndMethod = Dictionary(
+      model.map { ("\($0.classID)/\($0.methodID)", $0) },
+      uniquingKeysWith: { first, _ in first }
+    )
+    var deviations = Set<String>()
+    var checked = Set<String>()
+
+    for (identification, type) in OcaDeviceClassRegistry.shared.registeredClasses {
+      // the generic basic sensors and the matrix need their own initialisers
+      let classID = identification.classID
+      guard !"\(classID)".hasPrefix("1.1.2.1."),
+            classID != SwiftOCADevice.OcaMatrix<SwiftOCADevice.OcaWorker>.classID
+      else { continue }
+      let object = try await type.init(
+        objectNumber: 0x0001_0000,
+        lockable: true,
+        role: nil,
+        deviceDelegate: nil,
+        addToRootBlock: false
+      )
+      for (swiftName, keyPath) in object.allDevicePropertyKeyPathsUncached {
+        guard let property = object[keyPath: keyPath] as? any OcaDevicePropertyRepresentable
+        else { continue }
+        let propertyID = property.propertyID
+        // a vector supplies no names: the encoder derives X and Y from the record
+        let responseNames = property.responseNames(propertyName: swiftName)
+        guard !responseNames.isEmpty else { continue }
+
+        var definingClass = classID
+        while definingClass.defLevel > propertyID.defLevel, let parent = definingClass.parent {
+          definingClass = parent
+        }
+        func lookup(_ methodID: OcaMethodID?) -> Method? {
+          guard let methodID else { return nil }
+          return byClassAndMethod["\(definingClass)/\(methodID)"]
+        }
+        let getter = lookup(property.getMethodID)
+        let setter = lookup(property.setMethodID)
+        for (method, expected, sent) in [
+          (getter, getter?.outputs, responseNames),
+          (setter, setter?.inputs, [property.wireName(propertyName: swiftName)]),
+        ] {
+          guard let method, let expected, !expected.isEmpty else { continue }
+          checked.insert("\(definingClass)/\(method.methodID)")
+          if !namesMatch(sent, expected) {
+            deviations.insert("\(method.className) \(method.methodID) \(method.name): sends \(sent), model says \(expected)")
+          }
+        }
+      }
+    }
+    return (checked.count, deviations)
+  }
+
+  func testDeviceAccessorNamesAgainstModel() async throws {
+    guard let path = ProcessInfo.processInfo.environment["AES70_2_XMI"] else {
+      throw XCTSkip("set AES70_2_XMI to the AES70-2 XMI file to run the naming oracle")
+    }
+    let model = try Self.loadModel(from: URL(fileURLWithPath: path))
+    XCTAssertFalse(model.isEmpty, "no methods found in \(path)")
+
+    let (checked, deviations) = try await Self.audit(model)
+    print(
+      "Ocp2 device naming oracle: checked \(checked) accessors, \(deviations.count) deviations "
+        + "(capitalisation alone is not a deviation)"
+    )
+    for deviation in deviations.sorted() {
+      print("  \(deviation)")
+    }
+  }
+}
+
+#endif

--- a/Tests/SwiftOCADeviceTests/Ocp2LevelSensorTests.swift
+++ b/Tests/SwiftOCADeviceTests/Ocp2LevelSensorTests.swift
@@ -1,0 +1,134 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if NonEmbeddedBuild
+import Foundation
+@testable @_spi(SwiftOCAPrivate) import SwiftOCA
+@testable @_spi(SwiftOCAPrivate) import SwiftOCADevice
+@preconcurrency import XCTest
+
+/// `OcaLevelSensor` encodes its own property-changed events to keep metering off the
+/// `Codable` path; the notification must still reach a controller speaking OCP.2.
+final class Ocp2LevelSensorTests: XCTestCase {
+  private struct Harness {
+    let device: OcaDevice
+    let endpoint: OcaLocalDeviceEndpoint
+    let connection: OcaLocalConnection
+    let endpointTask: Task<(), Never>
+
+    func tearDown() async {
+      try? await connection.disconnect()
+      endpointTask.cancel()
+    }
+  }
+
+  func testLevelSensorNotifiesAnOcp2Controller() async throws {
+    let harness = try await makeHarness(controlProtocol: .ocp2)
+    defer { Task { await harness.tearDown() } }
+
+    let sensorONo: OcaONo = 0x0001_0400
+    let sensor = try await SwiftOCADevice.OcaLevelSensor(
+      objectNumber: sensorONo,
+      role: "Meter",
+      deviceDelegate: harness.device,
+      addToRootBlock: true
+    )
+    let client: SwiftOCA.OcaLevelSensor = try await harness.connection.resolve(
+      object: OcaObjectIdentification(
+        oNo: sensorONo,
+        classIdentification: SwiftOCA.OcaLevelSensor.classIdentification
+      )
+    )
+
+    await client.$reading.subscribe(client)
+    let subscribed = await wait { (try? await client.isSubscribed) == true }
+    XCTAssertTrue(subscribed)
+
+    try await sensor.update(reading: -12.0)
+
+    let observed = await wait {
+      if case let .success(value) = client.$reading.currentValue { return value.value == -12.0 }
+      return false
+    }
+    XCTAssertTrue(observed, "OCP.2 controller did not observe the level sensor reading")
+  }
+
+  /// The same path on OCP.1, so a failure above is about the protocol and not the sensor.
+  func testLevelSensorNotifiesAnOcp1Controller() async throws {
+    let harness = try await makeHarness(controlProtocol: .ocp1)
+    defer { Task { await harness.tearDown() } }
+
+    let sensorONo: OcaONo = 0x0001_0401
+    let sensor = try await SwiftOCADevice.OcaLevelSensor(
+      objectNumber: sensorONo,
+      role: "Meter",
+      deviceDelegate: harness.device,
+      addToRootBlock: true
+    )
+    let client: SwiftOCA.OcaLevelSensor = try await harness.connection.resolve(
+      object: OcaObjectIdentification(
+        oNo: sensorONo,
+        classIdentification: SwiftOCA.OcaLevelSensor.classIdentification
+      )
+    )
+
+    await client.$reading.subscribe(client)
+    let subscribed = await wait { (try? await client.isSubscribed) == true }
+    XCTAssertTrue(subscribed)
+
+    try await sensor.update(reading: -12.0)
+
+    let observed = await wait {
+      if case let .success(value) = client.$reading.currentValue { return value.value == -12.0 }
+      return false
+    }
+    XCTAssertTrue(observed, "OCP.1 controller did not observe the level sensor reading")
+  }
+
+  private func makeHarness(controlProtocol: OcaControlProtocol) async throws -> Harness {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    let endpoint = try await OcaLocalDeviceEndpoint(
+      device: device,
+      controlProtocol: controlProtocol
+    )
+    let endpointTask = Task { do { try await endpoint.run() } catch {} }
+    let connection = await OcaLocalConnection(
+      endpoint,
+      options: Ocp1ConnectionOptions(controlProtocol: controlProtocol)
+    )
+    try await connection.connect()
+    return Harness(
+      device: device,
+      endpoint: endpoint,
+      connection: connection,
+      endpointTask: endpointTask
+    )
+  }
+
+  private func wait(
+    timeout: Duration = .seconds(5),
+    until condition: @Sendable () async -> Bool
+  ) async -> Bool {
+    let deadline = ContinuousClock.now + timeout
+    while ContinuousClock.now < deadline {
+      if await condition() { return true }
+      try? await Task.sleep(for: .milliseconds(25))
+    }
+    return await condition()
+  }
+}
+#endif

--- a/Tests/SwiftOCADeviceTests/Ocp2LoopbackTests.swift
+++ b/Tests/SwiftOCADeviceTests/Ocp2LoopbackTests.swift
@@ -1,0 +1,330 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if NonEmbeddedBuild
+import Foundation
+@testable @_spi(SwiftOCAPrivate) import SwiftOCA
+@testable @_spi(SwiftOCAPrivate) import SwiftOCADevice
+@preconcurrency import XCTest
+
+/// A controller and a device speaking OCP.2 in-process.
+final class Ocp2LoopbackTests: XCTestCase {
+  private struct Harness {
+    let device: OcaDevice
+    let endpoint: OcaLocalDeviceEndpoint
+    let connection: OcaLocalConnection
+    let endpointTask: Task<(), Never>
+
+    func tearDown() async {
+      try? await connection.disconnect()
+      endpointTask.cancel()
+    }
+  }
+
+  /// A vector property is one wrapper standing in for two properties, so its OCP.2
+  /// parameters are named after the vector record's fields. Regression: the storage
+  /// borrowed OcaRoot's property 1.1 and named them `ClassID`.
+  func testVectorPropertyRoundTripsOverOcp2() async throws {
+    let harness = try await makeHarness()
+    defer { Task { await harness.tearDown() } }
+
+    let matrixONo: OcaONo = 0x0001_0200
+    _ = try await SwiftOCADevice.OcaMatrix<SwiftOCADevice.OcaRoot>(
+      rows: 4,
+      columns: 2,
+      objectNumber: matrixONo,
+      role: "Matrix",
+      deviceDelegate: harness.device,
+      addToRootBlock: true
+    )
+    let matrix: SwiftOCA.OcaMatrix = try await harness.connection.resolve(
+      object: OcaObjectIdentification(
+        oNo: matrixONo,
+        classIdentification: SwiftOCA.OcaMatrix.classIdentification
+      )
+    )
+
+    // `size` is deliberately not exercised: OcaMatrix.GetSize returns the model's
+    // six-field MatrixSize while the client property is a two-field vector, which is
+    // a structural divergence from AES70-2A rather than a naming one.
+    // both directions must name the OCP.2 parameters after the vector's own fields
+    // (X, Y), not after some other property the storage borrowed an ID from
+    let xy = try await matrix.$currentXY._getValue(matrix, flags: [])
+    XCTAssertEqual(xy.x, 0xFFFF) // the wildcard coordinate a fresh matrix starts at
+    XCTAssertEqual(xy.y, 0xFFFF)
+
+    // the type-erased setter was a stub before; it now goes through the same
+    // `setValueIfMutable` naming path the wrapper's own setter uses
+    try await matrix.$currentXY._setValue(matrix, OcaVector2D<OcaMatrixCoordinate>(x: 1, y: 1))
+    let updated = try await matrix.$currentXY._getValue(matrix, flags: [])
+    XCTAssertEqual(updated.x, 1)
+    XCTAssertEqual(updated.y, 1)
+  }
+
+  private func makeHarness() async throws -> Harness {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    let endpoint = try await OcaLocalDeviceEndpoint(device: device, controlProtocol: .ocp2)
+    let endpointTask = Task { do { try await endpoint.run() } catch {} }
+    let connection = await OcaLocalConnection(
+      endpoint,
+      options: Ocp1ConnectionOptions(controlProtocol: .ocp2)
+    )
+    try await connection.connect()
+    return Harness(device: device, endpoint: endpoint, connection: connection, endpointTask: endpointTask)
+  }
+
+  private func wait(
+    timeout: Duration = .seconds(5),
+    until condition: @Sendable () async -> Bool
+  ) async -> Bool {
+    let deadline = ContinuousClock.now + timeout
+    while ContinuousClock.now < deadline {
+      if await condition() { return true }
+      try? await Task.sleep(for: .milliseconds(25))
+    }
+    return await condition()
+  }
+
+  func testConnectsAndReadsManagers() async throws {
+    let harness = try await makeHarness()
+    defer { Task { await harness.tearDown() } }
+
+    XCTAssertEqual(harness.connection.controlProtocol, .ocp2)
+    let controllers = await harness.endpoint.controllers
+    XCTAssertEqual(controllers.count, 1)
+    let controllerProtocol = await controllers.first?.controlProtocol
+    XCTAssertEqual(controllerProtocol, .ocp2)
+
+    // GetClassIdentification (1.1): a parameter record response
+    let identification = try await harness.connection.deviceManager.getClassIdentification()
+    XCTAssertEqual(identification.classID, SwiftOCA.OcaDeviceManager.classID)
+
+    // GetRole (1.5): a named scalar response
+    let role = try await harness.connection.deviceManager.$role._getValue(
+      harness.connection.deviceManager,
+      flags: []
+    )
+    XCTAssertFalse(role.isEmpty)
+
+    // GetLockable (1.2): a named boolean response
+    let lockable = try await harness.connection.rootBlock.$lockable._getValue(
+      harness.connection.rootBlock,
+      flags: []
+    )
+    XCTAssertTrue(lockable)
+
+    // an unknown object number produces a status, not a transport error
+    do {
+      _ = try await harness.connection.getClassIdentification(objectNumber: 0x7FFF_FFFF)
+      XCTFail("expected badONo")
+    } catch Ocp1Error.status(.badONo) {}
+  }
+
+  func testBoundedPropertyGetAndSet() async throws {
+    let harness = try await makeHarness()
+    defer { Task { await harness.tearDown() } }
+
+    let deviceGain = try await SwiftOCADevice.OcaGain(
+      objectNumber: 0x0001_0010,
+      role: "Master Gain",
+      deviceDelegate: harness.device,
+      addToRootBlock: true
+    )
+    let clientGain: SwiftOCA.OcaGain = try await harness.connection.resolve(
+      object: OcaObjectIdentification(
+        oNo: 0x0001_0010,
+        classIdentification: SwiftOCA.OcaGain.classIdentification
+      )
+    )
+
+    await { @OcaDevice in deviceGain.gain = OcaBoundedPropertyValue(value: -6, in: -100...12) }()
+
+    // GetGain returns Gain, MinGain, MaxGain as separate parameters
+    let gain = try await clientGain.$gain._getValue(clientGain, flags: [])
+    XCTAssertEqual(gain.value, -6)
+    XCTAssertEqual(gain.minValue, -100)
+    XCTAssertEqual(gain.maxValue, 12)
+
+    // SetGain takes a single Gain parameter
+    try await clientGain.$gain._setValue(clientGain, OcaBoundedPropertyValue<OcaDB>(value: -3.5, in: -100...12))
+    let deviceValue = await { @OcaDevice in deviceGain.gain.value }()
+    XCTAssertEqual(deviceValue, -3.5)
+  }
+
+  func testFindActionObjectsByRole() async throws {
+    let harness = try await makeHarness()
+    defer { Task { await harness.tearDown() } }
+
+    _ = try await SwiftOCADevice.OcaGain(
+      objectNumber: 0x0001_0011,
+      role: "Master Gain",
+      deviceDelegate: harness.device,
+      addToRootBlock: true
+    )
+
+    let results = try await harness.connection.rootBlock.find(
+      actionObjectsByRole: "Master Gain",
+      nameComparisonType: .exact,
+      resultFlags: [.oNo, .classIdentification, .role]
+    )
+    XCTAssertEqual(results.count, 1)
+    XCTAssertEqual(results.first?.oNo, 0x0001_0011)
+    XCTAssertEqual(results.first?.classIdentification?.classID, SwiftOCA.OcaGain.classID)
+    XCTAssertEqual(results.first?.role, "Master Gain")
+    XCTAssertNil(results.first?.label)
+  }
+
+  func testPropertyChangeNotification() async throws {
+    let harness = try await makeHarness()
+    defer { Task { await harness.tearDown() } }
+
+    let deviceBlock = try await SwiftOCADevice.OcaBlock<SwiftOCADevice.OcaRoot>(
+      objectNumber: 0x0001_0020,
+      role: "Control",
+      deviceDelegate: harness.device,
+      addToRootBlock: true
+    )
+    let clientBlock: SwiftOCA.OcaBlock = try await harness.connection.resolve(
+      object: OcaObjectIdentification(
+        oNo: 0x0001_0020,
+        classIdentification: SwiftOCA.OcaBlock.classIdentification
+      )
+    )
+
+    await clientBlock.$label.subscribe(clientBlock)
+    let subscribed = await wait { (try? await clientBlock.isSubscribed) == true }
+    XCTAssertTrue(subscribed)
+
+    // the device holds an EV2 subscription for this OCP.2 controller
+    let controllers = await harness.endpoint.controllers
+    let controller = try XCTUnwrap(controllers.first as? OcaLocalController)
+    let subscriptions = await controller.subscriptions[0x0001_0020] ?? []
+    XCTAssertEqual(subscriptions.count, 1)
+    XCTAssertEqual(subscriptions.first?.version, .ev2)
+
+    await { @OcaDevice in deviceBlock.label = "changed" }()
+    let observed = await wait {
+      if case let .success(value) = clientBlock.$label.currentValue { return value == "changed" }
+      return false
+    }
+    XCTAssertTrue(observed, "property did not observe the device change over OCP.2")
+
+    try await clientBlock.unsubscribe()
+    let unsubscribed = await wait { await controller.subscriptions[0x0001_0020]?.isEmpty ?? true }
+    XCTAssertTrue(unsubscribed)
+  }
+
+  func testEv1SubscriptionsAreRefused() async throws {
+    let harness = try await makeHarness()
+    defer { Task { await harness.tearDown() } }
+
+    do {
+      try await harness.connection.subscriptionManager.addSubscription(
+        event: OcaEvent(emitterONo: OcaRootBlockONo, eventID: OcaPropertyChangedEventID),
+        subscriber: OcaMethod(oNo: 1055, methodID: OcaMethodID("1.1")),
+        subscriberContext: OcaBlob(),
+        notificationDeliveryMode: .normal,
+        destinationInformation: OcaNetworkAddress()
+      )
+      XCTFail("EV1 subscription accepted over OCP.2")
+    } catch Ocp1Error.status(.notImplemented) {}
+  }
+
+  func testLocking() async throws {
+    let harness = try await makeHarness()
+    defer { Task { await harness.tearDown() } }
+
+    let deviceBlock = try await SwiftOCADevice.OcaBlock<SwiftOCADevice.OcaRoot>(
+      objectNumber: 0x0001_0030,
+      role: "Lockable",
+      deviceDelegate: harness.device,
+      addToRootBlock: true
+    )
+    let clientBlock: SwiftOCA.OcaBlock = try await harness.connection.resolve(
+      object: OcaObjectIdentification(
+        oNo: 0x0001_0030,
+        classIdentification: SwiftOCA.OcaBlock.classIdentification
+      )
+    )
+
+    try await clientBlock.lockReadOnly()
+    let lockState = try await clientBlock.$lockState._getValue(clientBlock, flags: [])
+    XCTAssertEqual(lockState, .lockNoWrite)
+    let deviceLocked = await { @OcaDevice in deviceBlock.lockState.lockState }()
+    XCTAssertEqual(deviceLocked, .lockNoWrite)
+    try await clientBlock.unlock()
+  }
+}
+#endif
+
+#if NonEmbeddedBuild
+/// The controller-side JSON export is the OCP.2 representation of the object.
+final class Ocp2JsonExportTests: XCTestCase {
+  func testJsonValueMatchesOcp2Marshaling() async throws {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    let endpoint = try await OcaLocalDeviceEndpoint(device: device, controlProtocol: .ocp2)
+    let endpointTask = Task { do { try await endpoint.run() } catch {} }
+    defer { endpointTask.cancel() }
+    let connection = await OcaLocalConnection(
+      endpoint,
+      options: Ocp1ConnectionOptions(controlProtocol: .ocp2)
+    )
+    try await connection.connect()
+    defer { Task { try? await connection.disconnect() } }
+
+    let deviceGain = try await SwiftOCADevice.OcaGain(
+      objectNumber: 0x0001_0040,
+      role: "Master Gain",
+      deviceDelegate: device,
+      addToRootBlock: true
+    )
+    await { @OcaDevice in
+      deviceGain.gain = OcaBoundedPropertyValue(value: -6, in: -.infinity...12)
+      deviceGain.label = "Main"
+    }()
+
+    let clientGain: SwiftOCA.OcaGain = try await connection.resolve(
+      object: OcaObjectIdentification(
+        oNo: 0x0001_0040,
+        classIdentification: SwiftOCA.OcaGain.classIdentification
+      )
+    )
+    let json = await clientGain.jsonObject
+
+    // identity, as OCP.2 marshals it
+    XCTAssertEqual(json["ObjectNumber"] as? Int, 0x0001_0040)
+    XCTAssertEqual(json["ClassID"] as? [Int], [1, 1, 1, 5])
+    XCTAssertEqual(json["ClassVersion"] as? Int, Int(SwiftOCA.OcaGain.classVersion))
+    // a bounded property takes the shape of its OCP.2 getter response
+    XCTAssertEqual(json["Gain"] as? Double, -6)
+    XCTAssertEqual(json["MinGain"] as? String, "-Infinity")
+    XCTAssertEqual(json["MaxGain"] as? Double, 12)
+    // plain properties under their wire names
+    XCTAssertEqual(json["Role"] as? String, "Master Gain")
+    XCTAssertEqual(json["Label"] as? String, "Main")
+    XCTAssertEqual(json["Lockable"] as? Bool, true)
+    // ONo is what the model calls object-number parameters, not this property
+    XCTAssertNil(json["ONo"])
+    // OCA 1.5B's spelling, not the 2023 model's
+    XCTAssertNil(json["minGain"])
+
+    // and it serialises
+    XCTAssertTrue(JSONSerialization.isValidJSONObject(json))
+  }
+}
+#endif

--- a/Tests/SwiftOCADeviceTests/Ocp2SynchronizeStateTests.swift
+++ b/Tests/SwiftOCADeviceTests/Ocp2SynchronizeStateTests.swift
@@ -1,0 +1,144 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if NonEmbeddedBuild
+import Foundation
+@testable @_spi(SwiftOCAPrivate) import SwiftOCA
+@testable @_spi(SwiftOCAPrivate) import SwiftOCADevice
+@preconcurrency import XCTest
+
+/// `OcaSubscriptionManager` emits SynchronizeState when notifications are re-enabled;
+/// like any other event it must reach a controller whatever protocol it speaks.
+final class Ocp2SynchronizeStateTests: XCTestCase {
+  /// Every payload delivered for the subscribed emitter. A subscriber to one of an
+  /// object's events is currently sent all of them, so the object list is picked out
+  /// by decoding rather than by assuming it arrived alone.
+  private final class Received: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _payloads = [Data]()
+
+    var payloads: [Data] {
+      lock.withLock { _payloads }
+    }
+
+    func store(_ data: Data) {
+      lock.withLock { _payloads.append(data) }
+    }
+  }
+
+  func testSynchronizeStateReachesAnOcp2Controller() async throws {
+    try await assertSynchronizeStateIsDelivered(over: .ocp2)
+  }
+
+  /// The same path on OCP.1, so a failure above is about the protocol and not the manager.
+  func testSynchronizeStateReachesAnOcp1Controller() async throws {
+    try await assertSynchronizeStateIsDelivered(over: .ocp1)
+  }
+
+  private func assertSynchronizeStateIsDelivered(
+    over controlProtocol: OcaControlProtocol,
+    line: UInt = #line
+  ) async throws {
+    let harness = try await makeHarness(controlProtocol: controlProtocol)
+    defer { Task { await harness.tearDown() } }
+
+    let block = try await SwiftOCADevice.OcaBlock<SwiftOCADevice.OcaRoot>(
+      objectNumber: 0x0001_0500,
+      role: "Changed",
+      deviceDelegate: harness.device,
+      addToRootBlock: true
+    )
+
+    let received = Received()
+    let subscriptionManager = await harness.connection.subscriptionManager
+    let event = OcaEvent(
+      emitterONo: subscriptionManager.objectNumber,
+      eventID: SwiftOCA.OcaSubscriptionManager.SynchronizeStateEventID
+    )
+    _ = try await harness.connection.addSubscription(event: event) { _, data in
+      received.store(data)
+    }
+
+    try await subscriptionManager.disableNotifications()
+    // a change made while notifications are off is what SynchronizeState reports
+    await { @OcaDevice in block.label = "changed" }()
+    try await subscriptionManager.reenableNotifications()
+
+    let format = controlProtocol.parameterFormat
+    let changedONo = block.objectNumber
+    let delivered = await wait {
+      received.payloads.contains { payload in
+        guard let objectList = try? OcaEventDataCoding.decode(
+          OcaObjectListEventData.self,
+          from: payload,
+          format: format
+        ) else { return false }
+        return objectList.objectList.contains(changedONo)
+      }
+    }
+    XCTAssertTrue(
+      delivered,
+      "\(controlProtocol) controller did not receive SynchronizeState listing the changed object",
+      line: line
+    )
+  }
+
+  private struct Harness {
+    let device: OcaDevice
+    let endpoint: OcaLocalDeviceEndpoint
+    let connection: OcaLocalConnection
+    let endpointTask: Task<(), Never>
+
+    func tearDown() async {
+      try? await connection.disconnect()
+      endpointTask.cancel()
+    }
+  }
+
+  private func makeHarness(controlProtocol: OcaControlProtocol) async throws -> Harness {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    let endpoint = try await OcaLocalDeviceEndpoint(
+      device: device,
+      controlProtocol: controlProtocol
+    )
+    let endpointTask = Task { do { try await endpoint.run() } catch {} }
+    let connection = await OcaLocalConnection(
+      endpoint,
+      options: Ocp1ConnectionOptions(controlProtocol: controlProtocol)
+    )
+    try await connection.connect()
+    return Harness(
+      device: device,
+      endpoint: endpoint,
+      connection: connection,
+      endpointTask: endpointTask
+    )
+  }
+
+  private func wait(
+    timeout: Duration = .seconds(5),
+    until condition: @Sendable () async -> Bool
+  ) async -> Bool {
+    let deadline = ContinuousClock.now + timeout
+    while ContinuousClock.now < deadline {
+      if await condition() { return true }
+      try? await Task.sleep(for: .milliseconds(25))
+    }
+    return await condition()
+  }
+}
+#endif

--- a/Tests/SwiftOCADeviceTests/Ocp2SynchronizeStateTests.swift
+++ b/Tests/SwiftOCADeviceTests/Ocp2SynchronizeStateTests.swift
@@ -94,6 +94,20 @@ final class Ocp2SynchronizeStateTests: XCTestCase {
       "\(controlProtocol) controller did not receive SynchronizeState listing the changed object",
       line: line
     )
+
+    // the manager emits other events of its own while notifications are toggled; a
+    // subscription to one event must not be sent them
+    for payload in received.payloads {
+      XCTAssertNoThrow(
+        try OcaEventDataCoding.decode(
+          OcaObjectListEventData.self,
+          from: payload,
+          format: format
+        ),
+        "a subscription to SynchronizeState received another event's data",
+        line: line
+      )
+    }
   }
 
   private struct Harness {

--- a/Tests/SwiftOCADeviceTests/Ocp2TransportTests.swift
+++ b/Tests/SwiftOCADeviceTests/Ocp2TransportTests.swift
@@ -578,6 +578,22 @@ private struct RawWebSocket {
   }
 
   func receive() async throws -> (opcode: UInt8, payload: [UInt8]) {
+    let (_, opcode, payload) = try await receiveFrame()
+    return (opcode, payload)
+  }
+
+  /// Reads one message, reassembling it from continuation frames.
+  func receiveMessage() async throws -> (opcode: UInt8, payload: [UInt8]) {
+    var (fin, opcode, payload) = try await receiveFrame()
+    while !fin {
+      let (nextFin, _, fragment) = try await receiveFrame()
+      payload += fragment
+      fin = nextFin
+    }
+    return (opcode, payload)
+  }
+
+  private func receiveFrame() async throws -> (fin: Bool, opcode: UInt8, payload: [UInt8]) {
     let header = try await socket.read(bytes: 2)
     var length = Int(header[1] & 0x7F)
     if length == 126 {
@@ -588,7 +604,7 @@ private struct RawWebSocket {
     let mask = header[1] & 0x80 != 0 ? try await socket.read(bytes: 4) : nil
     var payload = length > 0 ? try await socket.read(bytes: length) : []
     if let mask { payload = payload.enumerated().map { $1 ^ mask[$0 % 4] } }
-    return (header[0] & 0x0F, payload)
+    return (header[0] & 0x80 != 0, header[0] & 0x0F, payload)
   }
 
   /// Reads until the device's close frame and returns its status code.
@@ -809,6 +825,117 @@ final class Ocp2WebSocketTests: XCTestCase {
     )
     let response = try XCTUnwrap((object["Responses"] as? [[String: Any]])?.first, file: file, line: line)
     XCTAssertEqual(response["StatusCode"] as? String, "OK", file: file, line: line)
+  }
+}
+
+// MARK: - large hierarchies
+
+/// `blocks` blocks under the root, each holding `perBlock` gains.
+@OcaDevice
+private func buildWideHierarchy(_ device: OcaDevice, blocks: Int, perBlock: Int) async throws {
+  var oNo: OcaONo = 0x0010_0000
+  for b in 0..<blocks {
+    let block = try await SwiftOCADevice.OcaBlock<SwiftOCADevice.OcaRoot>(
+      objectNumber: oNo, role: "Block \(b)", deviceDelegate: device, addToRootBlock: true
+    )
+    oNo += 1
+    for g in 0..<perBlock {
+      let gain = try await SwiftOCADevice.OcaGain(
+        objectNumber: oNo, role: "Gain \(g)", deviceDelegate: device, addToRootBlock: false
+      )
+      try await block.add(actionObject: gain)
+      oNo += 1
+    }
+  }
+}
+
+/// A chain of `depth` nested blocks under the root.
+@OcaDevice
+private func buildDeepHierarchy(_ device: OcaDevice, depth: Int) async throws {
+  var oNo: OcaONo = 0x0020_0000
+  var parent: SwiftOCADevice.OcaBlock<SwiftOCADevice.OcaRoot>?
+  for d in 0..<depth {
+    let block = try await SwiftOCADevice.OcaBlock<SwiftOCADevice.OcaRoot>(
+      objectNumber: oNo, role: "Level \(d)", deviceDelegate: device, addToRootBlock: parent == nil
+    )
+    try await parent?.add(actionObject: block)
+    parent = block
+    oNo += 1
+  }
+}
+
+/// Every object number reachable from the device's root block.
+@OcaDevice
+private func recursiveMemberONos(of device: OcaDevice) async -> Set<OcaONo> {
+  Set(await device.rootBlock!.mapRecursive { member, _ in member.objectNumber })
+}
+
+private let getMembersRecursiveOnRoot = Data(
+  "{\"ProtocolVersion\":1,\"Commands\":[{\"Handle\":1,\"TargetONo\":\(OcaRootBlockONo),\"MethodID\":[3,6]}]}\n"
+    .utf8
+)
+
+/// A GetMembersRecursive answer is the largest PDU a device sends. Ten thousand members
+/// put the JSON response well past the reader's 64 KiB chunk and any single WebSocket
+/// frame; a thousand nested blocks recurse on both device and controller.
+final class Ocp2LargeHierarchyTests: XCTestCase {
+  private static let wideBlocks = 10
+  private static let gainsPerBlock = 999
+  private static let depth = 1000
+
+  // the walk under test is the explicit one, not the tree refresh on connect
+  private static let options = Ocp1ConnectionOptions(flags: [], controlProtocol: .ocp2)
+
+  private func assertRecursiveMembers(
+    of fixture: TCPFixture,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) async throws {
+    let expected = await recursiveMemberONos(of: fixture.device)
+    let connection = try await makeStreamConnection(port: fixture.port, options: Self.options)
+    try await connection.connect()
+
+    let members: OcaList<OcaBlockMember> = try await connection.rootBlock.getActionObjectsRecursive()
+    XCTAssertEqual(Set(members.map(\.memberObjectIdentification.oNo)), expected, file: file, line: line)
+    let resolved = try await connection.rootBlock.resolveActionObjectsRecursive()
+    XCTAssertEqual(resolved.count, expected.count, file: file, line: line)
+
+    try await connection.disconnect()
+  }
+
+  func testWideHierarchyOverTCP() async throws {
+    let fixture = try await TCPFixture()
+    defer { fixture.tearDown() }
+    try await buildWideHierarchy(fixture.device, blocks: Self.wideBlocks, perBlock: Self.gainsPerBlock)
+    try await assertRecursiveMembers(of: fixture)
+  }
+
+  func testDeepHierarchyOverTCP() async throws {
+    let fixture = try await TCPFixture()
+    defer { fixture.tearDown() }
+    try await buildDeepHierarchy(fixture.device, depth: Self.depth)
+    try await assertRecursiveMembers(of: fixture)
+  }
+
+  func testWideHierarchyOverWebSocket() async throws {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    try await buildWideHierarchy(device, blocks: Self.wideBlocks, perBlock: Self.gainsPerBlock)
+    let expected = await recursiveMemberONos(of: device)
+    let (_, endpointTask, port) = try await makeWSEndpoint(device: device)
+    defer { endpointTask.cancel() }
+
+    let webSocket = try await RawWebSocket(port: port)
+    try await webSocket.send(opcode: 0x1, getMembersRecursiveOnRoot)
+    let (opcode, payload) = try await webSocket.receiveMessage()
+    await webSocket.close()
+
+    XCTAssertEqual(opcode, 0x1, "expected a text frame")
+    let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(payload)) as? [String: Any])
+    let response = try XCTUnwrap((object["Responses"] as? [[String: Any]])?.first)
+    XCTAssertEqual(response["StatusCode"] as? String, "OK")
+    let objects = try XCTUnwrap((response["Parameters"] as? [String: Any])?["Objects"] as? [Any])
+    XCTAssertEqual(objects.count, expected.count)
   }
 }
 

--- a/Tests/SwiftOCADeviceTests/Ocp2TransportTests.swift
+++ b/Tests/SwiftOCADeviceTests/Ocp2TransportTests.swift
@@ -1,0 +1,815 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if (os(macOS) || os(iOS) || os(Linux)) && NonEmbeddedBuild
+
+import FlyingFox
+import FlyingSocks
+import Foundation
+@testable @_spi(SwiftOCAPrivate) import SwiftOCA
+@testable @_spi(SwiftOCAPrivate) import SwiftOCADevice
+@preconcurrency import XCTest
+
+// MARK: - helpers
+
+private func boundPort(of socket: Socket) throws -> UInt16 {
+  switch try socket.sockname() {
+  case let .ip4(_, port): return port
+  case let .ip6(_, port): return port
+  default: throw SocketError.unsupportedAddress
+  }
+}
+
+private func localhostAddress(port: UInt16) -> Data {
+  var addr = sockaddr_in()
+  addr.sin_family = sa_family_t(AF_INET)
+  addr.sin_port = port.bigEndian
+  addr.sin_addr.s_addr = UInt32(0x7F00_0001).bigEndian
+  #if canImport(Darwin)
+  addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+  #endif
+  return withUnsafeBytes(of: addr) { Data($0) }
+}
+
+private let ocp2Options = Ocp1ConnectionOptions(
+  flags: .refreshDeviceTreeOnConnection,
+  controlProtocol: .ocp2
+)
+
+// The platform's native socket backends: io_uring on Linux, FlyingSocks elsewhere.
+#if canImport(IORing)
+private typealias StreamDeviceEndpoint = Ocp1IORingStreamDeviceEndpoint
+private typealias DatagramDeviceEndpoint = Ocp1IORingDatagramDeviceEndpoint
+private typealias StreamConnection = Ocp1IORingStreamConnection
+private typealias DatagramConnection = Ocp1IORingDatagramConnection
+
+/// io_uring endpoints bind only once they run, so reserve a loopback port for them.
+private func unusedPort(_ type: SocketType) throws -> UInt16 {
+  let socket = try Socket(domain: AF_INET, type: type)
+  defer { try? socket.close() }
+  try socket.bind(to: .inet(ip4: "127.0.0.1", port: 0))
+  return try boundPort(of: socket)
+}
+
+private func startStreamEndpoint(
+  device: OcaDevice,
+  timeout: Duration
+) async throws -> (StreamDeviceEndpoint, Task<(), Error>, UInt16) {
+  let port = try unusedPort(.stream)
+  let endpoint = try await StreamDeviceEndpoint(
+    address: localhostAddress(port: port),
+    timeout: timeout,
+    device: device,
+    controlProtocol: .ocp2
+  )
+  return (endpoint, Task { try await endpoint.run() }, port)
+}
+
+private func startDatagramEndpoint(
+  device: OcaDevice,
+  timeout: Duration
+) async throws -> (DatagramDeviceEndpoint, Task<(), Error>, UInt16) {
+  let port = try unusedPort(.datagram)
+  let endpoint = try await DatagramDeviceEndpoint(
+    address: localhostAddress(port: port),
+    timeout: timeout,
+    device: device,
+    controlProtocol: .ocp2
+  )
+  return (endpoint, Task { try await endpoint.run() }, port)
+}
+#else
+private typealias StreamDeviceEndpoint = Ocp1FlyingSocksStreamDeviceEndpoint
+private typealias DatagramDeviceEndpoint = Ocp1FlyingSocksDatagramDeviceEndpoint
+private typealias StreamConnection = Ocp1FlyingSocksStreamConnection
+private typealias DatagramConnection = Ocp1FlyingSocksDatagramConnection
+
+private func startStreamEndpoint(
+  device: OcaDevice,
+  timeout: Duration
+) async throws -> (StreamDeviceEndpoint, Task<(), Error>, UInt16) {
+  let endpoint = try await StreamDeviceEndpoint(
+    address: localhostAddress(port: 0),
+    timeout: timeout,
+    device: device,
+    controlProtocol: .ocp2
+  )
+  let socket = try await endpoint.preparePoolAndSocket()
+  let port = try boundPort(of: socket)
+  return (endpoint, Task { try await endpoint._run(on: socket, pool: endpoint.pool) }, port)
+}
+
+private func startDatagramEndpoint(
+  device: OcaDevice,
+  timeout: Duration
+) async throws -> (DatagramDeviceEndpoint, Task<(), Error>, UInt16) {
+  let endpoint = try await DatagramDeviceEndpoint(
+    address: localhostAddress(port: 0),
+    timeout: timeout,
+    device: device,
+    controlProtocol: .ocp2
+  )
+  let socket = try await endpoint.preparePoolAndSocket()
+  let port = try boundPort(of: socket)
+  return (endpoint, Task { try await endpoint._run(on: socket, pool: endpoint.pool) }, port)
+}
+#endif
+
+@OcaConnection
+private func makeStreamConnection(
+  port: UInt16,
+  options: Ocp1ConnectionOptions = ocp2Options
+) throws -> StreamConnection {
+  try StreamConnection(deviceAddress: localhostAddress(port: port), options: options)
+}
+
+@OcaConnection
+private func makeCFSocketTCPConnection(port: UInt16) throws -> Ocp1CFSocketTCPConnection {
+  try Ocp1CFSocketTCPConnection(deviceAddress: localhostAddress(port: port), options: ocp2Options)
+}
+
+#if canImport(Network)
+@OcaConnection
+private func makeNWTCPConnection(port: UInt16) throws -> Ocp1NWTCPConnection {
+  try Ocp1NWTCPConnection(deviceAddress: localhostAddress(port: port), options: ocp2Options)
+}
+#endif
+
+/// A device with a gain object, listening for OCP.2 over TCP.
+private struct TCPFixture {
+  let device: OcaDevice
+  let endpoint: StreamDeviceEndpoint
+  let port: UInt16
+  let gain: SwiftOCADevice.OcaGain
+  let endpointTask: Task<(), Error>
+
+  static let gainONo: OcaONo = 0x0001_0100
+
+  init(timeout: Duration = .seconds(5)) async throws {
+    device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    gain = try await SwiftOCADevice.OcaGain(
+      objectNumber: Self.gainONo,
+      role: "Master Gain",
+      deviceDelegate: device,
+      addToRootBlock: true
+    )
+    let (endpoint, endpointTask, port) = try await startStreamEndpoint(device: device, timeout: timeout)
+    self.endpoint = endpoint
+    self.endpointTask = endpointTask
+    self.port = port
+    try await Task.sleep(for: .milliseconds(100))
+  }
+
+  func tearDown() {
+    endpointTask.cancel()
+  }
+}
+
+/// Exercises a connected OCP.2 controller: property read, write, and a search.
+private func exerciseConnection(_ connection: Ocp1Connection, fixture: TCPFixture) async throws {
+  XCTAssertEqual(connection.controlProtocol, .ocp2)
+  XCTAssertTrue(connection.connectionPrefix.hasPrefix(OcaJsonTcpConnectionPrefix))
+  let deviceManagerONo = await connection.deviceManager.objectNumber
+  XCTAssertEqual(deviceManagerONo, OcaDeviceManagerONo)
+
+  let clientGain: SwiftOCA.OcaGain = try await connection.resolve(
+    object: OcaObjectIdentification(
+      oNo: TCPFixture.gainONo,
+      classIdentification: SwiftOCA.OcaGain.classIdentification
+    )
+  )
+  await { @OcaDevice in fixture.gain.gain = OcaBoundedPropertyValue(value: -6, in: -100...12) }()
+  let gain = try await clientGain.$gain._getValue(clientGain, flags: [])
+  XCTAssertEqual(gain.value, -6)
+  XCTAssertEqual(gain.minValue, -100)
+
+  try await clientGain.$gain._setValue(clientGain, OcaBoundedPropertyValue<OcaDB>(value: -3.5, in: -100...12))
+  let deviceValue = await { @OcaDevice in fixture.gain.gain.value }()
+  XCTAssertEqual(deviceValue, -3.5)
+
+  let results = try await connection.rootBlock.find(
+    actionObjectsByRole: "Master Gain",
+    nameComparisonType: .exact,
+    resultFlags: [.oNo, .role]
+  )
+  XCTAssertEqual(results.map(\.oNo), [TCPFixture.gainONo])
+}
+
+// MARK: - UDP
+
+/// AES70-4 10.4.3 makes UDP a Control Session Transport Type in its own right, with
+/// `_ocajson._udp` as the service type. A session opens on the first KeepAlive — the
+/// device ignores anything before it — which `connect()` sends for datagram transports.
+private struct UDPFixture {
+  let device: OcaDevice
+  let endpoint: DatagramDeviceEndpoint
+  let port: UInt16
+  let gain: SwiftOCADevice.OcaGain
+  let endpointTask: Task<(), Error>
+
+  static let gainONo: OcaONo = 0x0001_0100
+
+  init(timeout: Duration = .seconds(5)) async throws {
+    device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    gain = try await SwiftOCADevice.OcaGain(
+      objectNumber: Self.gainONo,
+      role: "Master Gain",
+      deviceDelegate: device,
+      addToRootBlock: true
+    )
+    let (endpoint, endpointTask, port) = try await startDatagramEndpoint(device: device, timeout: timeout)
+    self.endpoint = endpoint
+    self.endpointTask = endpointTask
+    self.port = port
+    try await Task.sleep(for: .milliseconds(100))
+  }
+
+  func tearDown() {
+    endpointTask.cancel()
+  }
+}
+
+final class Ocp2UDPTests: XCTestCase {
+  func testDatagramEndpointAdvertisesJsonServiceType() async throws {
+    let fixture = try await UDPFixture()
+    defer { fixture.tearDown() }
+    XCTAssertEqual(fixture.endpoint.serviceType, .udpJson)
+  }
+
+  func testRoundTripOverDatagram() async throws {
+    let fixture = try await UDPFixture()
+    defer { fixture.tearDown() }
+
+    let connection = try await DatagramConnection(
+      deviceAddress: localhostAddress(port: fixture.port),
+      options: ocp2Options
+    )
+    try await connection.connect()
+    defer { Task { try? await connection.disconnect() } }
+
+    XCTAssertEqual(connection.controlProtocol, .ocp2)
+    XCTAssertTrue(connection.connectionPrefix.hasPrefix(OcaJsonUdpConnectionPrefix))
+
+    let clientGain: SwiftOCA.OcaGain = try await connection.resolve(
+      object: OcaObjectIdentification(
+        oNo: UDPFixture.gainONo,
+        classIdentification: SwiftOCA.OcaGain.classIdentification
+      )
+    )
+    await { @OcaDevice in fixture.gain.gain = OcaBoundedPropertyValue(value: -6, in: -100...12) }()
+    let gain = try await clientGain.$gain._getValue(clientGain, flags: [])
+    XCTAssertEqual(gain.value, -6)
+
+    try await clientGain.$gain._setValue(
+      clientGain,
+      OcaBoundedPropertyValue<OcaDB>(value: -3.5, in: -100...12)
+    )
+    let deviceValue = await { @OcaDevice in fixture.gain.gain.value }()
+    XCTAssertEqual(deviceValue, -3.5)
+
+    let controllers = await fixture.endpoint.controllers
+    XCTAssertEqual((controllers.first as? any Ocp1ControllerInternal)?.connectionPrefix, OcaJsonUdpConnectionPrefix)
+  }
+}
+
+// MARK: - TCP
+
+final class Ocp2TCPTests: XCTestCase {
+  func testStreamClient() async throws {
+    let fixture = try await TCPFixture()
+    defer { fixture.tearDown() }
+
+    let connection = try await makeStreamConnection(port: fixture.port)
+    try await connection.connect()
+    try await exerciseConnection(connection, fixture: fixture)
+    try await connection.disconnect()
+  }
+
+  func testCFSocketClient() async throws {
+    let fixture = try await TCPFixture()
+    defer { fixture.tearDown() }
+
+    let connection = try await makeCFSocketTCPConnection(port: fixture.port)
+    try await connection.connect()
+    try await exerciseConnection(connection, fixture: fixture)
+    try await connection.disconnect()
+  }
+
+  #if canImport(Network)
+  func testNWClient() async throws {
+    let fixture = try await TCPFixture()
+    defer { fixture.tearDown() }
+
+    let connection = try await makeNWTCPConnection(port: fixture.port)
+    try await connection.connect()
+    try await exerciseConnection(connection, fixture: fixture)
+    try await connection.disconnect()
+  }
+  #endif
+
+  func testBatchedCommands() async throws {
+    let fixture = try await TCPFixture()
+    defer { fixture.tearDown() }
+
+    let options = Ocp1ConnectionOptions(
+      flags: .refreshDeviceTreeOnConnection,
+      batchingOptions: try .init(batchSize: 4096, batchThreshold: .milliseconds(50)),
+      controlProtocol: .ocp2
+    )
+    let connection = try await makeStreamConnection(port: fixture.port, options: options)
+    try await connection.connect()
+
+    // several concurrent requests share a batch: one `Commands` array on the wire
+    let identifications = try await withThrowingTaskGroup(of: OcaClassIdentification.self) { group in
+      for objectNumber in [OcaDeviceManagerONo, OcaSubscriptionManagerONo, OcaRootBlockONo] {
+        group.addTask { try await connection.getClassIdentification(objectNumber: objectNumber) }
+      }
+      return try await group.reduce(into: [OcaClassIdentification]()) { $0.append($1) }
+    }
+    XCTAssertEqual(identifications.count, 3)
+
+    try await connection.disconnect()
+  }
+
+  func testPropertyChangeNotificationOverTCP() async throws {
+    let fixture = try await TCPFixture()
+    defer { fixture.tearDown() }
+
+    let connection = try await makeStreamConnection(port: fixture.port)
+    try await connection.connect()
+
+    let clientGain: SwiftOCA.OcaGain = try await connection.resolve(
+      object: OcaObjectIdentification(
+        oNo: TCPFixture.gainONo,
+        classIdentification: SwiftOCA.OcaGain.classIdentification
+      )
+    )
+    await clientGain.$gain.subscribe(clientGain)
+    let deadline = ContinuousClock.now + .seconds(5)
+    while ContinuousClock.now < deadline, (try? await clientGain.isSubscribed) != true {
+      try await Task.sleep(for: .milliseconds(25))
+    }
+
+    await { @OcaDevice in fixture.gain.gain = OcaBoundedPropertyValue(value: 1.25, in: -100...12) }()
+    var observed = false
+    while ContinuousClock.now < deadline, !observed {
+      if case let .success(value) = clientGain.$gain.currentValue, value.value == 1.25 {
+        observed = true
+      } else {
+        try await Task.sleep(for: .milliseconds(25))
+      }
+    }
+    XCTAssertTrue(observed, "gain change not observed over OCP.2/TCP")
+
+    try await connection.disconnect()
+  }
+
+  /// A hand-written OCP.2 session, as another implementation would produce it.
+  func testRawJSONSession() async throws {
+    let fixture = try await TCPFixture(timeout: .seconds(2))
+    defer { fixture.tearDown() }
+
+    let socket = try await AsyncSocket.connected(to: .inet(ip4: "127.0.0.1", port: fixture.port))
+    defer { try? socket.close() }
+
+    func exchange(_ text: String) async throws -> [String: Any] {
+      try await socket.write(Data(text.utf8))
+      var line = Data()
+      while !line.contains(UInt8(ascii: "\n")) {
+        line += try await socket.read(atMost: 4096)
+      }
+      return try XCTUnwrap(JSONSerialization.jsonObject(with: line) as? [String: Any])
+    }
+
+    // AES70-4 example A05, aimed at our gain
+    let setGain = try await exchange("""
+    {"ProtocolVersion":1,"Commands":[{"Handle":49,"TargetONo":\(TCPFixture.gainONo),"MethodID":[4,2,"SetGain"],"Parameters":{"Gain":-3.5}}]}
+
+    """)
+    let responses = try XCTUnwrap(setGain["Responses"] as? [[String: Any]])
+    XCTAssertEqual(responses.count, 1)
+    XCTAssertEqual(responses[0]["Handle"] as? Int, 49)
+    XCTAssertEqual(responses[0]["StatusCode"] as? String, "OK")
+    let deviceValue = await { @OcaDevice in fixture.gain.gain.value }()
+    XCTAssertEqual(deviceValue, -3.5)
+
+    // GetGain: Gain, minGain, maxGain
+    let getGain = try await exchange("""
+    {"ProtocolVersion":1,"Commands":[{"Handle":50,"TargetONo":\(TCPFixture.gainONo),"MethodID":[4,1]}]}
+
+    """)
+    let getResponse = try XCTUnwrap((getGain["Responses"] as? [[String: Any]])?.first)
+    let parameters = try XCTUnwrap(getResponse["Parameters"] as? [String: Any])
+    XCTAssertEqual(parameters["Gain"] as? Double, -3.5)
+    XCTAssertNotNil(parameters["MinGain"])
+    XCTAssertNotNil(parameters["MaxGain"])
+
+    // AES70-4 example A01 against the root block
+    let find = try await exchange("""
+    {"ProtocolVersion":1,"Commands":[{"Handle":47,"TargetONo":\(OcaRootBlockONo),"MethodID":[3,17,"FindActionObjectsByRole"],"Parameters":{"SearchName":"Master Gain","NameComparisonType":"Exact","SearchClassID":[1,1,1,5],"ResultFlags":1}}]}
+
+    """)
+    let findResponse = try XCTUnwrap((find["Responses"] as? [[String: Any]])?.first)
+    XCTAssertEqual(findResponse["StatusCode"] as? String, "OK")
+    let result = try XCTUnwrap((findResponse["Parameters"] as? [String: Any])?["Result"] as? [[String: Any]])
+    XCTAssertEqual(result.first?["ONo"] as? Int, Int(TCPFixture.gainONo))
+
+    // an unknown object is a status, not a dropped connection
+    let badONo = try await exchange("""
+    {"ProtocolVersion":1,"Commands":[{"Handle":51,"TargetONo":123456789,"MethodID":[1,1]}]}
+
+    """)
+    XCTAssertEqual((badONo["Responses"] as? [[String: Any]])?.first?["StatusCode"] as? String, "BadONo")
+  }
+
+  func testKeepAliveExpiry() async throws {
+    let fixture = try await TCPFixture(timeout: .seconds(2))
+    defer { fixture.tearDown() }
+
+    let socket = try await AsyncSocket.connected(to: .inet(ip4: "127.0.0.1", port: fixture.port))
+    defer { try? socket.close() }
+
+    try await socket.write(Data("{\"ProtocolVersion\":1,\"KeepAlive\":{\"HeartbeatTimeout\":200}}\n".utf8))
+    let deadline = ContinuousClock.now + .seconds(2)
+    var controllers = await fixture.endpoint.controllers
+    while ContinuousClock.now < deadline, controllers.isEmpty {
+      try await Task.sleep(for: .milliseconds(25))
+      controllers = await fixture.endpoint.controllers
+    }
+    XCTAssertEqual(controllers.count, 1)
+    let controllerProtocol = controllers.first?.controlProtocol
+    XCTAssertEqual(controllerProtocol, .ocp2)
+    XCTAssertEqual((controllers.first as? any Ocp1ControllerInternal)?.connectionPrefix, OcaJsonTcpConnectionPrefix)
+
+    // the device sends its own keep-alives at the negotiated interval
+    var received = Data()
+    let keepAliveDeadline = ContinuousClock.now + .seconds(1)
+    while ContinuousClock.now < keepAliveDeadline, !received.contains(UInt8(ascii: "\n")) {
+      received += try await socket.read(atMost: 4096)
+    }
+    let keepAlive = try XCTUnwrap(JSONSerialization.jsonObject(with: received.prefix(while: { $0 != UInt8(ascii: "\n") })) as? [String: Any])
+    XCTAssertEqual((keepAlive["KeepAlive"] as? [String: Any])?["HeartbeatTimeout"] as? Int, 200)
+
+    // then we go silent: three missed heartbeats and the controller is expired
+    let expiryDeadline = ContinuousClock.now + .seconds(3)
+    while ContinuousClock.now < expiryDeadline, await !fixture.endpoint.controllers.isEmpty {
+      try await Task.sleep(for: .milliseconds(50))
+    }
+    let remaining = await fixture.endpoint.controllers
+    XCTAssertTrue(remaining.isEmpty, "silent OCP.2 controller was not expired")
+  }
+
+  func testOcp1ClientIsRejectedByOcp2Endpoint() async throws {
+    let fixture = try await TCPFixture(timeout: .seconds(2))
+    defer { fixture.tearDown() }
+
+    let connection = try await makeStreamConnection(
+      port: fixture.port,
+      options: Ocp1ConnectionOptions(flags: [], connectionTimeout: .seconds(2), responseTimeout: .seconds(1))
+    )
+    try await connection.connect()
+    do {
+      _ = try await connection.getClassIdentification(objectNumber: OcaRootBlockONo)
+      XCTFail("an OCP.1 command was answered by an OCP.2 endpoint")
+    } catch {}
+    try? await connection.disconnect()
+  }
+}
+
+// MARK: - WebSocket
+
+private func makeWSEndpoint(
+  device: OcaDevice,
+  controlProtocols: Set<OcaControlProtocol> = [.ocp2],
+  paths: [OcaControlProtocol: String] = [:],
+  timeout: Duration = .seconds(5)
+) async throws -> (Ocp1FlyingFoxDeviceEndpoint, Task<(), Error>, UInt16) {
+  let endpoint = try await Ocp1FlyingFoxDeviceEndpoint(
+    address: localhostAddress(port: 0),
+    timeout: timeout,
+    device: device,
+    controlProtocols: controlProtocols,
+    paths: paths
+  )
+  let endpointTask = Task { try await endpoint.run() }
+  try await endpoint.httpServer.waitUntilListening(timeout: 5)
+  guard let listeningAddress = await endpoint.httpServer.listeningAddress else {
+    throw Ocp1Error.notConnected
+  }
+  let port: UInt16
+  switch listeningAddress {
+  case let .ip4(_, p): port = p
+  case let .ip6(_, p): port = p
+  default: throw Ocp1Error.notConnected
+  }
+  return (endpoint, endpointTask, port)
+}
+
+/// A minimal RFC 6455 client, so the handshake and close codes can be checked on
+/// Linux, where URLSession's WebSocket support depends on how libcurl was built.
+private struct RawWebSocket {
+  let socket: AsyncSocket
+  let negotiatedProtocol: String?
+
+  init(port: UInt16, path: String = "/", protocols: [String] = ["AES70-OCP.2"]) async throws {
+    socket = try await AsyncSocket.connected(to: .inet(ip4: "127.0.0.1", port: port))
+    let key = Data((0..<16).map { _ in UInt8.random(in: 0...255) }).base64EncodedString()
+    let requestLines = [
+      "GET \(path) HTTP/1.1",
+      "Host: 127.0.0.1:\(port)",
+      "Upgrade: websocket",
+      "Connection: Upgrade",
+      "Sec-WebSocket-Key: \(key)",
+      "Sec-WebSocket-Version: 13",
+    ] + (protocols.isEmpty ? [] : ["Sec-WebSocket-Protocol: \(protocols.joined(separator: ", "))"])
+      + ["", ""]
+    let request = requestLines.joined(separator: "\r\n")
+    try await socket.write(Data(request.utf8))
+
+    // read byte-wise so no frame data is consumed with the headers
+    var response = [UInt8]()
+    while !response.suffix(4).elementsEqual("\r\n\r\n".utf8) {
+      try response.append(await socket.read())
+    }
+    let lines = String(decoding: response, as: UTF8.self).components(separatedBy: "\r\n")
+    guard lines.first?.hasPrefix("HTTP/1.1 101") == true else {
+      throw Ocp1Error.notConnected
+    }
+    negotiatedProtocol = lines.dropFirst().compactMap { line -> String? in
+      let field = line.split(separator: ":", maxSplits: 1)
+      guard field.count == 2,
+            field[0].lowercased() == "sec-websocket-protocol" else { return nil }
+      return field[1].trimmingCharacters(in: .whitespaces)
+    }.first
+  }
+
+  func send(opcode: UInt8, _ payload: Data) async throws {
+    var frame = Data([0x80 | opcode])
+    switch payload.count {
+    case ..<126:
+      frame.append(0x80 | UInt8(payload.count))
+    case ...0xFFFF:
+      frame.append(0x80 | 126)
+      frame.append(contentsOf: [UInt8(payload.count >> 8), UInt8(payload.count & 0xFF)])
+    default:
+      frame.append(0x80 | 127)
+      frame.append(contentsOf: stride(from: 56, through: 0, by: -8).map { UInt8((payload.count >> $0) & 0xFF) })
+    }
+    // clients must mask every frame they send
+    let mask = (0..<4).map { _ in UInt8.random(in: 0...255) }
+    frame.append(contentsOf: mask)
+    frame.append(contentsOf: payload.enumerated().map { $1 ^ mask[$0 % 4] })
+    try await socket.write(frame)
+  }
+
+  func receive() async throws -> (opcode: UInt8, payload: [UInt8]) {
+    let header = try await socket.read(bytes: 2)
+    var length = Int(header[1] & 0x7F)
+    if length == 126 {
+      length = try await socket.read(bytes: 2).reduce(0) { $0 << 8 | Int($1) }
+    } else if length == 127 {
+      length = try await socket.read(bytes: 8).reduce(0) { $0 << 8 | Int($1) }
+    }
+    let mask = header[1] & 0x80 != 0 ? try await socket.read(bytes: 4) : nil
+    var payload = length > 0 ? try await socket.read(bytes: length) : []
+    if let mask { payload = payload.enumerated().map { $1 ^ mask[$0 % 4] } }
+    return (header[0] & 0x0F, payload)
+  }
+
+  /// Reads until the device's close frame and returns its status code.
+  func closeCode() async throws -> UInt16? {
+    while true {
+      let (opcode, payload) = try await receive()
+      guard opcode == 0x8 else { continue }
+      return payload.count >= 2 ? UInt16(payload[0]) << 8 | UInt16(payload[1]) : nil
+    }
+  }
+
+  func close() async {
+    try? await send(opcode: 0x8, Data([0x03, 0xE8]))
+    try? socket.close()
+  }
+}
+
+final class Ocp2WebSocketTests: XCTestCase {
+  // Ocp1FlyingFoxConnection is built on URLSessionWebSocketTask, so it is Apple-only
+  #if os(macOS) || os(iOS)
+  func testClientRoundTrip() async throws {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    let expectedName = "OCP.2 WebSocket device"
+    let deviceManager = await device.deviceManager!
+    await { @OcaDevice in deviceManager.deviceName = expectedName }()
+
+    let (_, endpointTask, port) = try await makeWSEndpoint(device: device)
+    defer { endpointTask.cancel() }
+
+    let connection = await Ocp1FlyingFoxConnection(host: "127.0.0.1", port: port, options: ocp2Options)
+    try await connection.connect()
+    XCTAssertEqual(connection.controlProtocol, .ocp2)
+    XCTAssertTrue(connection.connectionPrefix.hasPrefix(OcaJsonWebSocketTcpConnectionPrefix))
+
+    let deviceName = try await connection.deviceManager.$deviceName._getValue(connection.deviceManager)
+    XCTAssertEqual(deviceName, expectedName)
+    let members = try await connection.rootBlock.resolveActionObjects()
+    XCTAssertFalse(members.isEmpty)
+
+    try await connection.disconnect()
+  }
+
+  /// SwiftOCA's own OCP.1 and OCP.2 WebSocket clients, connected to one endpoint at once.
+  func testBothClientsOnOnePort() async throws {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    let expectedName = "OCP.1 and OCP.2 WebSocket device"
+    let deviceManager = await device.deviceManager!
+    await { @OcaDevice in deviceManager.deviceName = expectedName }()
+
+    let (_, endpointTask, port) = try await makeWSEndpoint(
+      device: device,
+      controlProtocols: [.ocp1, .ocp2]
+    )
+    defer { endpointTask.cancel() }
+
+    let ocp1 = await Ocp1FlyingFoxConnection(host: "127.0.0.1", port: port)
+    let ocp2 = await Ocp1FlyingFoxConnection(host: "127.0.0.1", port: port, options: ocp2Options)
+    try await ocp1.connect()
+    try await ocp2.connect()
+    XCTAssertEqual(ocp1.controlProtocol, .ocp1)
+    XCTAssertEqual(ocp2.controlProtocol, .ocp2)
+
+    for connection in [ocp1, ocp2] {
+      let deviceName = try await connection.deviceManager.$deviceName._getValue(connection.deviceManager)
+      XCTAssertEqual(deviceName, expectedName, "\(connection.controlProtocol)")
+    }
+
+    try await ocp1.disconnect()
+    try await ocp2.disconnect()
+  }
+  #endif
+
+  func testSubprotocolIsNegotiatedAndPathAdvertised() async throws {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    let (endpoint, endpointTask, port) = try await makeWSEndpoint(device: device, paths: [.ocp2: "/aes70"])
+    defer { endpointTask.cancel() }
+
+    XCTAssertEqual(endpoint.txtRecordAdditions.map { "\($0)=\($1)" }, ["path=/aes70"])
+    #if canImport(dnssd)
+    // AES70-4: txtvers, then protovers, then the optional path
+    let deviceManager = await device.deviceManager!
+    let txtRecords = await deviceManager.txtRecords(adding: endpoint.txtRecordAdditions)
+    XCTAssertEqual(txtRecords.prefix(3).map(\.0), ["txtvers", "protovers", "path"])
+    #endif
+    XCTAssertEqual(endpoint.serviceType, .tcpWebSocketJson)
+
+    let webSocket = try await RawWebSocket(port: port, path: "/aes70")
+    XCTAssertEqual(webSocket.negotiatedProtocol, "AES70-OCP.2")
+
+    // a text-framed OCP.2 exchange
+    try await webSocket.send(
+      opcode: 0x1,
+      Data("{\"ProtocolVersion\":1,\"Commands\":[{\"Handle\":1,\"TargetONo\":1,\"MethodID\":[1,1]}]}\n".utf8)
+    )
+    let (opcode, payload) = try await webSocket.receive()
+    XCTAssertEqual(opcode, 0x1, "expected a text frame")
+    let text = String(decoding: payload, as: UTF8.self)
+    XCTAssertTrue(text.hasSuffix("\n"))
+    let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(text.utf8)) as? [String: Any])
+    let response = try XCTUnwrap((object["Responses"] as? [[String: Any]])?.first)
+    XCTAssertEqual(response["StatusCode"] as? String, "OK")
+    XCTAssertNotNil((response["Parameters"] as? [String: Any])?["ClassIdentification"])
+
+    await webSocket.close()
+  }
+
+  func testBinaryFrameCloses1003() async throws {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    let (_, endpointTask, port) = try await makeWSEndpoint(device: device)
+    defer { endpointTask.cancel() }
+
+    let webSocket = try await RawWebSocket(port: port)
+    try await webSocket.send(opcode: 0x2, Data([0x3B, 0, 1, 0, 0, 0, 9, 4, 0, 0]))
+    let closeCode = try await webSocket.closeCode()
+    XCTAssertEqual(closeCode, 1003)
+    await webSocket.close()
+  }
+
+  func testMalformedMessageCloses1007() async throws {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    let (_, endpointTask, port) = try await makeWSEndpoint(device: device)
+    defer { endpointTask.cancel() }
+
+    let webSocket = try await RawWebSocket(port: port)
+    try await webSocket.send(opcode: 0x1, Data("{\"ProtocolVersion\":2,\"KeepAlive\":{\"HeartbeatTimeout\":1}}\n".utf8))
+    let closeCode = try await webSocket.closeCode()
+    XCTAssertEqual(closeCode, 1007)
+    await webSocket.close()
+  }
+
+  /// OCP.1 and OCP.2 on one port and path: the offered subprotocol picks the protocol.
+  func testOneEndpointServesBothProtocols() async throws {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    let (endpoint, endpointTask, port) = try await makeWSEndpoint(
+      device: device,
+      controlProtocols: [.ocp1, .ocp2]
+    )
+    defer { endpointTask.cancel() }
+
+    XCTAssertEqual(endpoint.advertisedServices.map(\.serviceType), [.tcpWebSocket, .tcpWebSocketJson])
+    XCTAssertTrue(endpoint.advertisedServices.allSatisfy(\.txtRecordAdditions.isEmpty))
+
+    let ocp2 = try await RawWebSocket(port: port)
+    XCTAssertEqual(ocp2.negotiatedProtocol, "AES70-OCP.2")
+    try await assertOcp2RoundTrip(ocp2)
+    await ocp2.close()
+
+    // no subprotocol offered: OCP.1, which answers a binary KeepAlive with its own
+    let ocp1 = try await RawWebSocket(port: port, protocols: [])
+    XCTAssertNil(ocp1.negotiatedProtocol)
+    try await ocp1.send(opcode: 0x2, Self.ocp1KeepAlive)
+    let (opcode, payload) = try await ocp1.receive()
+    XCTAssertEqual(opcode, 0x2, "expected a binary frame")
+    XCTAssertEqual(payload.first, 0x3B, "expected an OCP.1 PDU")
+    await ocp1.close()
+  }
+
+  /// Each protocol on its own path, advertised with its own `path` TXT record.
+  func testProtocolsOnTheirOwnPaths() async throws {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    let (endpoint, endpointTask, port) = try await makeWSEndpoint(
+      device: device,
+      controlProtocols: [.ocp1, .ocp2],
+      paths: [.ocp2: "aes70"]
+    )
+    defer { endpointTask.cancel() }
+
+    XCTAssertEqual(endpoint.paths, [.ocp1: "/", .ocp2: "/aes70"])
+    XCTAssertEqual(
+      endpoint.advertisedServices.map { $0.txtRecordAdditions.map { "\($0)=\($1)" } },
+      [[], ["path=/aes70"]]
+    )
+
+    let ocp2 = try await RawWebSocket(port: port, path: "/aes70")
+    XCTAssertEqual(ocp2.negotiatedProtocol, "AES70-OCP.2")
+    try await assertOcp2RoundTrip(ocp2)
+    await ocp2.close()
+
+    // "/" serves only OCP.1, so an OCP.2 offer there is not taken up
+    let ocp1 = try await RawWebSocket(port: port, path: "/")
+    XCTAssertNil(ocp1.negotiatedProtocol)
+    await ocp1.close()
+  }
+
+  func testAnEndpointNeedsAControlProtocol() async throws {
+    do {
+      _ = try await makeWSEndpoint(device: OcaDevice(), controlProtocols: [])
+      XCTFail("an endpoint serving no control protocol was created")
+    } catch Ocp1Error.unsupportedControlProtocol {}
+  }
+
+  /// A KeepAlive PDU with a one-second heartbeat.
+  private static let ocp1KeepAlive = Data([0x3B, 0x00, 0x01, 0x00, 0x00, 0x00, 0x0B, 0x04, 0x00, 0x01, 0x00, 0x01])
+
+  /// A GetClassIdentification on the device manager, answered in a text frame.
+  private func assertOcp2RoundTrip(
+    _ webSocket: RawWebSocket,
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) async throws {
+    try await webSocket.send(
+      opcode: 0x1,
+      Data("{\"ProtocolVersion\":1,\"Commands\":[{\"Handle\":1,\"TargetONo\":1,\"MethodID\":[1,1]}]}\n".utf8)
+    )
+    let (opcode, payload) = try await webSocket.receive()
+    XCTAssertEqual(opcode, 0x1, "expected a text frame", file: file, line: line)
+    let object = try XCTUnwrap(
+      JSONSerialization.jsonObject(with: Data(payload)) as? [String: Any],
+      file: file,
+      line: line
+    )
+    let response = try XCTUnwrap((object["Responses"] as? [[String: Any]])?.first, file: file, line: line)
+    XCTAssertEqual(response["StatusCode"] as? String, "OK", file: file, line: line)
+  }
+}
+
+#endif

--- a/Tests/SwiftOCADeviceTests/Ocp2TransportTests.swift
+++ b/Tests/SwiftOCADeviceTests/Ocp2TransportTests.swift
@@ -883,8 +883,13 @@ final class Ocp2LargeHierarchyTests: XCTestCase {
   private static let gainsPerBlock = 999
   private static let depth = 1000
 
-  // the walk under test is the explicit one, not the tree refresh on connect
-  private static let options = Ocp1ConnectionOptions(flags: [], controlProtocol: .ocp2)
+  // the walk under test is the explicit one, not the tree refresh on connect; a
+  // ten-thousand-member response takes seconds on a slow or sanitized build
+  private static let options = Ocp1ConnectionOptions(
+    flags: [],
+    responseTimeout: .seconds(60),
+    controlProtocol: .ocp2
+  )
 
   private func assertRecursiveMembers(
     of fixture: TCPFixture,

--- a/Tests/SwiftOCADeviceTests/Ocp2WireNameTests.swift
+++ b/Tests/SwiftOCADeviceTests/Ocp2WireNameTests.swift
@@ -130,6 +130,32 @@ final class Ocp2WireNameTests: XCTestCase {
     XCTAssertEqual(parameters["Name"] as? String, "In 1")
   }
 
+  func testSetterParameterIsNamedSeparatelyFromTheGetter() async throws {
+    let fixture = try await makeFixture()
+    defer { fixture.tearDown() }
+
+    // OcaDeviceManager 3.17 GetMessage → Message, but 3.18 SetMessage ← Text
+    let before = try await Self.responseParameters(
+      fixture,
+      targetONo: OcaDeviceManagerONo,
+      methodID: "3,17"
+    )
+    XCTAssertEqual(Set(before.keys), ["Message"])
+
+    _ = try await Self.responseParameters(
+      fixture,
+      targetONo: OcaDeviceManagerONo,
+      methodID: "3,18",
+      parameters: "{\"Text\":\"on air\"}"
+    )
+    let after = try await Self.responseParameters(
+      fixture,
+      targetONo: OcaDeviceManagerONo,
+      methodID: "3,17"
+    )
+    XCTAssertEqual(after["Message"] as? String, "on air")
+  }
+
   func testRecordParametersAreNamedByField() async throws {
     let fixture = try await makeFixture()
     defer { fixture.tearDown() }
@@ -211,6 +237,16 @@ final class Ocp2WireNameTests: XCTestCase {
     getEndpoint.cancel()
     XCTAssertEqual(scalar.methodID, [3, 22])
     XCTAssertEqual(Set(scalar.parameters.keys), ["ID"])
+
+    // OcaDeviceManager 3.18 SetMessage(Text): the setter's name is not the getter's
+    let deviceManager = await connection.deviceManager
+    let setMessage = Task {
+      try? await deviceManager.$message._setValue(deviceManager, "on air")
+    }
+    let differing = try await Self.nextCommand(from: endpoint)
+    setMessage.cancel()
+    XCTAssertEqual(differing.methodID, [3, 18])
+    XCTAssertEqual(Set(differing.parameters.keys), ["Text"])
   }
 }
 

--- a/Tests/SwiftOCADeviceTests/Ocp2WireNameTests.swift
+++ b/Tests/SwiftOCADeviceTests/Ocp2WireNameTests.swift
@@ -1,0 +1,217 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if NonEmbeddedBuild
+
+import Foundation
+@testable @_spi(SwiftOCAPrivate) import SwiftOCA
+@testable @_spi(SwiftOCAPrivate) import SwiftOCADevice
+@preconcurrency import XCTest
+
+/// AES70-4 names a command's and a response's parameters after the model (AES70-2A), and
+/// a strict peer matches them by name. These pin the exact keys on the wire, one test per
+/// shape a name can take, without needing the model file (see the naming oracles).
+final class Ocp2WireNameTests: XCTestCase {
+  private static let dynamicsONo: OcaONo = 0x0001_0400
+  private static let matrixONo: OcaONo = 0x0001_0500
+  private static let applicationONo: OcaONo = 0x0001_0600
+  private static let portID = OcaPortID(mode: .input, index: 1)
+
+  /// A device with one object of each shape, served over the OCP.2 local endpoint.
+  private struct Fixture {
+    let endpoint: OcaLocalDeviceEndpoint
+    let endpointTask: Task<(), Never>
+
+    func tearDown() {
+      endpointTask.cancel()
+    }
+  }
+
+  @OcaDevice
+  private static func populate(_ device: OcaDevice) async throws {
+    _ = try await SwiftOCADevice.OcaDynamics(
+      objectNumber: dynamicsONo,
+      role: "Dynamics",
+      deviceDelegate: device,
+      addToRootBlock: true
+    )
+    _ = try await SwiftOCADevice.OcaMatrix<SwiftOCADevice.OcaWorker>(
+      rows: 2,
+      columns: 2,
+      objectNumber: matrixONo,
+      deviceDelegate: device,
+      addToRootBlock: true
+    )
+    let application = try await SwiftOCADevice.OcaMediaTransportApplication(
+      objectNumber: applicationONo,
+      deviceDelegate: device
+    )
+    application.ports = [OcaPort(owner: applicationONo, id: portID, name: "In 1")]
+  }
+
+  private func makeFixture() async throws -> Fixture {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    try await Self.populate(device)
+    let endpoint = try await OcaLocalDeviceEndpoint(device: device, controlProtocol: .ocp2)
+    let endpointTask = Task { do { try await endpoint.run() } catch {} }
+    return Fixture(endpoint: endpoint, endpointTask: endpointTask)
+  }
+
+  /// One command in, its response's `Parameters` out, over the endpoint's raw channels.
+  @OcaDevice
+  private static func responseParameters(
+    _ fixture: Fixture,
+    targetONo: OcaONo,
+    methodID: String,
+    parameters: String? = nil
+  ) async throws -> [String: any Sendable] {
+    var command = "{\"Handle\":1,\"TargetONo\":\(targetONo),\"MethodID\":[\(methodID)]"
+    if let parameters {
+      command += ",\"Parameters\":\(parameters)"
+    }
+    command += "}"
+    let pdu = "{\"ProtocolVersion\":1,\"Commands\":[\(command)]}\n"
+    await fixture.endpoint.requestChannel.send(Data(pdu.utf8))
+    for await data in fixture.endpoint.responseChannel {
+      let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+      let response = try XCTUnwrap((object["Responses"] as? [[String: Any]])?.first)
+      XCTAssertEqual(response["StatusCode"] as? String, "OK", "method \(methodID)")
+      return Ocp2JSON.sendableObject(response["Parameters"] as? [String: Any] ?? [:])
+    }
+    throw Ocp1Error.notConnected
+  }
+
+  // MARK: - what the device answers
+
+  func testGetterResponseIsNamedAfterTheModel() async throws {
+    let fixture = try await makeFixture()
+    defer { fixture.tearDown() }
+
+    // OcaBlock 3.6 GetActionObjectsRecursive → Objects, not ActionObjects
+    let parameters = try await Self.responseParameters(fixture, targetONo: OcaRootBlockONo, methodID: "3,6")
+    XCTAssertEqual(Set(parameters.keys), ["Objects"])
+  }
+
+  func testBoundedGetterResponseCarriesMinAndMax() async throws {
+    let fixture = try await makeFixture()
+    defer { fixture.tearDown() }
+
+    // OcaDynamics 4.13 GetAttackTime → Time, MinTime, MaxTime
+    let parameters = try await Self.responseParameters(fixture, targetONo: Self.dynamicsONo, methodID: "4,13")
+    XCTAssertEqual(Set(parameters.keys), ["Time", "MinTime", "MaxTime"])
+  }
+
+  func testScalarResponseIsNamed() async throws {
+    let fixture = try await makeFixture()
+    defer { fixture.tearDown() }
+
+    // OcaMediaTransportApplication 3.4 GetPortName(PortID) → Name, once the "Value" placeholder
+    let parameters = try await Self.responseParameters(
+      fixture,
+      targetONo: Self.applicationONo,
+      methodID: "3,4",
+      parameters: "{\"PortID\":{\"Mode\":1,\"Index\":1}}"
+    )
+    XCTAssertEqual(Set(parameters.keys), ["Name"])
+    XCTAssertEqual(parameters["Name"] as? String, "In 1")
+  }
+
+  func testRecordParametersAreNamedByField() async throws {
+    let fixture = try await makeFixture()
+    defer { fixture.tearDown() }
+
+    // OcaBlock 3.17 FindActionObjectsByRole: a record in, keyed by the model's field names
+    let parameters = try await Self.responseParameters(
+      fixture,
+      targetONo: OcaRootBlockONo,
+      methodID: "3,17",
+      parameters: "{\"SearchName\":\"Dynamics\",\"NameComparisonType\":\"Exact\",\"SearchClassID\":[1,1,1,14],\"ResultFlags\":1}"
+    )
+    let result = try XCTUnwrap(parameters["Result"] as? [[String: any Sendable]])
+    XCTAssertEqual(result.map { $0["ONo"] as? Int }, [Int(Self.dynamicsONo)])
+  }
+
+  func testVectorGetterIsNamedByField() async throws {
+    let fixture = try await makeFixture()
+    defer { fixture.tearDown() }
+
+    // OcaMatrix 3.1 GetCurrentXY → X, Y from the vector record, not the property
+    let parameters = try await Self.responseParameters(fixture, targetONo: Self.matrixONo, methodID: "3,1")
+    XCTAssertEqual(Set(parameters.keys), ["X", "Y"])
+  }
+
+  // MARK: - what the client sends
+
+  /// The next command written to an endpoint nobody is serving.
+  @OcaDevice
+  private static func nextCommand(
+    from endpoint: OcaLocalDeviceEndpoint
+  ) async throws -> (methodID: [Int], parameters: [String: any Sendable]) {
+    for await data in endpoint.requestChannel {
+      let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+      guard let command = (object["Commands"] as? [[String: Any]])?.first else { continue }
+      let methodID = try XCTUnwrap(command["MethodID"] as? [Any]).prefix(2).compactMap { $0 as? Int }
+      return (methodID, Ocp2JSON.sendableObject(command["Parameters"] as? [String: Any] ?? [:]))
+    }
+    throw Ocp1Error.notConnected
+  }
+
+  func testClientNamesCommandParametersAfterTheModel() async throws {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    let endpoint = try await OcaLocalDeviceEndpoint(device: device, controlProtocol: .ocp2)
+    let connection = await OcaLocalConnection(
+      endpoint,
+      options: Ocp1ConnectionOptions(flags: [], controlProtocol: .ocp2)
+    )
+    try await connection.connect()
+    defer { Task { try? await connection.disconnect() } }
+
+    let dynamics: SwiftOCA.OcaDynamics = try await connection.resolve(
+      object: OcaObjectIdentification(
+        oNo: Self.dynamicsONo,
+        classIdentification: SwiftOCA.OcaDynamics.classIdentification
+      )
+    )
+    let application: SwiftOCA.OcaMediaTransportApplication = try await connection.resolve(
+      object: OcaObjectIdentification(
+        oNo: Self.applicationONo,
+        classIdentification: SwiftOCA.OcaMediaTransportApplication.classIdentification
+      )
+    )
+
+    // OcaDynamics 4.4 SetFunction(Func): a wrapper's setter, named by its ocp2Name
+    let setFunction = Task {
+      try? await dynamics.$function._setValue(dynamics, OcaDynamicsFunction.compress)
+    }
+    let setter = try await Self.nextCommand(from: endpoint)
+    setFunction.cancel()
+    XCTAssertEqual(setter.methodID, [4, 4])
+    XCTAssertEqual(Set(setter.parameters.keys), ["Func"])
+
+    // OcaMediaTransportApplication 3.22 GetEndpoint(ID): a scalar once sent as "Value"
+    let getEndpoint = Task {
+      _ = try? await application.getEndpoint(1)
+    }
+    let scalar = try await Self.nextCommand(from: endpoint)
+    getEndpoint.cancel()
+    XCTAssertEqual(scalar.methodID, [3, 22])
+    XCTAssertEqual(Set(scalar.parameters.keys), ["ID"])
+  }
+}
+
+#endif

--- a/Tests/SwiftOCADeviceTests/Ocp2WireNameTests.swift
+++ b/Tests/SwiftOCADeviceTests/Ocp2WireNameTests.swift
@@ -220,7 +220,7 @@ final class Ocp2WireNameTests: XCTestCase {
       )
     )
 
-    // OcaDynamics 4.4 SetFunction(Func): a wrapper's setter, named by its ocp2Name
+    // OcaDynamics 4.4 SetFunction(Func): a wrapper's setter, named by its ocp2SetName
     let setFunction = Task {
       try? await dynamics.$function._setValue(dynamics, OcaDynamicsFunction.compress)
     }

--- a/Tests/SwiftOCADeviceTests/OpenSSLEnginePipeTests.swift
+++ b/Tests/SwiftOCADeviceTests/OpenSSLEnginePipeTests.swift
@@ -64,6 +64,7 @@ final class OpenSSLEnginePipeTests: XCTestCase {
         )
         return try await engine.read(
           payload.count,
+          awaitingAllRead: true,
           read: { c in try await stream.read(count: c, awaitingAllRead: false) },
           write: { d in try await stream.write(d) }
         )
@@ -81,6 +82,7 @@ final class OpenSSLEnginePipeTests: XCTestCase {
         // Echo whatever we receive.
         let inbound = try await engine.read(
           payload.count,
+          awaitingAllRead: true,
           read: { c in try await stream.read(count: c, awaitingAllRead: false) },
           write: { d in try await stream.write(d) }
         )
@@ -221,6 +223,7 @@ final class OpenSSLEnginePipeTests: XCTestCase {
         )
         return try await engine.read(
           payload.count,
+          awaitingAllRead: true,
           read: { c in try await stream.read(count: c, awaitingAllRead: false) },
           write: { d in try await stream.write(d) }
         )
@@ -236,6 +239,7 @@ final class OpenSSLEnginePipeTests: XCTestCase {
         )
         let inbound = try await engine.read(
           payload.count,
+          awaitingAllRead: true,
           read: { c in try await stream.read(count: c, awaitingAllRead: false) },
           write: { d in try await stream.write(d) }
         )
@@ -301,6 +305,7 @@ final class OpenSSLEnginePipeTests: XCTestCase {
         )
         return try await engine.read(
           payload.count,
+          awaitingAllRead: true,
           read: { c in try await stream.read(count: c, awaitingAllRead: false) },
           write: { d in try await stream.write(d) }
         )
@@ -354,6 +359,7 @@ final class OpenSSLEnginePipeTests: XCTestCase {
         )
         return try await engine.read(
           payload.count,
+          awaitingAllRead: true,
           read: { c in try await stream.read(count: c, awaitingAllRead: false) },
           write: { d in try await stream.write(d) }
         )

--- a/Tests/SwiftOCATests/Ocp2CoderTests.swift
+++ b/Tests/SwiftOCATests/Ocp2CoderTests.swift
@@ -1,0 +1,349 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if NonEmbeddedBuild
+import Foundation
+@testable import SwiftOCA
+import XCTest
+
+/// AES70-4 clause 8 marshaling, and the naming rules SwiftOCA layers on it.
+final class Ocp2CoderTests: XCTestCase {
+  private func json(_ text: String) throws -> Any {
+    try JSONSerialization.jsonObject(with: Data(text.utf8), options: [.fragmentsAllowed])
+  }
+
+  private func object(_ text: String) throws -> [String: Any] {
+    try XCTUnwrap(json(text) as? [String: Any])
+  }
+
+  // MARK: parameter records
+
+  func testParameterRecordUsesDerivedNames() throws {
+    let params = OcaBlock.FindActionObjectsByRoleParameters(
+      searchName: "Master Gain",
+      nameComparisonType: .exact,
+      searchClassID: "1.1.1.5",
+      resultFlags: .oNo
+    )
+    let encoded = try Ocp2Encoder().encodeParameters(params)
+    XCTAssertEqual(encoded["SearchName"] as? String, "Master Gain")
+    XCTAssertEqual(encoded["NameComparisonType"] as? Int, 0)
+    XCTAssertEqual(encoded["SearchClassID"] as? [Int], [1, 1, 1, 5])
+    XCTAssertEqual(encoded["ResultFlags"] as? Int, 1)
+    XCTAssertEqual(encoded.count, 4)
+  }
+
+  func testParameterRecordDecodesSpecExampleA01() throws {
+    // example A01, with the enumeration spelled by name
+    let parameters = try object("""
+    {
+      "SearchName" : "Master Gain",
+      "NameComparisonType" : "Exact",
+      "SearchClassID" : [ 1, 1, 1, 5 ],
+      "ResultFlags" : 1
+    }
+    """)
+    let params = try Ocp2Decoder().decodeParameters(
+      OcaBlock.FindActionObjectsByRoleParameters.self,
+      from: parameters
+    )
+    XCTAssertEqual(params.searchName, "Master Gain")
+    XCTAssertEqual(params.nameComparisonType, .exact)
+    XCTAssertEqual(params.searchClassID, "1.1.1.5")
+    XCTAssertEqual(params.resultFlags, .oNo)
+  }
+
+  func testParameterRecordMatchesNamesCaseInsensitively() throws {
+    let parameters = try object("""
+    {"searchname": "x", "namecomparisontype": 2, "SEARCHCLASSID": [1, 1], "resultflags": 3}
+    """)
+    let params = try Ocp2Decoder().decodeParameters(
+      OcaBlock.FindActionObjectsByRoleParameters.self,
+      from: parameters
+    )
+    XCTAssertEqual(params.searchName, "x")
+    XCTAssertEqual(params.nameComparisonType, .contains)
+    XCTAssertEqual(params.searchClassID, "1.1")
+  }
+
+  func testExplicitParameterNamesOverrideFieldNames() throws {
+    // GetGain returns Gain, minGain, maxGain, which SwiftOCA holds in a generic
+    // bounded value whose fields are named value, minValue, maxValue
+    let value = OcaBoundedPropertyValue<Float>(value: -3.5, minValue: -100, maxValue: 10)
+    let names = Ocp2Naming.boundedWireNames("Gain")
+    let encoded = try Ocp2Encoder().encodeParameters(value, parameterNames: names)
+    XCTAssertEqual(encoded["Gain"] as? Double, -3.5)
+    XCTAssertEqual(encoded["MinGain"] as? Double, -100)
+    XCTAssertEqual(encoded["MaxGain"] as? Double, 10)
+
+    let decoded = try Ocp2Decoder().decodeParameters(
+      OcaBoundedPropertyValue<Float>.self,
+      from: encoded,
+      parameterNames: names
+    )
+    XCTAssertEqual(decoded, value)
+
+    // a peer that spells the names differently still gets through
+    let spelledDifferently = try object("""
+    {"gain": -3.5, "MinGain": -100, "MAXGAIN": 10}
+    """)
+    XCTAssertEqual(
+      try Ocp2Decoder().decodeParameters(
+        OcaBoundedPropertyValue<Float>.self,
+        from: spelledDifferently,
+        parameterNames: names
+      ),
+      value
+    )
+  }
+
+  // MARK: single parameters
+
+  func testSingleParameterIsNamed() throws {
+    let encoded = try Ocp2Encoder().encodeParameters(Float(-3.5), parameterNames: ["Gain"])
+    XCTAssertEqual(encoded as? [String: Double], ["Gain": -3.5])
+
+    let unnamed = try Ocp2Encoder().encodeParameters(Float(-3.5))
+    XCTAssertEqual(unnamed as? [String: Double], [Ocp2Naming.unnamedParameter: -3.5])
+  }
+
+  func testSingleParameterIsAcceptedWhateverItsName() throws {
+    for text in ["{\"Gain\": -3.5}", "{\"gain\": -3.5}", "{\"Value\": -3.5}", "{\"anything\": -3.5}"] {
+      let decoded = try Ocp2Decoder().decodeParameters(
+        Float.self,
+        from: try object(text),
+        parameterNames: ["Gain"]
+      )
+      XCTAssertEqual(decoded, -3.5, text)
+    }
+  }
+
+  func testAmbiguousSingleParameterRequiresAName() throws {
+    let parameters = try object("{\"a\": 1, \"b\": 2}")
+    XCTAssertThrowsError(try Ocp2Decoder().decodeParameters(
+      Float.self,
+      from: parameters,
+      parameterNames: ["Gain"]
+    ))
+    XCTAssertEqual(
+      try Ocp2Decoder().decodeParameters(Int.self, from: parameters, parameterNames: ["b"]),
+      2
+    )
+  }
+
+  func testPlaceholderAndEmptyParameters() throws {
+    XCTAssertTrue(try Ocp2Encoder().encodeParameters(OcaRoot.Placeholder()).isEmpty)
+    _ = try Ocp2Decoder().decodeParameters(OcaRoot.Placeholder.self, from: nil)
+    _ = try Ocp2Decoder().decodeParameters(OcaRoot.Placeholder.self, from: [:])
+    let optional: Float? = try Ocp2Decoder().decodeParameters(Float?.self, from: [:])
+    XCTAssertNil(optional)
+  }
+
+  // MARK: special datatypes
+
+  func testEnumerationsEncodeAsNumbersAndDecodeEitherWay() throws {
+    XCTAssertEqual(try Ocp2Encoder().encodeValue(OcaStatus.locked) as? Int, 3)
+    XCTAssertEqual(try Ocp2Decoder().decodeValue(OcaStatus.self, from: 3), .locked)
+    XCTAssertEqual(try Ocp2Decoder().decodeValue(OcaStatus.self, from: "OK"), .ok)
+    XCTAssertEqual(try Ocp2Decoder().decodeValue(OcaStatus.self, from: "locked"), .locked)
+    XCTAssertEqual(
+      try Ocp2Decoder().decodeValue(OcaPropertyChangeType.self, from: "CurrentChanged"),
+      .currentChanged
+    )
+    XCTAssertThrowsError(try Ocp2Decoder().decodeValue(OcaStatus.self, from: "NoSuchStatus"))
+  }
+
+  func testClassIDs() throws {
+    let standard: OcaClassID = "1.1.1.5"
+    XCTAssertEqual(try Ocp2Encoder().encodeValue(standard) as? [Int], [1, 1, 1, 5])
+    XCTAssertEqual(try Ocp2Decoder().decodeValue(OcaClassID.self, from: [1, 1, 1, 5]), standard)
+
+    let proprietary = OcaClassID(
+      parent: standard,
+      authority: OcaOrganizationID((0xFA, 0x2A, 0xE9)),
+      "2300.1"
+    )
+    let encoded = try XCTUnwrap(try Ocp2Encoder().encodeValue(proprietary) as? [Any])
+    XCTAssertEqual(encoded.count, 7)
+    XCTAssertEqual(encoded[4] as? [String], nil)
+    let authority = try XCTUnwrap(encoded[4] as? [Any])
+    XCTAssertEqual(authority[0] as? Int, 65535)
+    XCTAssertEqual(authority[1] as? String, "FA2AE9")
+    XCTAssertEqual(encoded[5] as? Int, 2300)
+    XCTAssertEqual(encoded[6] as? Int, 1)
+    XCTAssertEqual(try Ocp2Decoder().decodeValue(OcaClassID.self, from: encoded), proprietary)
+  }
+
+  func testElementIDs() throws {
+    XCTAssertEqual(try Ocp2Encoder().encodeValue(OcaPropertyID("4.1")) as? [Int], [4, 1])
+    XCTAssertEqual(try Ocp2Encoder().encodeValue(OcaMethodID("4.2")) as? [Int], [4, 2])
+    XCTAssertEqual(try Ocp2Encoder().encodeValue(OcaEventID("1.1")) as? [Int], [1, 1])
+    // the optional third element is a comment
+    XCTAssertEqual(
+      try Ocp2Decoder().decodeValue(OcaPropertyID.self, from: [4, 1, "Gain"] as [Any]),
+      OcaPropertyID("4.1")
+    )
+    XCTAssertEqual(
+      try Ocp2Decoder().decodeValue(OcaMethodID.self, from: [4, 2]),
+      OcaMethodID("4.2")
+    )
+    // the other coders are unaffected
+    let json = try JSONEncoder().encode(OcaPropertyID("4.1"))
+    XCTAssertEqual(try JSONDecoder().decode(OcaPropertyID.self, from: json), OcaPropertyID("4.1"))
+    let ocp1 = try Ocp1Encoder().encode(OcaMethodID("4.2")) as [UInt8]
+    XCTAssertEqual(ocp1, [0, 4, 0, 2])
+  }
+
+  func testBlobsAreBase64() throws {
+    let blob = OcaBlob(Data([1, 2, 3]))
+    XCTAssertEqual(try Ocp2Encoder().encodeValue(blob) as? String, "AQID")
+    XCTAssertEqual(try Ocp2Decoder().decodeValue(OcaBlob.self, from: "AQID"), blob)
+    XCTAssertEqual(try Ocp2Encoder().encodeValue(Data([1, 2, 3])) as? String, "AQID")
+    XCTAssertEqual(try Ocp2Decoder().decodeValue(Data.self, from: "AQID"), Data([1, 2, 3]))
+    XCTAssertEqual(try Ocp2Decoder().decodeValue(OcaLongBlob.self, from: "AQID").wrappedValue, Data([1, 2, 3]))
+  }
+
+  func testMapsAreArraysOfPairs() throws {
+    let map: OcaMap<OcaUint16, OcaString> = [1: "left", 2: "right"]
+    let encoded = try XCTUnwrap(try Ocp2Encoder().encodeValue(map) as? [[Any]])
+    XCTAssertEqual(encoded.count, 2)
+    XCTAssertEqual(try Ocp2Decoder().decodeValue(OcaMap<OcaUint16, OcaString>.self, from: encoded), map)
+
+    let example = try json("[[\"left\",1],[\"right\",2]]")
+    XCTAssertEqual(
+      try Ocp2Decoder().decodeValue(OcaMap<OcaString, OcaUint8>.self, from: example),
+      ["left": 1, "right": 2]
+    )
+
+    let multi: OcaMultiMap<OcaUint16, OcaString> = [1: ["a", "b"]]
+    let multiEncoded = try Ocp2Encoder().encodeValue(multi)
+    XCTAssertEqual(
+      try Ocp2Decoder().decodeValue(OcaMultiMap<OcaUint16, OcaString>.self, from: multiEncoded),
+      multi
+    )
+  }
+
+  func testTwoDimensionalArrays() throws {
+    let array = try XCTUnwrap(OcaArray2D(arrayOfArrays: [["a", "b", "c"], ["d", "e", "f"]]))
+    let encoded = try Ocp2Encoder().encodeValue(array)
+    XCTAssertEqual(encoded as? [[String]], [["a", "b", "c"], ["d", "e", "f"]])
+    XCTAssertEqual(try Ocp2Decoder().decodeValue(OcaArray2D<String>.self, from: encoded), array)
+  }
+
+  func testNonFiniteFloats() throws {
+    XCTAssertEqual(try Ocp2Encoder().encodeValue(Float.infinity) as? String, "Infinity")
+    XCTAssertEqual(try Ocp2Encoder().encodeValue(-Double.infinity) as? String, "-Infinity")
+    XCTAssertEqual(try Ocp2Encoder().encodeValue(Float.nan) as? String, "NaN")
+    XCTAssertEqual(try Ocp2Decoder().decodeValue(Float.self, from: "Infinity"), .infinity)
+    XCTAssertTrue(try Ocp2Decoder().decodeValue(Double.self, from: "NaN").isNaN)
+    // a float keeps single precision digits
+    XCTAssertEqual(try Ocp2Encoder().encodeValue(Float(0.1)) as? Double, 0.1)
+  }
+
+  func testIntegersAreRangeCheckedAndAcceptStrings() throws {
+    XCTAssertEqual(try Ocp2Decoder().decodeValue(OcaONo.self, from: "5000"), 5000)
+    XCTAssertEqual(try Ocp2Decoder().decodeValue(OcaUint8.self, from: 255), 255)
+    XCTAssertThrowsError(try Ocp2Decoder().decodeValue(OcaUint8.self, from: 256))
+    XCTAssertThrowsError(try Ocp2Decoder().decodeValue(OcaUint8.self, from: -1))
+    XCTAssertThrowsError(try Ocp2Decoder().decodeValue(OcaUint8.self, from: 1.5))
+    XCTAssertEqual(try Ocp2Decoder().decodeValue(OcaInt16.self, from: -23), -23)
+    XCTAssertEqual(try Ocp2Decoder().decodeValue(OcaUint64.self, from: UInt64.max), UInt64.max)
+  }
+
+  func testOrganizationAndModelIdentifiers() throws {
+    let organization = OcaOrganizationID((0xFA, 0x2E, 0xE9))
+    XCTAssertEqual(try Ocp2Encoder().encodeValue(organization) as? String, "FA2EE9")
+    XCTAssertEqual(try Ocp2Decoder().decodeValue(OcaOrganizationID.self, from: "FA2EE9"), organization)
+
+    let guid = OcaModelGUID(mfrCode: organization, modelCode: (1, 2, 3, 4))
+    let encoded = try XCTUnwrap(try Ocp2Encoder().encodeValue(guid) as? [String: Any])
+    XCTAssertEqual(encoded["MfrCode"] as? String, "FA2EE9")
+    XCTAssertEqual(encoded["ModelCode"] as? String, "AQIDBA==")
+    XCTAssertEqual(encoded["Reserved"] as? Int, 0)
+    XCTAssertEqual(try Ocp2Decoder().decodeValue(OcaModelGUID.self, from: encoded), guid)
+  }
+
+  func testCompositeDatatypesAreObjectsKeyedByFieldName() throws {
+    let identification = OcaClassIdentification(classID: "1.3", classVersion: 1)
+    let encoded = try XCTUnwrap(try Ocp2Encoder().encodeValue(identification) as? [String: Any])
+    XCTAssertEqual(encoded["ClassID"] as? [Int], [1, 3])
+    XCTAssertEqual(encoded["ClassVersion"] as? Int, 1)
+    XCTAssertEqual(try Ocp2Decoder().decodeValue(OcaClassIdentification.self, from: encoded), identification)
+  }
+
+  func testPropertyChangedEventData() throws {
+    let eventData = OcaPropertyChangedEventData<Float>(
+      propertyID: "4.1",
+      propertyValue: -3.5,
+      changeType: .currentChanged
+    )
+    let encoded = try XCTUnwrap(try Ocp2Encoder().encodeValue(eventData) as? [String: Any])
+    XCTAssertEqual(encoded["PropertyID"] as? [Int], [4, 1])
+    XCTAssertEqual(encoded["PropertyValue"] as? Double, -3.5)
+    XCTAssertEqual(encoded["ChangeType"] as? Int, 1)
+
+    // example A07
+    let example = try object("""
+    {
+      "PropertyID" : [ 4, 1, "Gain" ],
+      "PropertyValue" : -3.5,
+      "ChangeType" : "CurrentChanged"
+    }
+    """)
+    let decoded = try Ocp2Decoder().decodeValue(OcaPropertyChangedEventData<Float>.self, from: example)
+    XCTAssertEqual(decoded.propertyID, "4.1")
+    XCTAssertEqual(decoded.propertyValue, -3.5)
+    XCTAssertEqual(decoded.changeType, .currentChanged)
+  }
+
+  func testOptionalFieldsAreKeyedNotPositional() throws {
+    // OcaActionObjectSearchResult omits fields the flags exclude, so members must
+    // be matched by name
+    let result = OcaObjectSearchResult(
+      oNo: 5000,
+      classIdentification: OcaClassIdentification(classID: "1.1.1.5", classVersion: 3),
+      containerPath: nil,
+      role: nil,
+      label: nil
+    )
+    let flags: OcaActionObjectSearchResultFlags = [.oNo, .classIdentification]
+    var encoder = Ocp2Encoder()
+    encoder.userInfo[OcaObjectSearchResult.FlagsUserInfoKey] = flags
+    let encoded = try XCTUnwrap(try encoder.encodeValue([result] as [OcaObjectSearchResult]) as? [[String: Any]])
+    XCTAssertEqual(encoded.count, 1)
+    XCTAssertEqual(encoded[0]["ONo"] as? Int, 5000)
+    XCTAssertNotNil(encoded[0]["ClassIdentification"])
+
+    var decoder = Ocp2Decoder()
+    decoder.userInfo[OcaObjectSearchResult.FlagsUserInfoKey] = flags
+    let decoded = try decoder.decodeValue([OcaObjectSearchResult].self, from: encoded)
+    XCTAssertEqual(decoded.first?.oNo, 5000)
+    XCTAssertEqual(decoded.first?.classIdentification?.classID, "1.1.1.5")
+    XCTAssertNil(decoded.first?.role)
+  }
+
+  func testWireNames() {
+    XCTAssertEqual(Ocp2Naming.wireName("gain"), "Gain")
+    XCTAssertEqual(Ocp2Naming.wireName("oNo"), "ONo")
+    XCTAssertEqual(Ocp2Naming.wireName("_gain"), "Gain")
+    XCTAssertEqual(Ocp2Naming.wireName("SearchName"), "SearchName")
+    XCTAssertTrue(Ocp2Naming.matches("minGain", "MINGAIN"))
+    XCTAssertTrue(Ocp2Naming.matches("_gain", "Gain"))
+    XCTAssertFalse(Ocp2Naming.matches("gain", "gains"))
+    XCTAssertEqual(Ocp2Naming.boundedWireNames("Gain"), ["Gain", "MinGain", "MaxGain"])
+  }
+}
+#endif

--- a/Tests/SwiftOCATests/Ocp2ExampleConformanceTests.swift
+++ b/Tests/SwiftOCATests/Ocp2ExampleConformanceTests.swift
@@ -1,0 +1,64 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if NonEmbeddedBuild
+import Foundation
+@testable @_spi(SwiftOCAPrivate) import SwiftOCA
+import XCTest
+
+/// Runs the AES70-4 supporting-file example PDUs through the OCP.2 codec, read from
+/// disk rather than transcribed so that a revised draft is picked up: every example
+/// must decode and re-encode, and every X-series (malformed) example must be
+/// rejected. Point `AES70_4_EXAMPLES` at the supporting-files directory to run it,
+/// and set `AES70_4_OUT` to also write each re-encoded PDU there for validation
+/// against the Annex A schema. Skipped otherwise.
+final class Ocp2ExampleConformanceTests: XCTestCase {
+  func testStandardExamples() throws {
+    guard let path = ProcessInfo.processInfo.environment["AES70_4_EXAMPLES"] else {
+      throw XCTSkip("set AES70_4_EXAMPLES to the AES70-4 supporting-files directory")
+    }
+    let directory = URL(fileURLWithPath: path)
+    let out = ProcessInfo.processInfo.environment["AES70_4_OUT"].map { URL(fileURLWithPath: $0) }
+    let files = try FileManager.default.contentsOfDirectory(atPath: path)
+      .filter { $0.hasPrefix("example-") && $0.hasSuffix(".json") }
+      .sorted()
+    XCTAssertFalse(files.isEmpty, "no examples in \(path)")
+
+    for file in files {
+      let data = try Data(contentsOf: directory.appendingPathComponent(file))
+      let malformed = file.hasPrefix("example-X")
+      do {
+        let (type, messages) = try OcaControlProtocol.ocp2.decodePdu(data)
+        guard !malformed else {
+          XCTFail("\(file): malformed example was accepted")
+          continue
+        }
+        let encoded = try OcaControlProtocol.ocp2.encodePdu(messages, type: type)
+        if let out {
+          try encoded.write(to: out.appendingPathComponent(file))
+        }
+        print("CONFORMANCE PASS \(file): \(messages.count) message(s) of \(type)")
+      } catch {
+        if malformed {
+          print("CONFORMANCE PASS \(file): rejected (\(error))")
+        } else {
+          XCTFail("\(file): \(error)")
+        }
+      }
+    }
+  }
+}
+#endif

--- a/Tests/SwiftOCATests/Ocp2MessageTests.swift
+++ b/Tests/SwiftOCATests/Ocp2MessageTests.swift
@@ -614,6 +614,21 @@ final class Ocp2MessageTests: XCTestCase {
     }
   }
 
+  func testReaderAcceptsAPduOfExactlyMaximumSize() async throws {
+    // the cap excludes the terminator, however it is delivered
+    let exact = String(repeating: "x", count: 1024)
+    for chunks in [[exact + "\n"], [exact + "\r\n"], [exact, "\n"], [exact, "\r", "\n"]] {
+      let pdus = try await readAll(chunks, maximumPduSize: 1024)
+      XCTAssertEqual(pdus, [exact], "\(chunks.map(\.count))")
+    }
+    do {
+      _ = try await readAll([exact + "x\n"], maximumPduSize: 1024)
+      XCTFail("expected an error")
+    } catch {
+      XCTAssertEqual(error as? Ocp1Error, .invalidPduSize)
+    }
+  }
+
   func testReaderEnforcesMaximumPduSizeWithinOneRead() async {
     // a transport may deliver a whole frame at once: the cap still applies
     let big = String(repeating: "x", count: 2048) + "\n"

--- a/Tests/SwiftOCATests/Ocp2MessageTests.swift
+++ b/Tests/SwiftOCATests/Ocp2MessageTests.swift
@@ -460,8 +460,7 @@ final class Ocp2MessageTests: XCTestCase {
     let notification = try Ocp1Notification2(
       event: event,
       notificationType: .event,
-      data: Ocp2JSON.serialize(Ocp2Encoder().encodeValue(eventData)),
-      dataFormat: .ocp2
+      eventData: .ocp2(Ocp2JSON.sendable(Ocp2Encoder().encodeValue(eventData)))
     )
     let exception = try Ocp1Notification2(
       event: event,

--- a/Tests/SwiftOCATests/Ocp2MessageTests.swift
+++ b/Tests/SwiftOCATests/Ocp2MessageTests.swift
@@ -1,0 +1,642 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if NonEmbeddedBuild
+import Foundation
+@testable import SwiftOCA
+import XCTest
+
+/// AES70-4 clause 6 framing, exercised with the standard's own example PDUs.
+final class Ocp2MessageTests: XCTestCase {
+  // MARK: AES70-4 Annex B examples
+
+  static let exampleA01 = """
+  {
+    "ProtocolVersion" : 1,
+    "Commands" : [
+      {
+        "Handle" : 47,
+        "TargetONo" : 5000,
+        "MethodID" : [ 3, 17, "FindActionObjectsByRole" ],
+        "Parameters" : {
+          "SearchName" : "Master Gain",
+          "NameComparisonType" : "Exact",
+          "SearchClassID" : [ 1, 1, 1, 5 ],
+          "ResultFlags" : 1
+        }
+      }
+    ]
+  }
+
+  """
+
+  static let exampleA02 = """
+  {
+    "ProtocolVersion" : 1,
+    "Responses" : [
+      {
+        "Handle" : 47,
+        "StatusCode" : "OK",
+        "Parameters" : {
+          "Result" : [
+            {
+              "ONo" : "5000",
+              "ClassIdentification" : [ 1, 1, 1, 5 ]
+            }
+          ]
+        }
+      }
+    ]
+  }
+
+  """
+
+  static let exampleA04 = """
+  {
+    "ProtocolVersion" : 1,
+    "Responses" : [
+      {
+        "Handle" : 48,
+        "StatusCode" : "OK"
+      }
+    ]
+  }
+
+  """
+
+  static let exampleA05 = """
+  {
+    "ProtocolVersion" : 1,
+    "Commands" : [
+      {
+        "Handle" : 49,
+        "TargetONo" : 5000,
+        "MethodID" : [ 4, 2, "SetGain" ],
+        "Parameters" : {
+          "Gain" : -3.5
+        }
+      }
+    ]
+  }
+
+  """
+
+  static let exampleA07 = """
+  {
+    "ProtocolVersion" : 1,
+    "Notifications" : [
+      {
+        "Event" : {
+          "EventIdentification" : {
+            "EmitterONo" : 5000,
+            "EventID" : [ 1, 1, "PropertyChanged" ]
+          },
+          "EventData" : {
+            "PropertyID" : [ 4, 1, "Gain" ],
+            "PropertyValue" : -3.5,
+            "ChangeType" : "CurrentChanged"
+          }
+        }
+      }
+    ]
+  }
+
+  """
+
+  static let exampleB = """
+  {
+    "ProtocolVersion" : 1,
+    "KeepAlive" : {
+      "HeartbeatTimeout" : 6000
+    }
+  }
+
+  """
+
+  static let exampleC = """
+  {
+    "ProtocolVersion" : 1,
+    "DeviceReset" : {
+      "ResetKey" : "ZGVhZmRhZGFjYWZlYmFiZQ=="
+    }
+  }
+
+  """
+
+  static let exampleD = """
+  {
+    "ProtocolVersion" : 1,
+    "Notifications" : [
+      {
+        "Exception" : {
+          "EventIdentification" : {
+            "EmitterONo" : 5000,
+            "EventID" : [ 1, 1, "PropertyChanged" ]
+          },
+          "ExceptionType" : "CancelledByDevice",
+          "TryAgain" : false
+        }
+      }
+    ]
+  }
+
+  """
+
+  static let exampleE = """
+  {
+    "ProtocolVersion" : 1,
+    "Commands" : [
+      {
+        "Handle" : 47,
+        "TargetONo" : 5000,
+        "MethodID" : [ 3, 17, "FindActionObjectsByRole" ],
+        "Parameters" : {
+          "SearchName" : "Master Gain",
+          "NameComparisonType" : "Exact",
+          "SearchClassID" : [ 1, 1, 1, 5 ],
+          "ResultFlags" : 1
+        }
+      },
+      {
+        "Handle" : 49,
+        "TargetONo" : 5000,
+        "MethodID" : [ 4, 2, "SetGain" ],
+        "Parameters" : {
+          "Gain" : -3.5
+        }
+      }
+    ]
+  }
+
+  """
+
+  static let exampleG = """
+  {
+    "ProtocolVersion" : 1,
+    "Notifications" : [
+      {
+        "Event" : {
+          "EventIdentification" : {
+            "EmitterONo" : 5000,
+            "EventID" : [ 1, 1, "PropertyChanged" ]
+          },
+          "EventData" : {
+            "PropertyID" : [ 4, 1, "Gain" ],
+            "PropertyValue" : -3.5,
+            "ChangeType" : "CurrentChanged"
+          }
+        }
+      },
+      {
+        "Exception" : {
+          "EventIdentification" : {
+            "EmitterONo" : 5000,
+            "EventID" : [ 1, 1, "PropertyChanged" ]
+          },
+          "ExceptionType" : "CancelledByDevice",
+          "TryAgain" : false
+        }
+      }
+    ]
+  }
+
+  """
+
+  /// invalid message array name
+  static let exampleX01 = """
+  {
+    "ProtocolVersion" : 1,
+    "xCommands" : [
+      {
+        "Handle" : 47,
+        "TargetONo" : 5000,
+        "MethodID" : [ 3, 17, "FindActionObjectsByRole" ],
+        "Parameters" : { "SearchName" : "Master Gain" }
+      }
+    ]
+  }
+
+  """
+
+  /// missing TargetONo
+  static let exampleX02 = """
+  {
+    "ProtocolVersion" : 1,
+    "Commands" : [
+      {
+        "Handle" : 47,
+        "MethodID" : [ 3, 17, "FindActionObjectsByRole" ],
+        "Parameters" : { "SearchName" : "Master Gain" }
+      }
+    ]
+  }
+
+  """
+
+  /// spurious property in a command
+  static let exampleX03 = """
+  {
+    "ProtocolVersion" : 1,
+    "Commands" : [
+      {
+        "Handle" : 47,
+        "TargetONo" : 5000,
+        "MethodID" : [ 3, 17, "FindActionObjectsByRole" ],
+        "Parameters" : { "SearchName" : "Master Gain" },
+        "badProperty" : "abc"
+      }
+    ]
+  }
+
+  """
+
+  private func decode(_ text: String) throws -> (OcaMessageType, [Ocp1Message]) {
+    try OcaControlProtocol.ocp2.decodePdu(Data(text.utf8))
+  }
+
+  func testDecodeCommand() throws {
+    let (type, messages) = try decode(Self.exampleA01)
+    XCTAssertEqual(type, .ocaCmdRrq)
+    let command = try XCTUnwrap(messages.first as? Ocp1Command)
+    XCTAssertEqual(command.handle, 47)
+    XCTAssertEqual(command.targetONo, 5000)
+    XCTAssertEqual(command.methodID, OcaMethodID("3.17"))
+    XCTAssertEqual(command.parameters.format, .ocp2)
+    let params = try Ocp2Decoder().decodeParameters(
+      OcaBlock.FindActionObjectsByRoleParameters.self,
+      from: command.parameters.parameterData
+    )
+    XCTAssertEqual(params.searchName, "Master Gain")
+    XCTAssertEqual(params.resultFlags, .oNo)
+  }
+
+  func testDecodeSetGain() throws {
+    let (_, messages) = try decode(Self.exampleA05)
+    let command = try XCTUnwrap(messages.first as? Ocp1Command)
+    XCTAssertEqual(command.methodID, OcaMethodID("4.2"))
+    let gain: Float = try Ocp2Decoder().decodeParameters(
+      Float.self,
+      from: command.parameters.parameterData,
+      parameterNames: ["Gain"]
+    )
+    XCTAssertEqual(gain, -3.5)
+  }
+
+  func testDecodeResponses() throws {
+    let (type, messages) = try decode(Self.exampleA02)
+    XCTAssertEqual(type, .ocaRsp)
+    let response = try XCTUnwrap(messages.first as? Ocp1Response)
+    XCTAssertEqual(response.handle, 47)
+    XCTAssertEqual(response.statusCode, .ok)
+    XCTAssertFalse(response.parameters.isEmpty)
+
+    let (_, bare) = try decode(Self.exampleA04)
+    let bareResponse = try XCTUnwrap(bare.first as? Ocp1Response)
+    XCTAssertEqual(bareResponse.handle, 48)
+    XCTAssertTrue(bareResponse.parameters.isEmpty)
+
+    let numeric =
+      try decode("{\"ProtocolVersion\":1,\"Responses\":[{\"Handle\":1,\"StatusCode\":3}]}\n")
+    XCTAssertEqual((numeric.1.first as? Ocp1Response)?.statusCode, .locked)
+  }
+
+  func testDecodeEventNotification() throws {
+    let (type, messages) = try decode(Self.exampleA07)
+    XCTAssertEqual(type, .ocaNtf2)
+    let notification = try XCTUnwrap(messages.first as? Ocp1Notification2)
+    XCTAssertEqual(
+      notification.event,
+      OcaEvent(emitterONo: 5000, eventID: OcaPropertyChangedEventID)
+    )
+    XCTAssertEqual(notification.notificationType, .event)
+    XCTAssertEqual(notification.dataFormat, .ocp2)
+    XCTAssertNoThrow(try notification.throwIfException())
+    let eventData = try Ocp2Decoder().decodeValue(
+      OcaPropertyChangedEventData<Float>.self,
+      from: Ocp2JSON.parse(notification.data)
+    )
+    XCTAssertEqual(eventData.propertyValue, -3.5)
+    XCTAssertEqual(eventData.changeType, .currentChanged)
+  }
+
+  func testDecodeExceptionNotification() throws {
+    let (_, messages) = try decode(Self.exampleD)
+    let notification = try XCTUnwrap(messages.first as? Ocp1Notification2)
+    XCTAssertEqual(notification.notificationType, .exception)
+    XCTAssertThrowsError(try notification.throwIfException()) { error in
+      guard case let Ocp1Error.exception(exception) = error else {
+        return XCTFail("unexpected error \(error)")
+      }
+      XCTAssertEqual(exception.exceptionType, .cancelledByDevice)
+      XCTAssertFalse(exception.tryAgain)
+    }
+  }
+
+  func testDecodeMultipleMessages() throws {
+    XCTAssertEqual(try decode(Self.exampleE).1.count, 2)
+    let notifications = try decode(Self.exampleG).1
+    XCTAssertEqual(notifications.count, 2)
+    XCTAssertEqual((notifications[0] as? Ocp1Notification2)?.notificationType, .event)
+    XCTAssertEqual((notifications[1] as? Ocp1Notification2)?.notificationType, .exception)
+  }
+
+  func testDecodeKeepAliveAndDeviceReset() throws {
+    let (type, messages) = try decode(Self.exampleB)
+    XCTAssertEqual(type, .ocaKeepAlive)
+    XCTAssertEqual((messages.first as? Ocp1KeepAlive2)?.heartBeatTime, 6000)
+
+    let (_, reset) = try decode(Self.exampleC)
+    XCTAssertEqual((reset.first as? Ocp2DeviceReset)?.resetKey, Data("deafdadacafebabe".utf8))
+  }
+
+  func testMalformedExamplesAreRejected() {
+    XCTAssertThrowsError(try decode(Self.exampleX01))
+    XCTAssertThrowsError(try decode(Self.exampleX02))
+    XCTAssertThrowsError(try decode(Self.exampleX03))
+    XCTAssertThrowsError(
+      try decode("{\"ProtocolVersion\":2,\"KeepAlive\":{\"HeartbeatTimeout\":1}}\n")
+    )
+    XCTAssertThrowsError(try decode("{\"KeepAlive\":{\"HeartbeatTimeout\":1}}\n"))
+    XCTAssertThrowsError(
+      try decode(
+        "{\"ProtocolVersion\":1,\"KeepAlive\":{\"HeartbeatTimeout\":1},\"Responses\":[]}\n"
+      )
+    )
+    XCTAssertThrowsError(
+      try decode(
+        "{\"ProtocolVersion\":1,\"Commands\":[{\"Handle\":1.5,\"TargetONo\":1,\"MethodID\":[1,1]}]}\n"
+      )
+    )
+    XCTAssertThrowsError(try decode("[1,2]\n"))
+    XCTAssertThrowsError(try decode("not json\n"))
+  }
+
+  // MARK: encoding
+
+  private func roundTrip(_ messages: [Ocp1Message], type: OcaMessageType) throws -> [Ocp1Message] {
+    let pdu = try OcaControlProtocol.ocp2.encodePdu(messages, type: type)
+    XCTAssertEqual(pdu.last, UInt8(ascii: "\n"))
+    XCTAssertEqual(pdu.first, UInt8(ascii: "{"))
+    let (decodedType, decoded) = try OcaControlProtocol.ocp2.decodePdu(pdu)
+    XCTAssertEqual(decodedType, type)
+    return decoded
+  }
+
+  func testEncodeCommandMatchesExampleA05() throws {
+    let command = try Ocp1Command(
+      handle: 49,
+      targetONo: 5000,
+      methodID: OcaMethodID("4.2"),
+      parameters: Ocp1Parameters(
+        ocp2ParameterData: Ocp2Encoder().encodeParametersData(Float(-3.5), parameterNames: ["Gain"])
+      )
+    )
+    let pdu = try OcaControlProtocol.ocp2.encodePdu([command], type: .ocaCmdRrq)
+    let expected = try XCTUnwrap(try JSONSerialization
+      .jsonObject(with: Data(Self.exampleA05.utf8)) as? NSDictionary)
+    let actual = try XCTUnwrap(try JSONSerialization.jsonObject(with: pdu) as? NSDictionary)
+    // the example carries the optional method name; we don't
+    let commands = try XCTUnwrap(actual["Commands"] as? [[String: Any]])
+    XCTAssertEqual(commands[0]["Handle"] as? Int, 49)
+    XCTAssertEqual(commands[0]["MethodID"] as? [Int], [4, 2])
+    XCTAssertEqual(commands[0]["Parameters"] as? [String: Double], ["Gain": -3.5])
+    XCTAssertEqual(actual["ProtocolVersion"] as? Int, expected["ProtocolVersion"] as? Int)
+
+    let decoded = try XCTUnwrap(try roundTrip([command], type: .ocaCmdRrq).first as? Ocp1Command)
+    XCTAssertEqual(decoded.handle, 49)
+    XCTAssertEqual(decoded.methodID, OcaMethodID("4.2"))
+  }
+
+  func testEncodeCommandWithoutParameters() throws {
+    let command = Ocp1Command(handle: 1, targetONo: 1, methodID: OcaMethodID("1.1"))
+    let pdu = try OcaControlProtocol.ocp2.encodePdu([command], type: .ocaCmd)
+    XCTAssertFalse(String(decoding: pdu, as: UTF8.self).contains("Parameters"))
+    XCTAssertTrue(String(decoding: pdu, as: UTF8.self).contains("CommandNRs"))
+    XCTAssertEqual(try roundTrip([command], type: .ocaCmd).count, 1)
+  }
+
+  func testOcp1ParametersCannotBeFramedAsOcp2() {
+    let command = Ocp1Command(
+      handle: 1,
+      targetONo: 1,
+      methodID: OcaMethodID("4.2"),
+      parameters: Ocp1Parameters(parameterCount: 1, parameterData: Data([0, 0, 0, 0]))
+    )
+    XCTAssertThrowsError(try OcaControlProtocol.ocp2.encodePdu([command], type: .ocaCmdRrq))
+  }
+
+  func testEncodeResponse() throws {
+    let response = Ocp1Response(handle: 7, statusCode: .locked)
+    let text = try String(
+      decoding: OcaControlProtocol.ocp2.encodePdu([response], type: .ocaRsp),
+      as: UTF8.self
+    )
+    XCTAssertTrue(text.contains("\"StatusCode\":\"Locked\""), text)
+    let decoded = try XCTUnwrap(try roundTrip([response], type: .ocaRsp).first as? Ocp1Response)
+    XCTAssertEqual(decoded.statusCode, .locked)
+    XCTAssertEqual(decoded.handle, 7)
+  }
+
+  func testEncodeNotifications() throws {
+    let event = OcaEvent(emitterONo: 5000, eventID: OcaPropertyChangedEventID)
+    let eventData = OcaPropertyChangedEventData<Float>(
+      propertyID: "4.1",
+      propertyValue: -3.5,
+      changeType: .currentChanged
+    )
+    let notification = try Ocp1Notification2(
+      event: event,
+      notificationType: .event,
+      data: Ocp2JSON.serialize(Ocp2Encoder().encodeValue(eventData)),
+      dataFormat: .ocp2
+    )
+    let exception = try Ocp1Notification2(
+      event: event,
+      notificationType: .exception,
+      data: Ocp1Encoder().encode(Ocp1Notification2ExceptionData(
+        exceptionType: .objectDeleted,
+        tryAgain: true,
+        exceptionData: OcaBlob()
+      ))
+    )
+    let decoded = try roundTrip([notification, exception], type: .ocaNtf2)
+    XCTAssertEqual(decoded.count, 2)
+    let decodedEvent = try XCTUnwrap(decoded[0] as? Ocp1Notification2)
+    XCTAssertEqual(decodedEvent.event, event)
+    let decodedData = try Ocp2Decoder().decodeValue(
+      OcaPropertyChangedEventData<Float>.self,
+      from: Ocp2JSON.parse(decodedEvent.data)
+    )
+    XCTAssertEqual(decodedData.propertyID, eventData.propertyID)
+    XCTAssertEqual(decodedData.propertyValue, eventData.propertyValue)
+    XCTAssertEqual(decodedData.changeType, eventData.changeType)
+    XCTAssertThrowsError(try (decoded[1] as? Ocp1Notification2)?.throwIfException()) { error in
+      guard case let Ocp1Error.exception(exception) = error else {
+        return XCTFail("unexpected error \(error)")
+      }
+      XCTAssertEqual(exception.exceptionType, .objectDeleted)
+      XCTAssertTrue(exception.tryAgain)
+    }
+  }
+
+  func testEncodeKeepAliveConvertsSecondsToMilliseconds() throws {
+    let seconds = try roundTrip([Ocp1KeepAlive1(heartBeatTime: 2)], type: .ocaKeepAlive)
+    XCTAssertEqual((seconds.first as? Ocp1KeepAlive2)?.heartBeatTime, 2000)
+    let milliseconds = try roundTrip([Ocp1KeepAlive2(heartBeatTime: 250)], type: .ocaKeepAlive)
+    XCTAssertEqual((milliseconds.first as? Ocp1KeepAlive2)?.heartBeatTime, 250)
+    XCTAssertThrowsError(try OcaControlProtocol.ocp2.encodePdu(
+      [Ocp1KeepAlive1(heartBeatTime: 1), Ocp1KeepAlive1(heartBeatTime: 1)],
+      type: .ocaKeepAlive
+    ))
+  }
+
+  func testEncodeDeviceReset() throws {
+    let reset = Ocp2DeviceReset(resetKey: Data("deafdadacafebabe".utf8))
+    let text = try String(
+      decoding: OcaControlProtocol.ocp2.encodePdu([reset], type: .ocaCmd),
+      as: UTF8.self
+    )
+    XCTAssertEqual(
+      text,
+      "{\"ProtocolVersion\":1,\"DeviceReset\":{\"ResetKey\":\"ZGVhZmRhZGFjYWZlYmFiZQ==\"}}\n"
+    )
+  }
+
+  func testEv1NotificationsCannotBeFramed() {
+    let notification = Ocp1Notification1(
+      targetONo: 1,
+      methodID: OcaMethodID("1.1"),
+      parameters: Ocp1NtfParams(
+        parameterCount: 2,
+        context: OcaBlob(),
+        eventData: Ocp1EventData(
+          event: OcaEvent(emitterONo: 1, eventID: OcaEventID("1.1")),
+          eventParameters: Data()
+        )
+      )
+    )
+    XCTAssertThrowsError(try OcaControlProtocol.ocp2.encodePdu([notification], type: .ocaNtf1))
+  }
+
+  func testBatchingAssemblesOneArray() throws {
+    let format = OcaControlProtocol.ocp2
+    let commands = (1...3).map { Ocp1Command(
+      handle: OcaUint32($0),
+      targetONo: 1,
+      methodID: OcaMethodID("1.1")
+    ) }
+    let encoded = try commands.map { try format.encodeMessage($0, type: .ocaCmdRrq) }
+    let pdu = try format.assemblePdu(type: .ocaCmdRrq, encodedMessages: encoded)
+    XCTAssertGreaterThanOrEqual(
+      format.pduOverhead(messageCount: 3) + encoded.reduce(0) { $0 + $1.count },
+      pdu.count
+    )
+    let (type, decoded) = try format.decodePdu(Data(pdu))
+    XCTAssertEqual(type, .ocaCmdRrq)
+    XCTAssertEqual(decoded.compactMap { ($0 as? Ocp1Command)?.handle }, [1, 2, 3])
+  }
+
+  // MARK: reader
+
+  private final class Feed {
+    var chunks: [Data]
+    init(_ chunks: [Data]) {
+      self.chunks = chunks
+    }
+
+    func read(_ count: Int, awaitingAllRead: Bool) async throws -> Data {
+      guard !awaitingAllRead else {
+        XCTFail("OCP.2 must not use exact-length reads")
+        return Data()
+      }
+      guard !chunks.isEmpty else { return Data() }
+      var chunk = chunks.removeFirst()
+      if chunk.count > count {
+        chunks.insert(chunk.dropFirst(count), at: 0)
+        chunk = chunk.prefix(count)
+      }
+      return chunk
+    }
+  }
+
+  private func readAll(
+    _ chunks: [String],
+    isMessageOriented: Bool = false,
+    maximumPduSize: Int = 1024
+  ) async throws -> [String] {
+    let reader = OcaControlProtocol.ocp2.makeReader(
+      isMessageOriented: isMessageOriented,
+      maximumPduSize: maximumPduSize
+    )
+    let feed = Feed(chunks.map { Data($0.utf8) })
+    var pdus = [String]()
+    while true {
+      do {
+        let pdu = try await reader.nextPdu(read: feed.read)
+        pdus.append(String(decoding: pdu, as: UTF8.self))
+      } catch Ocp1Error.notConnected {
+        return pdus
+      }
+    }
+  }
+
+  func testReaderSplitsAndJoinsLines() async throws {
+    let whole = try await readAll(["{\"a\":1}\n{\"b\":2}\n"])
+    XCTAssertEqual(whole, ["{\"a\":1}", "{\"b\":2}"])
+    let split = try await readAll(["{\"a\"", ":1}\n{\"b", "\":2}\n"])
+    XCTAssertEqual(split, ["{\"a\":1}", "{\"b\":2}"])
+    let crlf = try await readAll(["{\"a\":1}\r\n\n{\"b\":2}\n"])
+    XCTAssertEqual(crlf, ["{\"a\":1}", "{\"b\":2}"])
+    // an unterminated trailing line is not a PDU
+    let unterminated = try await readAll(["{\"a\":1}\n{\"b\""])
+    XCTAssertEqual(unterminated, ["{\"a\":1}"])
+  }
+
+  func testReaderEnforcesMaximumPduSize() async {
+    do {
+      _ = try await readAll([String(repeating: "x", count: 2048)], maximumPduSize: 1024)
+      XCTFail("expected an error")
+    } catch {
+      XCTAssertEqual(error as? Ocp1Error, .invalidPduSize)
+    }
+  }
+
+  func testReaderEnforcesMaximumPduSizeWithinOneRead() async {
+    // a transport may deliver a whole frame at once: the cap still applies
+    let big = String(repeating: "x", count: 2048) + "\n"
+    for messageOriented in [false, true] {
+      do {
+        _ = try await readAll([big], isMessageOriented: messageOriented, maximumPduSize: 1024)
+        XCTFail("expected an error (messageOriented: \(messageOriented))")
+      } catch {
+        XCTAssertEqual(error as? Ocp1Error, .invalidPduSize)
+      }
+    }
+    // several small PDUs in one large read are fine
+    let many = String(repeating: "{\"a\":1}\n", count: 500)
+    let pdus = try? await readAll([many], maximumPduSize: 1024)
+    XCTAssertEqual(pdus?.count, 500)
+  }
+
+  func testReaderMessageOrientedMode() async throws {
+    let pdus = try await readAll(
+      ["{\"a\":1}\n", "{\"b\":2}\r\n", "{\"c\":3}"],
+      isMessageOriented: true
+    )
+    XCTAssertEqual(pdus, ["{\"a\":1}", "{\"b\":2}", "{\"c\":3}"])
+  }
+}
+#endif

--- a/Tests/SwiftOCATests/Ocp2NamingOracleTests.swift
+++ b/Tests/SwiftOCATests/Ocp2NamingOracleTests.swift
@@ -117,6 +117,7 @@ final class Ocp2NamingOracleTests: XCTestCase {
         guard let wireName = property._ocp2WireName(object),
               let derived = property._ocp2ResponseNames(object)
         else { continue }
+        let setName = property._ocp2SetName(object) ?? wireName
 
         // the accessor lives on the class at the property's definition level
         var definingClass = classID
@@ -131,7 +132,7 @@ final class Ocp2NamingOracleTests: XCTestCase {
         let setter = lookup(property.setMethodID)
         for (method, expected, sent) in [
           (getter, getter?.outputs, derived),
-          (setter, setter?.inputs, [wireName]),
+          (setter, setter?.inputs, [setName]),
         ] {
           guard let method, let expected, !expected.isEmpty else { continue }
           checked.insert("\(definingClass)/\(method.methodID)")

--- a/Tests/SwiftOCATests/Ocp2NamingOracleTests.swift
+++ b/Tests/SwiftOCATests/Ocp2NamingOracleTests.swift
@@ -26,7 +26,7 @@ import XCTest
 /// alone is not a deviation: SwiftOCA upper-cases the first letter on send and
 /// `Ocp2Naming.matches` folds case on receipt, and the model itself spells 32 of its
 /// parameter names both ways (`Gain`/`gain`, `Label`/`label`). What is left is the
-/// names no derivation recovers, which need an `ocp2Name:` on the property wrapper.
+/// names no derivation recovers, which need an `ocp2GetName:` on the property wrapper.
 ///
 /// Informational: it prints every deviation and fails only if the model cannot be
 /// read. Point `AES70_2_XMI` at `AES70-2-2023-231218.xmi` (or a later revision) to
@@ -114,10 +114,10 @@ final class Ocp2NamingOracleTests: XCTestCase {
               let propertyID = property.propertyIDs.first
         else { continue }
         _ = swiftName
-        guard let wireName = property._ocp2WireName(object),
+        guard let getName = property._ocp2GetName(object),
               let derived = property._ocp2ResponseNames(object)
         else { continue }
-        let setName = property._ocp2SetName(object) ?? wireName
+        let setName = property._ocp2SetName(object) ?? getName
 
         // the accessor lives on the class at the property's definition level
         var definingClass = classID

--- a/Tests/SwiftOCATests/Ocp2NamingOracleTests.swift
+++ b/Tests/SwiftOCATests/Ocp2NamingOracleTests.swift
@@ -1,0 +1,155 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if NonEmbeddedBuild
+import Foundation
+@testable @_spi(SwiftOCAPrivate) import SwiftOCA
+import XCTest
+
+/// Compares the OCP.2 accessor names SwiftOCA derives from its Swift property names
+/// against the normative AES70-2 class model (the XMI that defines AES70-2A).
+///
+/// Names are judged by the rule the wire uses, so a difference of capitalisation
+/// alone is not a deviation: SwiftOCA upper-cases the first letter on send and
+/// `Ocp2Naming.matches` folds case on receipt, and the model itself spells 32 of its
+/// parameter names both ways (`Gain`/`gain`, `Label`/`label`). What is left is the
+/// names no derivation recovers, which need an `ocp2Name:` on the property wrapper.
+///
+/// Informational: it prints every deviation and fails only if the model cannot be
+/// read. Point `AES70_2_XMI` at `AES70-2-2023-231218.xmi` (or a later revision) to
+/// run it; it is skipped otherwise.
+final class Ocp2NamingOracleTests: XCTestCase {
+  private struct Method {
+    let classID: String
+    let className: String
+    let methodID: String
+    let name: String
+    let inputs: [String]
+    let outputs: [String]
+  }
+
+  /// A minimal scrape of the Enterprise Architect XMI: operations, their element IDs
+  /// (`<style value="04m01">`) and parameter names.
+  private static func loadModel(from url: URL) throws -> [Method] {
+    let text = try String(contentsOf: url, encoding: .windowsCP1252)
+
+    func matches(_ pattern: String, in string: String, options: NSRegularExpression.Options = []) -> [[String]] {
+      let regex = try! NSRegularExpression(pattern: pattern, options: options)
+      return regex.matches(in: string, range: NSRange(string.startIndex..., in: string)).map { match in
+        (1..<match.numberOfRanges).map { Range(match.range(at: $0), in: string).map { String(string[$0]) } ?? "" }
+      }
+    }
+
+    var methodIDs = [String: String]()
+    for m in matches("<operation xmi:idref=\"([^\"]+)\"[^>]*>.*?<style value=\"([^\"]*)\"", in: text, options: [.dotMatchesLineSeparators]) {
+      let style = m[1]
+      if let styleMatch = matches("^\\s*(\\d+)m(\\d+)", in: style).first {
+        methodIDs[m[0]] = "\(Int(styleMatch[0])!).\(Int(styleMatch[1])!)"
+      }
+    }
+
+    var methods = [Method]()
+    let classes = matches(
+      "<packagedElement xmi:type=\"uml:Class\" xmi:id=\"([^\"]+)\" name=\"(Oca[A-Za-z0-9]+)\"[^>]*>(.*?)</packagedElement>",
+      in: text,
+      options: [.dotMatchesLineSeparators]
+    )
+    for cls in classes {
+      guard let classID = matches("name=\"ClassID\".*?<defaultValue[^>]*value=\"([0-9.]+)\"", in: cls[2], options: [.dotMatchesLineSeparators]).first?[0]
+      else { continue }
+      for op in matches("<ownedOperation xmi:id=\"([^\"]+)\" name=\"([^\"]+)\"[^>]*>(.*?)</ownedOperation>", in: cls[2], options: [.dotMatchesLineSeparators]) {
+        guard let methodID = methodIDs[op[0]] else { continue }
+        let params = matches("<ownedParameter [^>]*name=\"([^\"]+)\" direction=\"(in|out|return)\"", in: op[2])
+        methods.append(Method(
+          classID: classID,
+          className: cls[1],
+          methodID: methodID,
+          name: op[1],
+          inputs: params.filter { $0[1] == "in" }.map { $0[0] },
+          outputs: params.filter { $0[1] == "out" }.map { $0[0] }
+        ))
+      }
+    }
+    return methods
+  }
+
+  /// Judged by the same rule the protocol uses: `Ocp2Naming.matches` folds ASCII case
+  /// and leading underscores, so only a genuinely different name counts.
+  private static func namesMatch(_ sent: [String], _ expected: [String]) -> Bool {
+    sent.count == expected.count && zip(sent, expected).allSatisfy(Ocp2Naming.matches)
+  }
+
+  func testDerivedAccessorNamesAgainstModel() async throws {
+    guard let path = ProcessInfo.processInfo.environment["AES70_2_XMI"] else {
+      throw XCTSkip("set AES70_2_XMI to the AES70-2 XMI file to run the naming oracle")
+    }
+    let model = try Self.loadModel(from: URL(fileURLWithPath: path))
+    XCTAssertFalse(model.isEmpty, "no methods found in \(path)")
+    let byClassAndMethod = Dictionary(
+      model.map { ("\($0.classID)/\($0.methodID)", $0) },
+      uniquingKeysWith: { first, _ in first }
+    )
+
+    var deviations = Set<String>()
+    var checked = Set<String>()
+
+    for (identification, type) in await OcaClassRegistry.shared.registeredClasses {
+      let object = type.init(objectNumber: 0x0001_0000)
+      let classID = identification.classID
+      for (swiftName, keyPath) in object.allPropertyKeyPathsUncached {
+        guard let property = object[keyPath: keyPath] as? any OcaPropertySubjectRepresentable,
+              let propertyID = property.propertyIDs.first
+        else { continue }
+        _ = swiftName
+        guard let wireName = property._ocp2WireName(object),
+              let derived = property._ocp2ResponseNames(object)
+        else { continue }
+
+        // the accessor lives on the class at the property's definition level
+        var definingClass = classID
+        while definingClass.defLevel > propertyID.defLevel, let parent = definingClass.parent {
+          definingClass = parent
+        }
+        func lookup(_ methodID: OcaMethodID?) -> Method? {
+          guard let methodID else { return nil }
+          return byClassAndMethod["\(definingClass)/\(methodID)"]
+        }
+        let getter = lookup(property.getMethodID)
+        let setter = lookup(property.setMethodID)
+        for (method, expected, sent) in [
+          (getter, getter?.outputs, derived),
+          (setter, setter?.inputs, [wireName]),
+        ] {
+          guard let method, let expected, !expected.isEmpty else { continue }
+          checked.insert("\(definingClass)/\(method.methodID)")
+          if !Self.namesMatch(sent, expected) {
+            deviations.insert("\(method.className) \(method.methodID) \(method.name): sends \(sent), model says \(expected)")
+          }
+        }
+      }
+    }
+
+    print(
+      "Ocp2 naming oracle: checked \(checked.count) accessors, \(deviations.count) deviations "
+        + "(capitalisation alone is not a deviation)"
+    )
+    for deviation in deviations.sorted() {
+      print("  \(deviation)")
+    }
+  }
+}
+
+#endif

--- a/Tests/SwiftOCATests/Ocp2VectorNamingTests.swift
+++ b/Tests/SwiftOCATests/Ocp2VectorNamingTests.swift
@@ -1,0 +1,53 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#if NonEmbeddedBuild
+import Foundation
+@testable @_spi(SwiftOCAPrivate) import SwiftOCA
+import XCTest
+
+/// Each stage of naming a vector record's OCP.2 parameters, pinned separately. A
+/// vector is a generic record (`OcaVector2D<T>`) whose parameters are named after
+/// its fields, so these exercise reflection, encoding, decoding and the client
+/// wrapper's own naming in isolation.
+final class Ocp2VectorNamingTests: XCTestCase {
+  func testReflectionFindsTheVectorFields() {
+    XCTAssertEqual(Ocp2Naming.fieldNames(of: OcaVector2D<OcaMatrixCoordinate>.self), ["x", "y"])
+  }
+
+  func testEncoderFlattensTheVectorUnderItsFieldNames() throws {
+    let object = try Ocp2Encoder().encodeParameters(
+      OcaVector2D<OcaMatrixCoordinate>(x: 1, y: 2),
+      parameterNames: []
+    )
+    XCTAssertEqual(object.keys.sorted(), ["X", "Y"])
+  }
+
+  func testDecoderReadsTheFlattenedVector() throws {
+    let data = try Ocp2JSON.serialize(["X": 1, "Y": 2])
+    let value = try Ocp2Decoder().decodeParameters(OcaVector2D<OcaMatrixCoordinate>.self, from: data)
+    XCTAssertEqual(value.x, 1)
+    XCTAssertEqual(value.y, 2)
+  }
+
+  func testVectorStorageBorrowsNoPropertyName() {
+    // the storage stands in for two properties, so it must not resolve to any one
+    let matrix = OcaMatrix(objectNumber: 0x0001_0200)
+    let name = matrix.propertyName(for: OcaPropertyID("0.0"))
+    XCTAssertNil(name)
+  }
+}
+#endif

--- a/Tests/SwiftOCATests/RequestContinuationTests.swift
+++ b/Tests/SwiftOCATests/RequestContinuationTests.swift
@@ -41,7 +41,7 @@ private final class MockConnection: Ocp1Connection, @unchecked Sendable {
 
   override var heartbeatTime: Duration { .zero }
 
-  override func read(_ length: Int) async throws -> Data {
+  override func read(_ length: Int, awaitingAllRead: Bool) async throws -> Data {
     // no device on the other end: block until cancelled
     try await Task.sleep(for: .seconds(3600))
     throw Ocp1Error.notConnected

--- a/Tests/SwiftOCATests/WriteSerialisationTests.swift
+++ b/Tests/SwiftOCATests/WriteSerialisationTests.swift
@@ -46,7 +46,7 @@ private final class ChunkedWriteConnection: Ocp1Connection, @unchecked Sendable 
 
   override var heartbeatTime: Duration { .zero }
 
-  override func read(_ length: Int) async throws -> Data {
+  override func read(_ length: Int, awaitingAllRead: Bool) async throws -> Data {
     try await Task.sleep(for: .seconds(3600))
     throw Ocp1Error.notConnected
   }


### PR DESCRIPTION
## Summary

Implements AES70-4 OCP.2, the JSON control protocol, on both the controller (`SwiftOCA`) and device (`SwiftOCADevice`) sides, alongside OCP.1.

- **Wire-format seam.** `OcaControlProtocol` / `OcaWireFormat` sit beneath the existing connection and endpoint classes, so every transport backend serves either protocol; OCP.1 framing is unchanged (its suite was green before any OCP.2 code landed).
- **Marshaling.** `Ocp2Encoder` / `Ocp2Decoder` implement AES70-4 clause 8 (base64 blobs, `[key, value]` pairs for maps, array-form class and element IDs with nonstandard authorities, enums as numbers with names accepted, `Infinity`/`NaN` spellings).
- **Framing.** Newline-delimited JSON PDUs with the standard's envelope validation. All 16 example PDUs from the standard decode; its malformed examples X01–X03 are rejected.
- **Transports.** Local loopback, TCP (FlyingSocks, Network framework and CFSocket clients), and WebSocket with `AES70-OCP.2` subprotocol negotiation, text frames, and the 1003/1007 close codes. Discovery browses and advertises `_ocajson._tcp` / `_ocajsonws._tcp` with the `path` TXT record.
- **Naming.** Parameter names derive from Swift identifiers: property names for accessors (`ocp2Name:` overrides on the wrappers, applied to `OcaDeviceManager`), `CodingKeys` for parameter records, and explicit `name:` / `parameterNames:` at 108 hand-written scalar sites. Receiving is lenient (case-insensitive, positional for a single parameter). `Ocp2NamingOracleTests` reports deviations from the AES70-2 UML model when `AES70_2_XMI` is set.
- **Device dispatch** needs no per-class changes: `OcaDevice.handleCommand` binds a task-local response context that `encodeResponse` reads. Only EV2 subscriptions are accepted over OCP.2.
- **JSON export.** The controller-side `jsonObject` / `getJsonValue` is now the OCP.2 representation, so only it and the device-side preset serialisation remain.
- Also fixes `OcaArray2D`'s JSON row layout and `OcaMatrix.GetSize`'s parameter count, adds `OcaStatus.busy`, and makes the remaining enumerations `CaseIterable`.

Not yet wired up: UDP and TLS-PSK for OCP.2, acting on `DeviceReset`. Linux was not built (the IORing `readSome` override is unexercised). See `Documentation/OCP2.md`.

## Test plan

- [x] `swift test`: 308 tests, 0 failures, 1 skipped (the oracle without the XMI)
- [x] `Ocp2CoderTests` / `Ocp2MessageTests`: marshaling round trips, the standard's example and malformed PDUs, reader edge cases
- [x] `Ocp2LoopbackTests`: get/set, bounded values, `FindActionObjectsByRole`, EV2 subscription and notification, locking, EV1 refusal, JSON export shape
- [x] `Ocp2TCPTests` / `Ocp2WebSocketTests`: three client backends, batching, notifications, a hand-written JSON session, keep-alive expiry, OCP.1 client rejected by an OCP.2 endpoint, subprotocol negotiation, close codes
- [ ] Interop against a third-party OCP.2 implementation
- [ ] Linux build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6qkqY6zbFM9dP5DqJC7yt
