### PR TITLE
OcaMatrix fixes and tests; one NotImplemented; ClearResetCause; TXT record order

### DIFF
--- a/Sources/AndroidNetworkServiceDiscovery/AndroidNsd.swift
+++ b/Sources/AndroidNetworkServiceDiscovery/AndroidNsd.swift
@@ -29,7 +29,7 @@ import SwiftJava
 /// host application hands a `Context` over once at startup.
 ///
 /// Call this before constructing an `OcaConnectionBroker`; browsing throws
-/// `Ocp1Error.notImplemented` until it has been called.
+/// `Ocp1Error.serviceBrowsingUnavailable` until it has been called.
 ///
 /// Pass the *application* context, not an Activity: Android may destroy and
 /// recreate the Activity while the broker outlives it, and holding the Activity

--- a/Sources/SwiftOCA/OCA/Browsing/ConnectionBroker.swift
+++ b/Sources/SwiftOCA/OCA/Browsing/ConnectionBroker.swift
@@ -285,7 +285,7 @@ public actor OcaConnectionBroker {
       #elseif os(Android)
       browser = try OcaNsdServiceBrowser(serviceType: serviceType)
       #else
-      throw Ocp1Error.notImplemented
+      throw Ocp1Error.serviceBrowsingUnavailable
       #endif
       browserMonitor = Task { @Sendable [weak broker, browser] in
         try await browser.start()

--- a/Sources/SwiftOCA/OCA/Browsing/DNSServiceBrowser.swift
+++ b/Sources/SwiftOCA/OCA/Browsing/DNSServiceBrowser.swift
@@ -383,7 +383,7 @@ public final class OcaDNSServiceBrowser: OcaNetworkAdvertisingServiceBrowser, @u
 
     guard error == DNSServiceErrorType(kDNSServiceErr_NoError), let sdRef else {
       Unmanaged<BrowseContext>.fromOpaque(context).release()
-      throw Ocp1Error.notImplemented
+      throw Ocp1Error.serviceBrowsingUnavailable
     }
 
     let source = DispatchSource.makeReadSource(

--- a/Sources/SwiftOCA/OCA/Browsing/NsdServiceBrowser.swift
+++ b/Sources/SwiftOCA/OCA/Browsing/NsdServiceBrowser.swift
@@ -86,7 +86,7 @@ public final class OcaNsdServiceBrowser: OcaNetworkAdvertisingServiceBrowser, @u
 
   public init(serviceType: OcaNetworkAdvertisingServiceType) throws {
     guard AndroidNsd.isConfigured else {
-      throw Ocp1Error.notImplemented
+      throw Ocp1Error.serviceBrowsingUnavailable
     }
 
     _serviceType = serviceType

--- a/Sources/SwiftOCA/OCC/ControlClasses/Managers/DeviceManager.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Managers/DeviceManager.swift
@@ -189,7 +189,7 @@ open class OcaDeviceManager: OcaManager, @unchecked Sendable {
 
   // 3.16
   public func clearResetCause() async throws {
-    throw Ocp1Error.notImplemented
+    try await sendCommandRrq(methodID: OcaMethodID("3.16"))
   }
 
   @OcaProperty(

--- a/Sources/SwiftOCA/OCF/Errors.swift
+++ b/Sources/SwiftOCA/OCF/Errors.swift
@@ -55,7 +55,6 @@ public enum Ocp1Error: Error, Equatable {
   case noInitialValue
   case noMatchingTypeForClass
   case notConnected
-  case notImplemented
   case notSubscribedToEvent
   case objectAlreadyContainedByBlock(OcaONo)
   case objectClassIsNotSubclass
@@ -72,6 +71,8 @@ public enum Ocp1Error: Error, Equatable {
   case responseTimeout
   case retryOperation
   case serviceResolutionFailed
+  /// service browsing is not available on this platform, or failed to start
+  case serviceBrowsingUnavailable
   case unknownDataset
   case unknownDatasetMimeType
   case unknownDatasetVersion

--- a/Sources/SwiftOCADevice/OCA/DeviceEndpointRegistrar.swift
+++ b/Sources/SwiftOCADevice/OCA/DeviceEndpointRegistrar.swift
@@ -36,12 +36,14 @@ public protocol OcaBonjourRegistrableDeviceEndpoint: OcaDeviceEndpoint {
 }
 
 extension OcaDeviceManager {
-  var txtRecords: [String: String] {
+  /// In registration order: AES70 requires the record to begin with `txtvers` and
+  /// `protovers`, in that order.
+  var txtRecords: [(String, String)] {
     [
-      "txtvers": "1",
-      "protovers": "\(version)",
-      "modelGUID": "\(modelGUID)",
-      "serialNumber": "\(serialNumber)",
+      ("txtvers", "1"),
+      ("protovers", "\(version)"),
+      ("modelGUID", "\(modelGUID)"),
+      ("serialNumber", "\(serialNumber)"),
     ]
   }
 }
@@ -130,7 +132,7 @@ fileprivate actor DNSServiceRegistration {
     domain: String? = nil,
     host: String? = nil,
     port: UInt16, // in host byte order, unlike DNSServiceRegister() API
-    txtRecord: [String: String] = [:]
+    txtRecord: [(String, String)] = []
   ) async throws {
     self.flags = flags
     self.name = name

--- a/Sources/SwiftOCADevice/OCC/Adaptations/Aes67/Aes67ControlClasses.swift
+++ b/Sources/SwiftOCADevice/OCC/Adaptations/Aes67/Aes67ControlClasses.swift
@@ -48,7 +48,7 @@ open class Aes67OcaMediaTransportApplication: OcaMediaTransportApplication {
   }
 
   public required init(from decoder: Decoder) throws {
-    throw Ocp1Error.notImplemented
+    throw Ocp1Error.status(.notImplemented)
   }
 
   open func getEndpointDelayConstraints(
@@ -142,7 +142,7 @@ open class Aes67OcaMediaTransportSessionAgent: OcaMediaTransportSessionAgent {
   }
 
   public required init(from decoder: Decoder) throws {
-    throw Ocp1Error.notImplemented
+    throw Ocp1Error.status(.notImplemented)
   }
 
   /// Default: the session's adaptation data, which AES70-21 defines as the SIP record.

--- a/Sources/SwiftOCADevice/OCC/Adaptations/Dante/DanteOcaMediaTransportApplication.swift
+++ b/Sources/SwiftOCADevice/OCC/Adaptations/Dante/DanteOcaMediaTransportApplication.swift
@@ -59,7 +59,7 @@ open class DanteOcaMediaTransportApplication: OcaMediaTransportApplication {
   }
 
   public required init(from decoder: Decoder) throws {
-    throw Ocp1Error.notImplemented
+    throw Ocp1Error.status(.notImplemented)
   }
 
   public func channelEndpoint(_ id: OcaID16) throws -> OcaChannelEndpoint {

--- a/Sources/SwiftOCADevice/OCC/Adaptations/Milan/MilanOcaMediaTransportSessionAgent.swift
+++ b/Sources/SwiftOCADevice/OCC/Adaptations/Milan/MilanOcaMediaTransportSessionAgent.swift
@@ -40,7 +40,7 @@ open class MilanOcaMediaTransportSessionAgent: OcaMediaTransportSessionAgent {
   }
 
   public required init(from decoder: Decoder) throws {
-    throw Ocp1Error.notImplemented
+    throw Ocp1Error.status(.notImplemented)
   }
 
   /// A session in the shape of AES70-22 Tables 24 and 25.

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Agents/Group.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Agents/Group.swift
@@ -195,7 +195,7 @@ open class _OcaPeerToPeerGroup<Member: OcaGroupPeerToPeerMember>: OcaGroup<Membe
   }
 
   public required init(from decoder: Decoder) throws {
-    throw Ocp1Error.notImplemented
+    throw Ocp1Error.status(.notImplemented)
   }
 
   public required init(
@@ -253,7 +253,7 @@ open class _OcaGroupControllerGroup<Member: OcaRoot>: OcaGroup<Member> {
   }
 
   public required init(from decoder: Decoder) throws {
-    throw Ocp1Error.notImplemented
+    throw Ocp1Error.status(.notImplemented)
   }
 
   public required init(
@@ -287,7 +287,7 @@ open class _OcaGroupControllerGroup<Member: OcaRoot>: OcaGroup<Member> {
     }
 
     public required init(from decoder: Decoder) throws {
-      throw Ocp1Error.notImplemented
+      throw Ocp1Error.status(.notImplemented)
     }
 
     public required init(

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Dataset/Dataset.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Dataset/Dataset.swift
@@ -200,18 +200,18 @@ Sendable {
     lockState: OcaLockState,
     controller: OcaController?
   ) async throws -> (OcaUint64, OcaIOSessionHandle) {
-    throw Ocp1Error.notImplemented
+    throw Ocp1Error.status(.notImplemented)
   }
 
   open func openWrite(
     lockState: OcaLockState,
     controller: OcaController?
   ) async throws -> (OcaUint64, OcaIOSessionHandle) {
-    throw Ocp1Error.notImplemented
+    throw Ocp1Error.status(.notImplemented)
   }
 
   open func close(handle: OcaIOSessionHandle, controller: OcaController?) async throws {
-    throw Ocp1Error.notImplemented
+    throw Ocp1Error.status(.notImplemented)
   }
 
   open func read(
@@ -220,7 +220,7 @@ Sendable {
     partSize: OcaUint64,
     controller: OcaController?
   ) async throws -> (OcaBoolean, OcaLongBlob) {
-    throw Ocp1Error.notImplemented
+    throw Ocp1Error.status(.notImplemented)
   }
 
   open func write(
@@ -229,15 +229,15 @@ Sendable {
     part: OcaLongBlob,
     controller: OcaController?
   ) async throws {
-    throw Ocp1Error.notImplemented
+    throw Ocp1Error.status(.notImplemented)
   }
 
   open func clear(handle: OcaIOSessionHandle, controller: OcaController?) async throws {
-    throw Ocp1Error.notImplemented
+    throw Ocp1Error.status(.notImplemented)
   }
 
   open func getDataSetSizes() async throws -> (OcaUint64, OcaUint64) {
-    throw Ocp1Error.notImplemented
+    throw Ocp1Error.status(.notImplemented)
   }
 
   override open func handleCommand(
@@ -341,7 +341,7 @@ extension OcaDataset {
     try await write(handle: handle, position: 0, part: blob, controller: controller)
     try await close(handle: handle, controller: controller)
     #else
-    throw Ocp1Error.notImplemented
+    throw Ocp1Error.status(.notImplemented)
     #endif
   }
 }

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Managers/DeviceManager.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Managers/DeviceManager.swift
@@ -207,6 +207,11 @@ open class OcaDeviceManager: OcaManager {
       try await ensureWritable(by: controller, command: command)
       try await setResetKey(key: Data(parameters.keyBytes), address: parameters.address)
       return Ocp1Response()
+    case OcaMethodID("3.16"):
+      try decodeNullCommand(command)
+      try await ensureWritable(by: controller, command: command)
+      resetCause = .powerOn
+      return Ocp1Response()
     #if NonEmbeddedBuild
     case OcaMethodID("3.27"):
       let oNo: OcaONo = try decodeCommand(command)

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Managers/DeviceManager.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Managers/DeviceManager.swift
@@ -167,7 +167,7 @@ open class OcaDeviceManager: OcaManager {
     address: OcaNetworkAddress
   ) async throws {
     // must be implemented by subclass
-    throw Ocp1Error.notImplemented
+    throw Ocp1Error.status(.notImplemented)
   }
 
   #if NonEmbeddedBuild

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Root.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Root.swift
@@ -167,7 +167,7 @@ open class OcaRoot: CustomStringConvertible, Codable, Sendable, _OcaObjectKeyPat
   }
 
   public required nonisolated init(from decoder: Decoder) throws {
-    throw Ocp1Error.notImplemented
+    throw Ocp1Error.status(.notImplemented)
   }
 
   open nonisolated var description: String {

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/BlocksAndMatrices/Block.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/BlocksAndMatrices/Block.swift
@@ -612,7 +612,7 @@ open class OcaBlock<ActionObject: OcaRoot>: OcaWorker, OcaBlockContainer {
     type: OcaMimeType,
     typeComparisonType: OcaStringComparisonType
   ) async throws -> [OcaDataset] {
-    throw Ocp1Error.notImplemented
+    throw Ocp1Error.status(.notImplemented)
   }
   #endif
 

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/BlocksAndMatrices/Matrix.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/BlocksAndMatrices/Matrix.swift
@@ -197,7 +197,11 @@ open class OcaMatrix<Member: OcaRoot>: OcaWorker {
       guard controller.id == lockholder else {
         throw Ocp1Error.status(.locked)
       }
-      lockStatePriorToSetCurrentXY = lockState
+      // a repeated SetCurrentXY must not replace the state the first one saved with
+      // its own temporary lock, or the proxy call that restores it leaves us locked
+      if lockStatePriorToSetCurrentXY == nil {
+        lockStatePriorToSetCurrentXY = lockState
+      }
       lockState = .lockedNoReadWrite(controller.id)
     }
     proxy.lockState = lockState

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/BlocksAndMatrices/Matrix.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/BlocksAndMatrices/Matrix.swift
@@ -130,22 +130,23 @@ open class OcaMatrix<Member: OcaRoot>: OcaWorker {
 
         do {
           response = try await object.handleCommand(command, from: controller)
-          if lastStatus != .ok {
-            lastStatus = .partiallySucceeded
-          } else {
-            lastStatus = .ok
-          }
+          record(.ok)
         } catch let Ocp1Error.status(status) {
-          if lastStatus == .ok {
-            lastStatus = .partiallySucceeded
-          } else if lastStatus != status {
-            lastStatus = .processingFailed
-          } else {
-            lastStatus = status
-          }
+          record(status)
         } catch {
-          lastStatus = .processingFailed // shouldn't happen
+          record(.processingFailed) // shouldn't happen
         }
+      }
+
+      /// The first member's status stands until another disagrees: then success mixed
+      /// with failure is partial success, and differing failures a processing failure.
+      private func record(_ status: OcaStatus) {
+        guard let lastStatus else {
+          self.lastStatus = status
+          return
+        }
+        guard lastStatus != status else { return }
+        self.lastStatus = lastStatus == .ok || status == .ok ? .partiallySucceeded : .processingFailed
       }
 
       func getResponse() throws -> Ocp1Response {

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/BlocksAndMatrices/Matrix.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/BlocksAndMatrices/Matrix.swift
@@ -61,7 +61,7 @@ open class OcaMatrix<Member: OcaRoot>: OcaWorker {
   }
 
   public required init(from decoder: Decoder) throws {
-    throw Ocp1Error.notImplemented
+    throw Ocp1Error.status(.notImplemented)
   }
 
   public required init(
@@ -94,7 +94,7 @@ open class OcaMatrix<Member: OcaRoot>: OcaWorker {
     }
 
     public required init(from decoder: Decoder) throws {
-      throw Ocp1Error.notImplemented
+      throw Ocp1Error.status(.notImplemented)
     }
 
     public required init(

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/BlocksAndMatrices/Matrix.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/BlocksAndMatrices/Matrix.swift
@@ -291,33 +291,59 @@ open class OcaMatrix<Member: OcaRoot>: OcaWorker {
     try? await notifySubscribers(members: members, changeType: .itemChanged)
   }
 
-  func withCurrentObject(_ body: @Sendable (_ object: Member) async throws -> ()) async rethrows {
-    if currentXY.x == OcaMatrixWildcardCoordinate && currentXY
-      .y == OcaMatrixWildcardCoordinate
-    {
-      for object in members.items {
-        if let object {
-          try await body(object)
-        }
-      }
+  /// The members of the current area — the whole matrix, a row, a column or a single
+  /// cell, according to the wildcards in `currentXY`. Empty cells are skipped.
+  private func currentMembers() -> [Member] {
+    let members = members
+    if currentXY.x == OcaMatrixWildcardCoordinate, currentXY.y == OcaMatrixWildcardCoordinate {
+      return members.items.compactMap { $0 }
     } else if currentXY.x == OcaMatrixWildcardCoordinate {
-      for x in 0..<members.nX {
-        if let object = members[x, Int(currentXY.y)] {
-          try await body(object)
-        }
-      }
+      return (0..<members.nX).compactMap { members[$0, Int(currentXY.y)] }
     } else if currentXY.y == OcaMatrixWildcardCoordinate {
-      for y in 0..<members.nY {
-        if let object = members[Int(currentXY.x), y] {
-          try await body(object)
-        }
-      }
+      return (0..<members.nY).compactMap { members[Int(currentXY.x), $0] }
     } else {
       precondition(currentXY.x < members.nX)
       precondition(currentXY.y < members.nY)
+      return [members[Int(currentXY.x), Int(currentXY.y)]].compactMap { $0 }
+    }
+  }
 
-      if let object = members[Int(currentXY.x), Int(currentXY.y)] {
-        try await body(object)
+  func withCurrentObject(_ body: @Sendable (_ object: Member) async throws -> ()) async rethrows {
+    for object in currentMembers() {
+      try await body(object)
+    }
+  }
+
+  /// SetCurrentXY's work, shared with SetCurrentXYLock: validate and set the current
+  /// area, then lock the matrix and its proxy until the next proxy call.
+  private func setCurrentXY(_ command: Ocp1Command, from controller: any OcaController) async throws {
+    let coordinates: OcaVector2D<OcaMatrixCoordinate> = try decodeCommand(command)
+    try await ensureWritable(by: controller, command: command)
+    let members = members
+    guard coordinates.x < members.nX || coordinates.x == OcaMatrixWildcardCoordinate,
+          coordinates.y < members.nY || coordinates.y == OcaMatrixWildcardCoordinate
+    else {
+      throw Ocp1Error.status(.parameterOutOfRange)
+    }
+    currentXY = coordinates
+    try lockSelfAndProxy(controller: controller)
+  }
+
+  /// Whether `lockNoReadWrite` would succeed for `member`, checked up front so that
+  /// SetCurrentXYLock can fail before locking anything.
+  private static func ensureLockable(_ member: Member, by controller: any OcaController) throws {
+    guard controller.flags.contains(.supportsLocking) else {
+      throw Ocp1Error.status(.permissionDenied)
+    }
+    guard member.lockable else {
+      throw Ocp1Error.status(.notImplemented)
+    }
+    switch member.lockState {
+    case .unlocked:
+      break
+    case let .lockedNoWrite(lockholder), let .lockedNoReadWrite(lockholder):
+      guard controller.id == lockholder else {
+        throw Ocp1Error.status(.locked)
       }
     }
   }
@@ -398,26 +424,26 @@ open class OcaMatrix<Member: OcaRoot>: OcaWorker {
       try await ensureReadable(by: controller, command: command)
       return try encodeResponse(proxy.objectNumber)
     case OcaMethodID("3.2"):
-      let coordinates: OcaVector2D<OcaMatrixCoordinate> = try decodeCommand(command)
-      try await ensureWritable(by: controller, command: command)
-      let members = members
-      guard coordinates.x < members.nX || coordinates.x == OcaMatrixWildcardCoordinate,
-            coordinates.y < members.nY || coordinates.y == OcaMatrixWildcardCoordinate
-      else {
-        throw Ocp1Error.status(.parameterOutOfRange)
-      }
-      currentXY = coordinates
-      try lockSelfAndProxy(controller: controller)
-      // lock the new current member as LockCurrent (3.15) does — not by falling
-      // through, since 3.15 begins by requiring an empty parameter list and this
-      // command carries the two coordinates
-      try await withCurrentObject { try await $0.lockNoReadWrite(controller: controller) }
+      // SetCurrentXY locks the matrix and its proxy, but not the members (AES70-2)
+      try await setCurrentXY(command, from: controller)
     case OcaMethodID("3.15"):
-      try decodeNullCommand(command)
-      try await withCurrentObject { try await $0.lockNoReadWrite(controller: controller) }
+      // SetCurrentXYLock also locks every member of the new current area, failing
+      // without locking any of them if one cannot be locked (AES70-2)
+      try await setCurrentXY(command, from: controller)
+      let members = currentMembers()
+      for member in members {
+        try Self.ensureLockable(member, by: controller)
+      }
+      for member in members {
+        try await member.lockNoReadWrite(controller: controller)
+      }
     case OcaMethodID("3.16"):
+      // UnlockCurrent must not fail on a member that is already unlocked (AES70-2)
       try decodeNullCommand(command)
-      try await withCurrentObject { try await $0.unlock(controller: controller) }
+      for member in currentMembers() {
+        if case .unlocked = member.lockState { continue }
+        try await member.unlock(controller: controller)
+      }
     default:
       return try await super.handleCommand(command, from: controller)
     }

--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Sensors/BasicSensors.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/Sensors/BasicSensors.swift
@@ -43,7 +43,7 @@ open class OcaGenericBasicSensor<T: Codable & Comparable & Sendable>: OcaSensor 
   }
 
   public required init(from decoder: Decoder) throws {
-    throw Ocp1Error.notImplemented
+    throw Ocp1Error.status(.notImplemented)
   }
 
   public required init(
@@ -93,7 +93,7 @@ open class OcaBooleanSensor: OcaSensor {
   }
 
   public required init(from decoder: Decoder) throws {
-    throw Ocp1Error.notImplemented
+    throw Ocp1Error.status(.notImplemented)
   }
 
   public required init(

--- a/Sources/SwiftOCADevice/OCC/PropertyTypes/BoundedDeviceProperty.swift
+++ b/Sources/SwiftOCADevice/OCC/PropertyTypes/BoundedDeviceProperty.swift
@@ -205,11 +205,14 @@ public struct OcaBoundedDeviceProperty<
     get {
       object[keyPath: storageKeyPath].storage.get()
     }
+    // NOTE: as for OcaDeviceProperty, the value is stored at once so that a read
+    // straight after the set sees it; only the notification needs the Task.
     set {
       let property = object[keyPath: storageKeyPath]
+      property.storage.subject.send(newValue)
 
       Task {
-        await property.setAndNotifySubscribers(object: object, newValue)
+        try? await property.notifySubscribers(object: object, newValue.value)
       }
     }
   }

--- a/Sources/SwiftOCADevice/OCC/PropertyTypes/VectorDeviceProperty.swift
+++ b/Sources/SwiftOCADevice/OCC/PropertyTypes/VectorDeviceProperty.swift
@@ -193,11 +193,14 @@ public struct OcaVectorDeviceProperty<
     get {
       object[keyPath: storageKeyPath].storage.get()
     }
+    // NOTE: as for OcaDeviceProperty, the value is stored at once so that a read
+    // straight after the set sees it; only the notification needs the Task.
     set {
       let property = object[keyPath: storageKeyPath]
+      property.storage.subject.send(newValue)
 
       Task {
-        await property.setAndNotifySubscribers(object: object, newValue)
+        try? await property.notifySubscribers(object: object, newValue)
       }
     }
   }

--- a/Tests/SwiftOCADeviceTests/DeviceManagerTests.swift
+++ b/Tests/SwiftOCADeviceTests/DeviceManagerTests.swift
@@ -1,0 +1,33 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+@testable @_spi(SwiftOCAPrivate) import SwiftOCA
+@testable @_spi(SwiftOCAPrivate) import SwiftOCADevice
+@preconcurrency import XCTest
+
+final class DeviceManagerTests: XCTestCase {
+  @OcaDevice
+  func testClearResetCauseRestoresPowerOn() async throws {
+    let harness = try await CM4TestHarness.make()
+    defer { harness.endpointTask.cancel() }
+
+    let deviceManager = await harness.device.deviceManager!
+    deviceManager.resetCause = .externalRequest
+
+    try await harness.connection.deviceManager.clearResetCause()
+    XCTAssertEqual(deviceManager.resetCause, .powerOn)
+  }
+}

--- a/Tests/SwiftOCADeviceTests/DeviceManagerTests.swift
+++ b/Tests/SwiftOCADeviceTests/DeviceManagerTests.swift
@@ -30,4 +30,18 @@ final class DeviceManagerTests: XCTestCase {
     try await harness.connection.deviceManager.clearResetCause()
     XCTAssertEqual(deviceManager.resetCause, .powerOn)
   }
+
+  /// AES70-4 requires NotImplemented of SetResetKey on a device without the reset
+  /// mechanism, which is what the base OcaDeviceManager is.
+  @OcaDevice
+  func testSetResetKeyAnswersNotImplementedWithoutAResetMechanism() async throws {
+    let harness = try await CM4TestHarness.make()
+    defer { harness.endpointTask.cancel() }
+
+    let key: SwiftOCA.OcaDeviceManager.ResetKey = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+    await XCTAssertThrowsStatus(.notImplemented) {
+      try await harness.connection.deviceManager
+        .setResetKey(key: key, address: OcaNetworkAddress())
+    }
+  }
 }

--- a/Tests/SwiftOCADeviceTests/MatrixTests.swift
+++ b/Tests/SwiftOCADeviceTests/MatrixTests.swift
@@ -1,0 +1,230 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+@testable @_spi(SwiftOCAPrivate) import SwiftOCA
+@testable @_spi(SwiftOCAPrivate) import SwiftOCADevice
+@preconcurrency import XCTest
+
+/// OcaMatrix over the local transport: its members, the current area, the proxy that
+/// forwards to it, and the locking AES70-2 specifies for SetCurrentXY (3.2),
+/// SetCurrentXYLock (3.15) and UnlockCurrent (3.16).
+final class MatrixTests: XCTestCase {
+  private static let matrixONo: OcaONo = 0x0001_0300
+  private static let columns: OcaUint16 = 3 // X
+  private static let rows: OcaUint16 = 2 // Y
+  private static let wildcard: OcaMatrixCoordinate = 0xFFFF
+
+  private struct Harness {
+    let connection: OcaLocalConnection
+    let endpointTask: Task<(), Never>
+    let deviceMatrix: SwiftOCADevice.OcaMatrix<SwiftOCADevice.OcaBooleanActuator>
+    /// indexed `[x][y]`
+    let actuators: [[SwiftOCADevice.OcaBooleanActuator]]
+    let matrix: SwiftOCA.OcaMatrix
+
+    func tearDown() async {
+      try? await connection.disconnect()
+      endpointTask.cancel()
+    }
+  }
+
+  private func makeHarness() async throws -> Harness {
+    let device = OcaDevice()
+    try await device.initializeDefaultObjects()
+    let deviceMatrix = try await SwiftOCADevice.OcaMatrix<SwiftOCADevice.OcaBooleanActuator>(
+      rows: Self.rows,
+      columns: Self.columns,
+      objectNumber: Self.matrixONo,
+      deviceDelegate: device,
+      addToRootBlock: true
+    )
+    var actuators = [[SwiftOCADevice.OcaBooleanActuator]]()
+    for x in 0..<Self.columns {
+      var column = [SwiftOCADevice.OcaBooleanActuator]()
+      for y in 0..<Self.rows {
+        let actuator = try await SwiftOCADevice.OcaBooleanActuator(
+          role: "Actuator \(x),\(y)",
+          deviceDelegate: device,
+          addToRootBlock: false
+        )
+        try await deviceMatrix.add(member: actuator, at: OcaVector2D(x: x, y: y))
+        column.append(actuator)
+      }
+      actuators.append(column)
+    }
+    let endpoint = try await OcaLocalDeviceEndpoint(device: device)
+    let endpointTask = Task { do { try await endpoint.run() } catch {} }
+    let connection = await OcaLocalConnection(endpoint)
+    try await connection.connect()
+    let matrix: SwiftOCA.OcaMatrix = try await connection.resolve(
+      object: OcaObjectIdentification(
+        oNo: Self.matrixONo,
+        classIdentification: SwiftOCA.OcaMatrix.classIdentification
+      )
+    )
+    return Harness(
+      connection: connection,
+      endpointTask: endpointTask,
+      deviceMatrix: deviceMatrix,
+      actuators: actuators,
+      matrix: matrix
+    )
+  }
+
+  private func isLocked(_ object: SwiftOCADevice.OcaRoot) async -> Bool {
+    await { @OcaDevice in
+      if case .unlocked = object.lockState { return false }
+      return true
+    }()
+  }
+
+  private func setting(_ actuator: SwiftOCADevice.OcaBooleanActuator) async -> Bool {
+    await { @OcaDevice in actuator.setting }()
+  }
+
+  /// SetCurrentXY as a request that awaits the device's response. Through the property
+  /// setter it would go without one once the matrix is subscribed (as resolving the
+  /// proxy leaves it), and the next proxy call could then overtake it.
+  private func setCurrentXY(_ h: Harness, x: OcaMatrixCoordinate, y: OcaMatrixCoordinate) async throws {
+    try await h.matrix.sendCommandRrq(
+      methodID: OcaMethodID("3.2"),
+      parameters: OcaVector2D<OcaMatrixCoordinate>(x: x, y: y)
+    )
+  }
+
+  // GetSize is not exercised: the device returns the model's six output parameters
+  // (xSize, ySize, minXSize, maxXSize, minYSize, maxYSize) but the client's `size` is a
+  // two-field vector, which OCP.1's response parameter count check rejects.
+  func testMembers() async throws {
+    let h = try await makeHarness()
+    defer { Task { await h.tearDown() } }
+
+    let members = try await h.matrix.$members._getValue(h.matrix, flags: [])
+    XCTAssertEqual(members.nX, Int(Self.columns))
+    XCTAssertEqual(members.nY, Int(Self.rows))
+    for x in 0..<Int(Self.columns) {
+      for y in 0..<Int(Self.rows) {
+        XCTAssertEqual(members[x, y], h.actuators[x][y].objectNumber, "(\(x),\(y))")
+      }
+    }
+  }
+
+  func testGetMemberReturnsTheMemberAtACoordinate() async throws {
+    let h = try await makeHarness()
+    defer { Task { await h.tearDown() } }
+
+    let oNo = try await h.matrix.get(x: 2, y: 1)
+    XCTAssertEqual(oNo, h.actuators[2][1].objectNumber)
+  }
+
+  func testSetCurrentXYLocksTheMatrixButNotItsMembers() async throws {
+    let h = try await makeHarness()
+    defer { Task { await h.tearDown() } }
+
+    try await setCurrentXY(h, x: 1, y: 0)
+    let xy = try await h.matrix.$currentXY._getValue(h.matrix, flags: [])
+    XCTAssertEqual(xy.x, 1)
+    XCTAssertEqual(xy.y, 0)
+    let matrixLocked = await isLocked(h.deviceMatrix)
+    let memberLocked = await isLocked(h.actuators[1][0])
+    XCTAssertTrue(matrixLocked)
+    XCTAssertFalse(memberLocked, "SetCurrentXY must not lock the members (AES70-2)")
+  }
+
+  func testProxyForwardsToTheCurrentMemberAndReleasesTheLock() async throws {
+    let h = try await makeHarness()
+    defer { Task { await h.tearDown() } }
+
+    // resolved first: any forwarded command consumes SetCurrentXY's temporary lock
+    let proxy: SwiftOCA.OcaBooleanActuator = try await h.matrix.resolveProxy()
+    try await setCurrentXY(h, x: 2, y: 1)
+    try await proxy.$setting._setValue(proxy, true)
+
+    for x in 0..<Int(Self.columns) {
+      for y in 0..<Int(Self.rows) {
+        let value = await setting(h.actuators[x][y])
+        XCTAssertEqual(value, x == 2 && y == 1, "(\(x),\(y))")
+      }
+    }
+    let matrixLocked = await isLocked(h.deviceMatrix)
+    XCTAssertFalse(matrixLocked, "the proxy call releases SetCurrentXY's lock")
+  }
+
+  func testWildcardAddressesAWholeRow() async throws {
+    let h = try await makeHarness()
+    defer { Task { await h.tearDown() } }
+
+    let proxy: SwiftOCA.OcaBooleanActuator = try await h.matrix.resolveProxy()
+    try await setCurrentXY(h, x: Self.wildcard, y: 1)
+    try await proxy.$setting._setValue(proxy, true)
+
+    for x in 0..<Int(Self.columns) {
+      for y in 0..<Int(Self.rows) {
+        let value = await setting(h.actuators[x][y])
+        XCTAssertEqual(value, y == 1, "(\(x),\(y))")
+      }
+    }
+  }
+
+  func testRepeatedSetCurrentXYStillReleasesTheLock() async throws {
+    let h = try await makeHarness()
+    defer { Task { await h.tearDown() } }
+
+    let proxy: SwiftOCA.OcaBooleanActuator = try await h.matrix.resolveProxy()
+    try await setCurrentXY(h, x: 0, y: 0)
+    try await setCurrentXY(h, x: 1, y: 1)
+    try await proxy.$setting._setValue(proxy, true)
+
+    let value = await setting(h.actuators[1][1])
+    XCTAssertTrue(value)
+    let matrixLocked = await isLocked(h.deviceMatrix)
+    XCTAssertFalse(matrixLocked, "a second SetCurrentXY must not leave the matrix locked")
+  }
+
+  func testSetCurrentXYLockLocksTheMembersUntilUnlockCurrent() async throws {
+    let h = try await makeHarness()
+    defer { Task { await h.tearDown() } }
+
+    try await h.matrix.lockCurrent(x: Self.wildcard, y: 0)
+    for x in 0..<Int(Self.columns) {
+      let row0 = await isLocked(h.actuators[x][0])
+      let row1 = await isLocked(h.actuators[x][1])
+      XCTAssertTrue(row0, "(\(x),0) is in the current area")
+      XCTAssertFalse(row1, "(\(x),1) is not")
+    }
+
+    try await h.matrix.unlockCurrent()
+    for x in 0..<Int(Self.columns) {
+      let row0 = await isLocked(h.actuators[x][0])
+      XCTAssertFalse(row0, "(\(x),0) after UnlockCurrent")
+    }
+
+    // members that are already unlocked are not a failure (AES70-2)
+    try await h.matrix.unlockCurrent()
+  }
+
+  func testCoordinatesOutsideTheMatrixAreRejected() async throws {
+    let h = try await makeHarness()
+    defer { Task { await h.tearDown() } }
+
+    do {
+      try await setCurrentXY(h, x: Self.columns, y: 0)
+      XCTFail("expected parameterOutOfRange")
+    } catch let Ocp1Error.status(status) {
+      XCTAssertEqual(status, .parameterOutOfRange)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes that turned up while checking OCP.2 (AES70-4) conformance but aren't OCP.2-specific, so they land on `main` first. One commit each:

- **TXT record order** — registrations must begin with `txtvers` then `protovers`; the pairs came from a `Dictionary`.
- **OcaMatrix locking per AES70-2** — SetCurrentXY (3.2) locks the matrix and proxy but not the members, which also corrects 7a1aa957 (it kept the member lock). SetCurrentXYLock (3.15) takes `x, y` and also locks the members, failing before locking any if one can't be locked. UnlockCurrent (3.16) tolerates members that are already unlocked.
- **Matrix lock leak** — a repeated SetCurrentXY before a proxy call left the matrix locked after the proxy call.
- **Proxy status** — every proxied command reported `PartiallySucceeded` (a `nil` status compared unequal to `.ok`), even when it worked.
- **Vector and bounded device property setters** — they deferred storing the new value to a `Task` along with the notification, so a read straight after a set returned the old value. SetCurrentXYLock read the previous current area (the whole matrix by default) and locked every member. They now store at once, as `OcaDeviceProperty` already did.
- **MatrixTests** — new, over the local transport.
- **ClearResetCause** — the controller threw locally instead of sending OcaDeviceManager.ClearResetCause (3.16), and the device didn't handle it. It is now sent, and the device resets ResetCause to PowerOn.
- **Remove `Ocp1Error.notImplemented`** — there were two ways to say NotImplemented, and a device handler throwing the bare case answered `DeviceError`. AES70-4 requires `SetResetKey` to answer `NotImplemented` on a device without the reset mechanism, which is how `OcaDeviceManager.setResetKey` signalled it. Device code now throws `Ocp1Error.status(.notImplemented)`; the service browsers, which used the case for a local condition, get `Ocp1Error.serviceBrowsingUnavailable`. **Source-breaking** for consumers that throw `Ocp1Error.notImplemented` (none catch it).

## Known issue, not addressed

`OcaMatrix.size` (GetSize, 3.3) does not work over OCP.1. The device returns the model's six output parameters (`xSize, ySize, minXSize, maxXSize, minYSize, maxYSize`), but the client models the property as a two-field vector and OCP.1 rejects the parameter count. Fixing it needs a decision: a new client type for the six-field result, or relaxing the response parameter-count check for trailing parameters.

A related ordering hazard, also not addressed: once a matrix is subscribed, the client's property setter sends SetCurrentXY without awaiting a reply, so a following proxy call can overtake it. The tests send SetCurrentXY as a request for that reason.

## Test plan

- `swift test` on macOS from a clean build: full suite green
- `MatrixTests`: 8 tests; `DeviceManagerTests`: 2 tests (ClearResetCause round trip, SetResetKey answers NotImplemented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Fq7ie1LzJERrh9uRuZZWE
