### PR TITLE
Time out requests on one timer per connection; drop the device command timeout

### DIFF
--- a/Sources/SwiftOCA/OCA/Helpers/DeadlineTimer.swift
+++ b/Sources/SwiftOCA/OCA/Helpers/DeadlineTimer.swift
@@ -1,0 +1,168 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Synchronization
+
+/// One timer for many deadlines on the continuous clock.
+///
+/// A timeout raced against an operation with its own `Task.sleep` is costly when the
+/// operation usually wins, as a response does: cancelling the sleep resumes its task at
+/// once, but the runtime keeps the timer, and with it the task's memory, until the
+/// deadline passes. At thousands of requests a second that is hundreds of thousands of
+/// parked timers, and as many late wake-ups. Here a cancelled wait is removed and
+/// resumed at once, and a single loop, running only while waits are outstanding,
+/// sleeps until the earliest deadline.
+final class DeadlineTimer: Sendable {
+  typealias Instant = ContinuousClock.Instant
+  private typealias Continuation = UnsafeContinuation<(), Error>
+
+  private enum Wait {
+    /// allocated; the waiter has not suspended yet
+    case pending
+    /// the waiter is suspended until the deadline
+    case waiting(Instant, Continuation)
+    /// cancelled before the waiter suspended
+    case cancelled
+  }
+
+  /// The loop firing due waits: `generation` tells one that has been replaced to
+  /// stop, and `wakesAt` is when it next wakes, unknown until its first pass.
+  private struct Loop {
+    let generation: UInt64
+    var wakesAt: Instant?
+    let task: Task<(), Never>
+  }
+
+  private struct State {
+    var waits = [UInt64: Wait]()
+    var nextID = UInt64(0)
+    var loop: Loop?
+    var generation = UInt64(0)
+  }
+
+  private let state = Mutex(State())
+
+  init() {}
+
+  /// Returns at `deadline`, or throws `CancellationError` as soon as the calling task is
+  /// cancelled.
+  func wait(until deadline: Instant) async throws {
+    let id = state.withLock { state in
+      state.nextID &+= 1
+      state.waits[state.nextID] = .pending
+      return state.nextID
+    }
+    try await withTaskCancellationHandler {
+      try await withUnsafeThrowingContinuation { (continuation: Continuation) in
+        let outcome: Result<(), Error>? = state.withLock { state in
+          if case .cancelled = state.waits[id] {
+            state.waits[id] = nil
+            return .failure(CancellationError())
+          }
+          guard deadline > .now else {
+            state.waits[id] = nil
+            return .success(())
+          }
+          state.waits[id] = .waiting(deadline, continuation)
+          startLoop(unlessItWakesBy: deadline, &state)
+          return nil
+        }
+        // resume outside the lock
+        if let outcome {
+          continuation.resume(with: outcome)
+        }
+      }
+    } onCancel: {
+      let continuation: Continuation? = state.withLock { state in
+        switch state.waits[id] {
+        case let .waiting(_, continuation):
+          state.waits[id] = nil
+          return continuation
+        case .pending:
+          state.waits[id] = .cancelled
+          return nil
+        case .cancelled, nil:
+          return nil // already resolved
+        }
+      }
+      continuation?.resume(throwing: CancellationError())
+    }
+  }
+
+  /// The waits outstanding, so that a test can check nothing is left behind.
+  var outstanding: Int {
+    state.withLock { $0.waits.count }
+  }
+
+  /// Starts a loop if none is running, or replaces one that would wake after
+  /// `deadline`, so that no wait fires late.
+  private func startLoop(unlessItWakesBy deadline: Instant, _ state: inout State) {
+    if let loop = state.loop {
+      guard let wakesAt = loop.wakesAt, deadline < wakesAt else { return }
+      loop.task.cancel()
+    }
+    state.generation &+= 1
+    let generation = state.generation
+    // Detached, because the loop serves every wait on the timer: it should take neither
+    // the priority nor the task-local values of whichever waiter happened to start it.
+    // It holds the timer only during each pass, never across its sleep, so a timer that
+    // nothing uses any more is freed at once rather than kept alive by its own loop.
+    let task = Task.detached(priority: .high) { [weak self] in
+      while let pass = self?.pass(generation) {
+        // resume outside the lock
+        for continuation in pass.due {
+          continuation.resume()
+        }
+        guard let next = pass.next else { return }
+        do {
+          try await Task.sleep(until: next, clock: .continuous)
+        } catch {
+          return // cancelled: replaced by a loop that wakes sooner
+        }
+      }
+    }
+    state.loop = Loop(generation: generation, wakesAt: nil, task: task)
+  }
+
+  /// One pass of loop `generation`: takes the waits that are due and finds when the next
+  /// falls due, or ends the loop if nothing waits. `nil` if a loop that wakes sooner has
+  /// replaced it.
+  private func pass(_ generation: UInt64) -> (due: [Continuation], next: Instant?)? {
+    state.withLock { state in
+      guard state.loop?.generation == generation else {
+        return nil
+      }
+      let now = Instant.now
+      var due = [Continuation]()
+      var next: Instant?
+      for (id, wait) in state.waits {
+        guard case let .waiting(deadline, continuation) = wait else { continue }
+        if deadline <= now {
+          state.waits[id] = nil
+          due.append(continuation)
+        } else if next.map({ deadline < $0 }) ?? true {
+          next = deadline
+        }
+      }
+      if let next {
+        state.loop?.wakesAt = next
+      } else {
+        state.loop = nil // nothing waits; the next wait starts a loop
+      }
+      return (due, next)
+    }
+  }
+}

--- a/Sources/SwiftOCA/OCA/Helpers/DeadlineTimer.swift
+++ b/Sources/SwiftOCA/OCA/Helpers/DeadlineTimer.swift
@@ -23,8 +23,10 @@ import Synchronization
 /// once, but the runtime keeps the timer, and with it the task's memory, until the
 /// deadline passes. At thousands of requests a second that is hundreds of thousands of
 /// parked timers, and as many late wake-ups. Here a cancelled wait is removed and
-/// resumed at once, and a single loop, running only while waits are outstanding,
-/// sleeps until the earliest deadline.
+/// resumed at once, and a single loop sleeps until the earliest deadline. The loop stops
+/// when it wakes to find nothing waiting, so it outlives the last wait by at most the
+/// sleep it had already begun: stopping as each wait is cancelled would park a timer per
+/// request again.
 final class DeadlineTimer: Sendable {
   typealias Instant = ContinuousClock.Instant
   private typealias Continuation = UnsafeContinuation<(), Error>
@@ -146,23 +148,26 @@ final class DeadlineTimer: Sendable {
         return nil
       }
       let now = Instant.now
-      var due = [Continuation]()
+      var due = [(id: UInt64, continuation: Continuation)]()
       var next: Instant?
       for (id, wait) in state.waits {
         guard case let .waiting(deadline, continuation) = wait else { continue }
         if deadline <= now {
-          state.waits[id] = nil
-          due.append(continuation)
+          due.append((id, continuation))
         } else if next.map({ deadline < $0 }) ?? true {
           next = deadline
         }
+      }
+      // removed after iterating, as removing during it would copy the table
+      for (id, _) in due {
+        state.waits[id] = nil
       }
       if let next {
         state.loop?.wakesAt = next
       } else {
         state.loop = nil // nothing waits; the next wait starts a loop
       }
-      return (due, next)
+      return (due.map(\.continuation), next)
     }
   }
 }

--- a/Sources/SwiftOCA/OCA/Helpers/Task+Timeout.swift
+++ b/Sources/SwiftOCA/OCA/Helpers/Task+Timeout.swift
@@ -7,6 +7,29 @@ public func withThrowingTimeout<R: Sendable, C: Clock>(
   operation: @escaping @Sendable () async throws -> R,
   onTimeout: (@Sendable () async throws -> ())? = nil
 ) async throws -> R {
+  try await _withThrowingTimeout(
+    of: duration,
+    clock: clock,
+    operation: operation,
+    onTimeout: onTimeout,
+    sleepingUntil: { deadline in
+      try await Task.sleep(until: deadline, tolerance: tolerance, clock: clock)
+    }
+  )
+}
+
+/// `withThrowingTimeout` with the wait for the deadline supplied: `sleepingUntil` must
+/// return at the deadline, or throw once its task is cancelled. A caller that races many
+/// operations it expects to win can pass a shared `DeadlineTimer`, because the
+/// `Task.sleep` of a timeout that loses is kept by the runtime, with its task, until the
+/// deadline passes.
+func _withThrowingTimeout<R: Sendable, C: Clock>(
+  of duration: C.Instant.Duration,
+  clock: C,
+  operation: @escaping @Sendable () async throws -> R,
+  onTimeout: (@Sendable () async throws -> ())?,
+  sleepingUntil: @escaping @Sendable (C.Instant) async throws -> ()
+) async throws -> R {
   guard duration != .zero else {
     return try await operation()
   }
@@ -16,7 +39,7 @@ public func withThrowingTimeout<R: Sendable, C: Clock>(
 
     defer { group.cancelAll() }
     group.addTask {
-      try await Task.sleep(until: deadline, tolerance: tolerance, clock: clock)
+      try await sleepingUntil(deadline)
       try? await onTimeout?()
       throw Ocp1Error.responseTimeout
     }

--- a/Sources/SwiftOCA/OCP.1/Ocp1Connection+Messages.swift
+++ b/Sources/SwiftOCA/OCP.1/Ocp1Connection+Messages.swift
@@ -51,14 +51,21 @@ extension Ocp1Connection {
 
     let request = consume command
 
-    return try await withThrowingTimeout(
+    // the connection's timer rather than a sleep of our own, which the runtime would keep
+    // for the whole timeout after the response arrived
+    let deadlines = monitor.deadlines
+    return try await _withThrowingTimeout(
       of: responseTimeout,
       clock: .continuous,
       operation: { [self] in
         try await sendMessage(request, type: .ocaCmdRrq)
         return try await monitor.response(for: handle)
-      }, onTimeout: {
+      },
+      onTimeout: {
         monitor.resumeTimedOut(handle: handle)
+      },
+      sleepingUntil: { deadline in
+        try await deadlines.wait(until: deadline)
       }
     )
   }

--- a/Sources/SwiftOCA/OCP.1/Ocp1ConnectionMonitor.swift
+++ b/Sources/SwiftOCA/OCP.1/Ocp1ConnectionMonitor.swift
@@ -57,6 +57,10 @@ extension Ocp1Connection {
     private let _requests = Mutex<Requests>(Requests())
     private let _lastMessageReceivedTime = Mutex<ContinuousClock.Instant>(.now)
 
+    /// Every request's response deadline on this connection: one timer, rather than a
+    /// `Task.sleep` per request that outlives the request by the whole timeout.
+    let deadlines = DeadlineTimer()
+
     init(_ connection: Ocp1Connection, id: Int) {
       _connection = Weak(connection)
       _connectionID = id

--- a/Sources/SwiftOCADevice/OCA/Device.swift
+++ b/Sources/SwiftOCADevice/OCA/Device.swift
@@ -203,7 +203,6 @@ public actor OcaDevice {
 
   public func handleCommand(
     _ command: Ocp1Command,
-    timeout: Duration = .zero,
     from controller: any OcaController
   ) async -> Ocp1Response {
     let object = objects[command.targetONo]
@@ -213,17 +212,15 @@ public actor OcaDevice {
         throw Ocp1Error.status(.badONo)
       }
 
-      return try await withThrowingTimeout(of: timeout, clock: .continuous) {
-        if command.methodID.defLevel > 1,
-           let peerToPeerObject = object as? any OcaGroupPeerToPeerMember
-        {
-          try await peerToPeerObject.handleCommandForEachPeerToPeerMember(
-            command,
-            from: controller
-          )
-        } else {
-          try await object.handleCommand(command, from: controller)
-        }
+      if command.methodID.defLevel > 1,
+         let peerToPeerObject = object as? any OcaGroupPeerToPeerMember
+      {
+        return try await peerToPeerObject.handleCommandForEachPeerToPeerMember(
+          command,
+          from: controller
+        )
+      } else {
+        return try await object.handleCommand(command, from: controller)
       }
     } catch let Ocp1Error.status(status) {
       return .init(responseSize: 0, handle: command.handle, statusCode: status)

--- a/Sources/SwiftOCADevice/OCP.1/Ocp1ControllerInternal.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Ocp1ControllerInternal.swift
@@ -117,13 +117,7 @@ extension Ocp1ControllerInternal {
     switch message {
     case let command as Ocp1Command:
       endpoint.logger.command(command, on: controller)
-      // disable timeout for firmware updates
-      let timeout = command.targetONo == OcaFirmwareManagerONo ? .zero : endpoint.timeout
-      let commandResponse = await endpoint.device.handleCommand(
-        command,
-        timeout: timeout,
-        from: controller
-      )
+      let commandResponse = await endpoint.device.handleCommand(command, from: controller)
       response = Ocp1Response(
         handle: command.handle,
         statusCode: commandResponse.statusCode,

--- a/Tests/SwiftOCATests/DeadlineTimerTests.swift
+++ b/Tests/SwiftOCATests/DeadlineTimerTests.swift
@@ -1,0 +1,130 @@
+//
+// Copyright (c) 2026 PADL Software Pty Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+@testable @_spi(SwiftOCAPrivate) import SwiftOCA
+import XCTest
+
+/// The timer `sendCommandRrq` waits on for its response deadline. A wait must return
+/// at its deadline, throw at once when cancelled whether or not it has suspended yet,
+/// fire on time even when it falls due before a wait already pending, and leave
+/// nothing behind.
+final class DeadlineTimerTests: XCTestCase {
+  /// generous, so that a slow scheduler cannot turn these into flakes
+  private static let slack = Duration.seconds(2)
+
+  private func waitUntilOutstanding(_ timer: DeadlineTimer, _ count: Int) async throws {
+    let deadline = ContinuousClock.now.advanced(by: .seconds(5))
+    while timer.outstanding < count, ContinuousClock.now < deadline {
+      try await Task.sleep(for: .milliseconds(1))
+    }
+    XCTAssertEqual(timer.outstanding, count, "wait never registered")
+  }
+
+  func testWaitReturnsAtItsDeadline() async throws {
+    let timer = DeadlineTimer()
+    let start = ContinuousClock.now
+    try await timer.wait(until: start.advanced(by: .milliseconds(50)))
+    let elapsed = ContinuousClock.now - start
+
+    XCTAssertGreaterThanOrEqual(elapsed, .milliseconds(50))
+    XCTAssertLessThan(elapsed, Self.slack)
+    XCTAssertEqual(timer.outstanding, 0)
+  }
+
+  func testAPassedDeadlineReturnsAtOnce() async throws {
+    let timer = DeadlineTimer()
+    try await timer.wait(until: .now)
+    XCTAssertEqual(timer.outstanding, 0)
+  }
+
+  func testCancellationWhileWaitingThrowsAtOnce() async throws {
+    let timer = DeadlineTimer()
+    let task = Task { try await timer.wait(until: .now.advanced(by: .seconds(60))) }
+    try await waitUntilOutstanding(timer, 1)
+
+    let start = ContinuousClock.now
+    task.cancel()
+    do {
+      try await task.value
+      XCTFail("expected CancellationError")
+    } catch is CancellationError {}
+
+    XCTAssertLessThan(ContinuousClock.now - start, Self.slack)
+    XCTAssertEqual(timer.outstanding, 0)
+  }
+
+  func testCancellationBeforeWaitingIsHonoured() async throws {
+    let timer = DeadlineTimer()
+    let task = Task {
+      // already cancelled by the time it reaches the timer
+      while !Task.isCancelled {
+        await Task.yield()
+      }
+      try await timer.wait(until: .now.advanced(by: .seconds(60)))
+    }
+    task.cancel()
+    do {
+      try await task.value
+      XCTFail("expected CancellationError")
+    } catch is CancellationError {}
+
+    XCTAssertEqual(timer.outstanding, 0)
+  }
+
+  /// The loop sleeps until the earliest deadline it knows of, so a wait due sooner
+  /// must wake it rather than wait behind the later one.
+  func testAnEarlierDeadlineAddedLaterIsNotLate() async throws {
+    let timer = DeadlineTimer()
+    let long = Task { try await timer.wait(until: .now.advanced(by: .seconds(60))) }
+    try await waitUntilOutstanding(timer, 1)
+    // let the loop settle on the long deadline
+    try await Task.sleep(for: .milliseconds(50))
+
+    let start = ContinuousClock.now
+    try await timer.wait(until: start.advanced(by: .milliseconds(50)))
+    XCTAssertLessThan(ContinuousClock.now - start, Self.slack)
+
+    long.cancel()
+    _ = try? await long.value
+    XCTAssertEqual(timer.outstanding, 0)
+  }
+
+  func testConcurrentWaitsAllReturn() async throws {
+    let timer = DeadlineTimer()
+    let start = ContinuousClock.now
+    try await withThrowingTaskGroup(of: Void.self) { group in
+      for milliseconds in [90, 30, 60] {
+        group.addTask {
+          try await timer.wait(until: start.advanced(by: .milliseconds(milliseconds)))
+        }
+      }
+      try await group.waitForAll()
+    }
+    XCTAssertLessThan(ContinuousClock.now - start, Self.slack)
+    XCTAssertEqual(timer.outstanding, 0)
+  }
+
+  /// What a busy connection does: each request's timeout is cancelled by its response.
+  func testCancelledWaitsLeaveNothingBehind() async throws {
+    let timer = DeadlineTimer()
+    for _ in 0..<1000 {
+      let task = Task { try await timer.wait(until: .now.advanced(by: .seconds(60))) }
+      task.cancel()
+      _ = try? await task.value
+    }
+    XCTAssertEqual(timer.outstanding, 0)
+  }
+}

--- a/Tests/SwiftOCATests/RequestContinuationTests.swift
+++ b/Tests/SwiftOCATests/RequestContinuationTests.swift
@@ -445,4 +445,29 @@ final class RequestContinuationTests: XCTestCase {
     let outstanding = await connection.statistics.outstandingRequests
     XCTAssertEqual(outstanding, [])
   }
+
+  /// A request answered in time leaves nothing waiting on the connection's deadline
+  /// timer: the wait for its timeout goes as soon as the response wins, rather than
+  /// staying, as a `Task.sleep` did, for the whole timeout.
+  func testAnsweredRequestLeavesNoDeadlineBehind() async throws {
+    let connection = await makeConnection(responseTimeout: .seconds(30))
+    let monitor = await installMonitor(on: connection)
+
+    let command = Ocp1Command(
+      handle: Self.handle,
+      targetONo: 5000,
+      methodID: OcaMethodID("2.6")
+    )
+    let request = Task { try await connection.sendCommandRrq(command) }
+
+    // the first handle the monitor allocates
+    let handle: OcaUint32 = 1
+    try await waitUntilWaiting(monitor, handle: handle)
+    try monitor.resume(with: makeResponse(handle: handle))
+
+    let received = try await request.value
+    XCTAssertEqual(received.handle, handle)
+    // the task group returns only once its timeout child has finished
+    XCTAssertEqual(monitor.deadlines.outstanding, 0)
+  }
 }


### PR DESCRIPTION
## Summary

Two commits, neither specific to OCP.2:

- **Stop timing out each device command.** `OcaDevice.handleCommand` no longer races every command against the endpoint's timeout (`OcaDevice.DefaultTimeout`, 5 s). Its `timeout:` parameter goes, and so does the controller's exemption for firmware updates, the one long-running case.
- **Time out requests on one timer per connection.** `sendCommandRrq` keeps the same race against `responseTimeout`, but its timeout side now waits on a `DeadlineTimer` owned by the connection's monitor instead of its own `Task.sleep`.

## Why

Found with the OCAPerfBench harness while comparing `main` with `ocp2` on Linux. A 120-second loop of `getDeviceName` round trips over the local transport, about 6 million requests, reached **266 MB** peak memory on `main`. On macOS, `leaks` finds no leaks and no retain cycles. Instead, `malloc_history` shows the only growing allocations come from `Task._sleep(until:tolerance:clock:)`: about 30,000 live of each of three kinds after 12 seconds.

Both timeouts raced the work against a `Task.sleep`. When the work wins, as a response almost always does, cancelling the sleep resumes its task at once. The runtime still keeps the timer, and with it the sleeping task's memory, until the original deadline. So at any moment about (requests per second × timeout) timers are parked. On Linux that's roughly 52,000 × 5 ≈ 260,000 timers, which at around 1 KB each matches the 266 MB. Every one of them also fires later, doubling the timer wake-ups. The same mechanism explains three other things we saw:

- Latency rose over the first few seconds of a run, then levelled off.
- A new connection started slower when earlier connections in the process had closed, because their timers were still firing.
- Memory reached a plateau instead of growing without limit, so it looked like a leak without being one.

This is a known runtime limitation: [swiftlang/swift#60441](https://github.com/swiftlang/swift/issues/60441), "Sleeping tasks high memory usage after being cancelled". It has been open since 2022, and the cause is that `dispatch_after_f` gives no way to remove the enqueued job. The new `withDeadline` ([SE-0526](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0526-deadline.md), on the Swift `main` branch since August 2026) doesn't avoid it: its timer is a detached `clock.sleep` that is cancelled when the body finishes first, with a TODO to replace it with a timer job that can be cancelled. [SE-0505](https://forums.swift.org/t/pitch-4-delayed-enqueuing-for-executors/87918) (delayed enqueuing, in its fourth pitch) would give executors that hook. If the default executor adopts it, `DeadlineTimer` can go: it's internal and used in one place.

## Behaviour

**Client, unchanged.** It's the same task group race as before:
- the request side sends and awaits the response
- the timeout side, when it wins, calls `onTimeout` → `resumeTimedOut`
- the error is still `Ocp1Error.responseTimeout`
- a zero timeout still means no timeout
- a stalled write still times out (`testStalledWriteStillTimesOut`)

`withThrowingTimeout` is unchanged for its other callers. It's now a wrapper over an internal `_withThrowingTimeout`, which takes the "wait until the deadline" step as a parameter.

**`DeadlineTimer`.**
- **Cancellation:** a cancelled wait is removed and resumed immediately, whether the cancellation arrives before or after the wait registers. It uses the same pattern as the monitor's request table.
- **Loop:** one loop sleeps until the earliest deadline and fires only waits that are due. It stops when it wakes to find nothing waiting.
- **Earlier deadlines:** a wait due before the loop's next wake-up replaces the loop, so no timeout fires late.
- **Cost:** a busy connection pays one timer wake-up about every timeout period, instead of one per request.

**Device.** Commands are no longer timed out. The old race couldn't stop a handler that ignores cancellation, because a task group only returns once all its children have finished. So it only ever cut short handlers that checked for cancellation, and even then it turned slowness into `DeviceError` while the handler kept running.

## Retain cycles

The timer holds nothing but its own state: the outstanding waits, and the handle of its loop task. Nothing in it points back to the monitor or connection that own it, so it can't keep a closed connection alive. Two references are held on purpose, and both are bounded:

- **Timer and waiting task.** While a wait is outstanding, the timer holds the waiting task's continuation, and that task's closure holds the timer. That's inherent to any wait. It ends when the wait is resumed: when its request completes, or at its deadline at the latest.
- **Loop task.** The loop holds the timer only weakly, taking a strong reference for the brief locked step of each pass and never across its sleep. A timer nobody uses any more is freed at once instead of lasting until the loop next wakes.

The loop deliberately doesn't exit as soon as its last wait is cancelled. With one request at a time in flight, that would cancel the loop's sleep after every response, bringing back a parked timer per request. Instead it exits on its next wake-up if nothing is waiting.

## Source compatibility

`OcaDevice.handleCommand(_:timeout:from:)` becomes `handleCommand(_:from:)`. Its only caller is `Ocp1ControllerInternal`. InfernoAES70 and MOMOCABridge don't call it.

## Measurements

macOS (Darwin 24.6.0, arm64, 10 CPUs), `BENCH_SLICE=10 compare.sh -m profile -s 30 -r 3 main fix-request-timeouts`: a `getDeviceName` loop over the local transport, with the `main` and branch runs interleaved in each round. The machine wasn't idle (load average about 8 from other work), but both sides shared that load.

| | `main` (6b9f404c) | this branch (1eb57f93) | change |
|---|---:|---:|---:|
| ns per round trip | 46,332 | 40,786 | −12.0% |
| round trips per 30 s run | 646,804 – 654,154 | 732,023 – 738,843 | +13% |
| peak resident memory | 87,120 KiB | 10,944 KiB | −87% |
| ns per round trip, by 10 s slice | 46,095 → 46,352 → 46,441 | 40,943 → 40,669 → 40,706 | rises on `main`, flat here |

A heap probe of this branch's build ran the same loop for 50 s:
- Resident memory held at 12.5–13.0 MB from 5 s to 40 s.
- Between 10 s and 40 s the heap grew by under 10 KB in total. The largest single growth was 4.6 KB. The `dispatch_after_f` allocations that park each cancelled sleep numbered 6 live, up 3 in that time. On `main`, about 30,000 of each of three `Task._sleep` allocation kinds had built up after 12 s.
- `leaks` reports 0 leaks.

Linux (7.0.0-28-generic, x86_64, 32 CPUs, `performance` governor, pinned with `taskset -c 2,3`), `BENCH_SLICE=10 compare.sh -m profile -s 120 -r 3 origin/main origin/fix-request-timeouts`:

| | `main` (6b9f404c) | this branch (93e0568c) | change |
|---|---:|---:|---:|
| ns per round trip | 18,690 | 17,307 | −7.4% |
| peak resident memory | 261,296 KiB | 34,980 KiB | −86.6% |
| ns per round trip, 0–10 s | 18,089 | 17,205 | −4.9% |
| ns per round trip, 10–20 s | 18,685 | 17,239 | −7.7% |
| ns per round trip, 110–120 s | 18,867 | 17,367 | −8.0% |

On `main`, latency climbs for the first 20 s while parked timers build up to about 5 s worth of requests. On this branch it stays within 1% of 17.3 µs for the whole 120 s.

## Tests

- `DeadlineTimerTests`:
  - a wait returns at its deadline, and one whose deadline has already passed returns at once
  - cancellation while waiting throws at once
  - cancellation before waiting is honoured
  - an earlier deadline added after a later one isn't late
  - concurrent waits all return
  - a thousand cancelled waits leave nothing behind
- `RequestContinuationTests.testAnsweredRequestLeavesNoDeadlineBehind`: after a `sendCommandRrq` is answered, the connection's timer has nothing outstanding.
- The existing timeout tests, including `testStalledWriteStillTimesOut` and `testFailedSendWithdrawsRequest`, are unchanged and still pass.

## Test plan

- [x] `swift test` on macOS: 284 tests, 0 failures
- [x] Linux CI: build and tests pass
- [x] Linux: `PIN="taskset -c 2,3" BENCH_SLICE=10 Examples/OCAPerfBench/compare.sh -m profile -s 120 -r 3 origin/main origin/fix-request-timeouts`, run from the `perfbench` branch: memory stays flat (see Measurements)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Fq7ie1LzJERrh9uRuZZWE
