### PR TITLE
Time out device stream reads on one timer per connection

### DIFF
--- a/Sources/SwiftOCA/OCA/Helpers/DeadlineTimer.swift
+++ b/Sources/SwiftOCA/OCA/Helpers/DeadlineTimer.swift
@@ -27,7 +27,7 @@ import Synchronization
 /// when it wakes to find nothing waiting, so it outlives the last wait by at most the
 /// sleep it had already begun: stopping as each wait is cancelled would park a timer per
 /// request again.
-final class DeadlineTimer: Sendable {
+package final class DeadlineTimer: Sendable {
   typealias Instant = ContinuousClock.Instant
   private typealias Continuation = UnsafeContinuation<(), Error>
 
@@ -57,7 +57,27 @@ final class DeadlineTimer: Sendable {
 
   private let state = Mutex(State())
 
-  init() {}
+  package init() {}
+
+  /// Runs `operation`, and if it hasn't returned within `duration`, calls `onTimeout` and
+  /// throws `Ocp1Error.responseTimeout`; a zero duration means no timeout. The race is
+  /// `withThrowingTimeout`'s, but its deadline is a wait on this timer, so an operation
+  /// that wins, as a response or a read almost always does, leaves nothing behind.
+  package func withThrowingTimeout<R: Sendable>(
+    of duration: Duration,
+    operation: @escaping @Sendable () async throws -> R,
+    onTimeout: (@Sendable () async throws -> ())? = nil
+  ) async throws -> R {
+    try await _withThrowingTimeout(
+      of: duration,
+      clock: .continuous,
+      operation: operation,
+      onTimeout: onTimeout,
+      sleepingUntil: { deadline in
+        try await self.wait(until: deadline)
+      }
+    )
+  }
 
   /// Returns at `deadline`, or throws `CancellationError` as soon as the calling task is
   /// cancelled.

--- a/Sources/SwiftOCA/OCP.1/Ocp1Connection+Messages.swift
+++ b/Sources/SwiftOCA/OCP.1/Ocp1Connection+Messages.swift
@@ -53,19 +53,14 @@ extension Ocp1Connection {
 
     // the connection's timer rather than a sleep of our own, which the runtime would keep
     // for the whole timeout after the response arrived
-    let deadlines = monitor.deadlines
-    return try await _withThrowingTimeout(
+    return try await monitor.deadlines.withThrowingTimeout(
       of: responseTimeout,
-      clock: .continuous,
       operation: { [self] in
         try await sendMessage(request, type: .ocaCmdRrq)
         return try await monitor.response(for: handle)
       },
       onTimeout: {
         monitor.resumeTimedOut(handle: handle)
-      },
-      sleepingUntil: { deadline in
-        try await deadlines.wait(until: deadline)
       }
     )
   }

--- a/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingSocksStreamController.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingSocksStreamController.swift
@@ -160,9 +160,12 @@ private extension AsyncThrowingStream
     from bytes: some AsyncBufferedSequence<UInt8>,
     timeout: Duration
   ) -> Self {
-    AsyncThrowingStream<Ocp1MessageList, Error> {
+    // one timer for every read on the connection, rather than a sleep per message that the
+    // runtime would keep for the whole timeout after the message arrived
+    let deadlines = DeadlineTimer()
+    return AsyncThrowingStream<Ocp1MessageList, Error> {
       do {
-        return try await withThrowingTimeout(of: timeout, clock: .continuous) {
+        return try await deadlines.withThrowingTimeout(of: timeout) {
           nonisolated(unsafe) var iterator = bytes.makeAsyncIterator()
           return try await OcaDevice.asyncReceiveMessages { count in
             var nremain = count

--- a/Sources/SwiftOCADevice/OCP.1/Backend/Network/Ocp1NWStreamController.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/Network/Ocp1NWStreamController.swift
@@ -38,6 +38,7 @@ package actor Ocp1NWStreamController: Ocp1ControllerInternal, CustomStringConver
   package nonisolated var peerIdentity: OcaPeerIdentity {
     _peerIdentity.withLock { $0 }
   }
+
   package nonisolated func setPeerIdentity(_ identity: OcaPeerIdentity) {
     _peerIdentity.withLock { $0 = identity }
   }
@@ -136,8 +137,11 @@ private extension Ocp1NWStreamController {
     on connection: NWConnection,
     timeout: Duration
   ) -> AsyncThrowingStream<Ocp1MessageList, Error> {
-    AsyncThrowingStream { () async throws -> Ocp1MessageList? in
-      try await withThrowingTimeout(of: timeout, clock: .continuous) {
+    // one timer for every read on the connection, rather than a sleep per message that the
+    // runtime would keep for the whole timeout after the message arrived
+    let deadlines = DeadlineTimer()
+    return AsyncThrowingStream { () async throws -> Ocp1MessageList? in
+      try await deadlines.withThrowingTimeout(of: timeout) {
         try await OcaDevice.asyncReceiveMessages { count in
           try await connection.receiveExactly(count)
         }

--- a/Tests/SwiftOCATests/DeadlineTimerTests.swift
+++ b/Tests/SwiftOCATests/DeadlineTimerTests.swift
@@ -17,13 +17,63 @@
 @testable @_spi(SwiftOCAPrivate) import SwiftOCA
 import XCTest
 
-/// The timer `sendCommandRrq` waits on for its response deadline. A wait must return
-/// at its deadline, throw at once when cancelled whether or not it has suspended yet,
-/// fire on time even when it falls due before a wait already pending, and leave
-/// nothing behind.
+/// The timer `sendCommandRrq` waits on for its response deadline, and a device stream
+/// controller for each read. A wait must return at its deadline, throw at once when
+/// cancelled whether or not it has suspended yet, fire on time even when it falls due
+/// before a wait already pending, and leave nothing behind.
 final class DeadlineTimerTests: XCTestCase {
   /// generous, so that a slow scheduler cannot turn these into flakes
   private static let slack = Duration.seconds(2)
+
+  private actor Flag {
+    var isSet = false
+
+    func set() {
+      isSet = true
+    }
+  }
+
+  func testTimeoutReturnsWhatTheOperationReturns() async throws {
+    let timer = DeadlineTimer()
+    let result = try await timer.withThrowingTimeout(of: .seconds(60)) { 42 }
+    XCTAssertEqual(result, 42)
+    XCTAssertEqual(timer.outstanding, 0, "the deadline should go with the operation")
+  }
+
+  func testTimeoutThrowsAndCallsOnTimeout() async throws {
+    let timer = DeadlineTimer()
+    let onTimeoutCalled = Flag()
+    let start = ContinuousClock.now
+    do {
+      _ = try await timer.withThrowingTimeout(
+        of: .milliseconds(50),
+        operation: {
+          try await Task.sleep(for: .seconds(60))
+          return 0
+        },
+        onTimeout: {
+          await onTimeoutCalled.set()
+        }
+      )
+      XCTFail("expected responseTimeout")
+    } catch Ocp1Error.responseTimeout {}
+
+    XCTAssertGreaterThanOrEqual(ContinuousClock.now - start, .milliseconds(50))
+    XCTAssertLessThan(ContinuousClock.now - start, Self.slack)
+    let called = await onTimeoutCalled.isSet
+    XCTAssertTrue(called)
+    XCTAssertEqual(timer.outstanding, 0)
+  }
+
+  func testZeroTimeoutMeansNoTimeout() async throws {
+    let timer = DeadlineTimer()
+    let result = try await timer.withThrowingTimeout(of: .zero) {
+      try await Task.sleep(for: .milliseconds(50))
+      return 1
+    }
+    XCTAssertEqual(result, 1)
+    XCTAssertEqual(timer.outstanding, 0)
+  }
 
   private func waitUntilOutstanding(_ timer: DeadlineTimer, _ count: Int) async throws {
     let deadline = ContinuousClock.now.advanced(by: .seconds(5))


### PR DESCRIPTION
## Summary

This is the follow-up to #67, for the device side. The Network and FlyingSocks stream controllers timed out every message read with `withThrowingTimeout`, so each message a device received left a cancelled `Task.sleep` parked for the endpoint's whole timeout, 5 s by default. That is what #67 fixed for client requests. The reads now wait on one `DeadlineTimer` per connection.

## Changes

- **`DeadlineTimer.withThrowingTimeout(of:operation:onTimeout:)`**: the same race as `withThrowingTimeout`, except that the deadline is a wait on the timer. `sendCommandRrq` uses it too, so the race is written in one place.
- **`package` access** for `DeadlineTimer`, its initialiser and that method, so that SwiftOCADevice can use them.
- **Stream controllers**: `Ocp1NWStreamController.makeMessagesStream` and `Ocp1FlyingSocksStreamController`'s `decodingMessages` each create one timer for the connection's message stream, and use it for every read.

Unchanged:
- **Other controllers**: the IORing, datagram, WebSocket and CF controllers don't time out reads, so they aren't touched. On Linux, TCP devices use IORing, so this matters for macOS and for devices built with the FlyingSocks or Network backends.
- **Timeout behaviour**: a read that doesn't finish in time throws `Ocp1Error.responseTimeout` as before.
- **`receiveExactly` on Network**: this existing limitation is out of scope. The receive doesn't respond to cancellation, and a task group waits for all its children. So a timed-out read only returns once data arrives or the connection is cancelled.

## Retain cycles

- **Timer lifetime:** each controller's message stream closure captures its timer, so the timer lives exactly as long as the stream. The timer holds no reference back to the stream or the controller.
- **Loop:** it holds the timer weakly, as in #67.

## Measurements

macOS (Darwin 24.6.0, arm64, 10 CPUs), where `Ocp1DeviceEndpoint` is the FlyingSocks stream endpoint. I ran `BENCH_TRANSPORT=tcp BENCH_SLICE=10 compare.sh -m profile -s 30 -r 3 95bfc133 deadline-timer-reads`: a `getDeviceName` loop over loopback TCP, with client and device in one process, comparing this branch with its base.

| | base (95bfc133) | this branch (752efc0c) | change |
|---|---:|---:|---:|
| peak resident memory | 40,960 KiB | 12,128 KiB | −70.4% |
| ns per round trip | 140,831 | 138,413 | −1.7% |
| round trips per 30 s run | 203,840 – 215,280 | 215,171 – 219,452 | +2% |
| ns per round trip, by 10 s slice | 140,229 → 141,384 → 142,815 | 137,949 → 138,547 → 137,282 | rises on the base, flat here |

The client's request timeouts were already on one timer per connection (#67) on both sides, so the difference is the device's reads. At about 7,100 messages a second, a 5 s read timeout keeps about 35,000 cancelled sleeps parked.

On Linux, TCP devices use IORing, which doesn't time out reads, so there's no difference to measure there.

## Tests

`DeadlineTimerTests` gains three tests of the method:
- the operation's result is returned, and no deadline is left outstanding
- a timeout throws `responseTimeout` and calls `onTimeout`
- a zero duration means no timeout

The existing suites, including the NW and FlyingSocks stream endpoint tests, still pass.

## Test plan

- [x] `swift test` on macOS: 287 tests, 0 failures
- [x] Linux CI: build and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Fq7ie1LzJERrh9uRuZZWE
