### PR TITLE
Find a property-change event's property by ID

### DIFF
--- a/Sources/SwiftOCA/OCC/ControlClasses/Root.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Root.swift
@@ -20,6 +20,7 @@ import FoundationEssentials
 #else
 import Foundation
 #endif
+import Synchronization
 
 open class OcaRoot: CustomStringConvertible, @unchecked Sendable, _OcaObjectKeyPathRepresentable {
   typealias Root = OcaRoot
@@ -187,11 +188,11 @@ open class OcaRoot: CustomStringConvertible, @unchecked Sendable, _OcaObjectKeyP
   #endif
 
   public func propertyKeyPath(for propertyID: OcaPropertyID) async -> AnyKeyPath? {
-    await OcaPropertyKeyPathCache.shared.lookupProperty(byID: propertyID, for: self)
+    OcaPropertyKeyPathCache.shared.lookupProperty(byID: propertyID, for: self)
   }
 
   public func propertyKeyPath(for name: String) async -> AnyKeyPath? {
-    await OcaPropertyKeyPathCache.shared.lookupProperty(byName: name, for: self)
+    OcaPropertyKeyPathCache.shared.lookupProperty(byName: name, for: self)
   }
 }
 
@@ -202,7 +203,6 @@ extension _OcaObjectKeyPathRepresentable where Self: OcaRoot {
     ObjectIdentifier(type(of: self))
   }
 
-  @OcaConnection
   var allKeyPaths: [String: AnyKeyPath] {
     OcaPropertyKeyPathCache.shared.keyPaths(for: self)
   }
@@ -243,19 +243,18 @@ public extension OcaRoot {
   @OcaConnection
   private func onPropertyEvent(event: OcaEvent, eventData data: Data) {
     let decoder = Ocp1Decoder()
+    // the property with this ID from the class's key paths, worked out once, rather than
+    // reading every property of the object in turn, computed ones included, and casting
+    // each to find it
     guard let propertyID = try? decoder.decode(
       OcaPropertyID.self,
       from: data
-    ) else { return }
+    ),
+      let keyPath = OcaPropertyKeyPathCache.shared.lookupProperty(byID: propertyID, for: self),
+      let value = self[keyPath: keyPath] as? (any OcaPropertyChangeEventNotifiable)
+    else { return }
 
-    for (_, keyPath) in allKeyPaths {
-      if let value = self[keyPath: keyPath] as? (any OcaPropertyChangeEventNotifiable),
-         value.propertyIDs.contains(propertyID)
-      {
-        try? value.onEvent(self, event: event, eventData: data)
-        break
-      }
-    }
+    try? value.onEvent(self, event: event, eventData: data)
   }
 
   @OcaConnection
@@ -383,11 +382,14 @@ public extension OcaRoot {
 
 extension AnyKeyPath: @retroactive @unchecked Sendable {}
 
-@OcaConnection
-private final class OcaPropertyKeyPathCache {
+/// Each class's property key paths, worked out once and shared by every instance of the
+/// class. Synchronous, and safe to use from any thread: building an entry reads the
+/// object's property wrappers, whose stored fields are constants, their values living in
+/// their subjects.
+private final class OcaPropertyKeyPathCache: Sendable {
   fileprivate static let shared = OcaPropertyKeyPathCache()
 
-  private struct CacheEntry {
+  private struct CacheEntry: Sendable {
     let keyPaths: [String: AnyKeyPath]
     let propertiesByID: [OcaPropertyID: AnyKeyPath]
     let propertiesByName: [String: AnyKeyPath]
@@ -418,45 +420,42 @@ private final class OcaPropertyKeyPathCache {
     }
   }
 
-  private var _cache = [ObjectIdentifier: CacheEntry]()
+  private let _cache = Mutex([ObjectIdentifier: CacheEntry]())
 
-  private func addCacheEntry(for object: some OcaRoot) -> CacheEntry {
-    let cacheEntry = CacheEntry(object: object)
-    _cache[object._metaTypeObjectIdentifier] = cacheEntry
-    return cacheEntry
-  }
-
-  @OcaConnection
-  fileprivate func keyPaths(for object: some OcaRoot) -> [String: AnyKeyPath] {
-    if let cacheEntry = _cache[object._metaTypeObjectIdentifier] {
-      return cacheEntry.keyPaths
+  private func cacheEntry(for object: some OcaRoot) -> CacheEntry {
+    let key = object._metaTypeObjectIdentifier
+    if let cacheEntry = _cache.withLock({ $0[key] }) {
+      return cacheEntry
     }
 
-    return addCacheEntry(for: object).keyPaths
+    // built outside the lock, as it reflects over the object; two threads building the
+    // same class's entry at once build the same thing, and the first stored is kept
+    let cacheEntry = CacheEntry(object: object)
+    return _cache.withLock { cache in
+      if let existing = cache[key] {
+        return existing
+      }
+      cache[key] = cacheEntry
+      return cacheEntry
+    }
   }
 
-  @OcaConnection
+  fileprivate func keyPaths(for object: some OcaRoot) -> [String: AnyKeyPath] {
+    cacheEntry(for: object).keyPaths
+  }
+
   fileprivate func lookupProperty(
     byID propertyID: OcaPropertyID,
     for object: some OcaRoot
   ) -> AnyKeyPath? {
-    if let cacheEntry = _cache[object._metaTypeObjectIdentifier] {
-      return cacheEntry.propertiesByID[propertyID]
-    }
-
-    return addCacheEntry(for: object).propertiesByID[propertyID]
+    cacheEntry(for: object).propertiesByID[propertyID]
   }
 
-  @OcaConnection
   fileprivate func lookupProperty(
     byName name: String,
     for object: some OcaRoot
   ) -> AnyKeyPath? {
-    if let cacheEntry = _cache[object._metaTypeObjectIdentifier] {
-      return cacheEntry.propertiesByName[name]
-    }
-
-    return addCacheEntry(for: object).propertiesByName[name]
+    cacheEntry(for: object).propertiesByName[name]
   }
 }
 

--- a/Sources/SwiftOCA/OCC/ControlClasses/Root.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Root.swift
@@ -187,11 +187,11 @@ open class OcaRoot: CustomStringConvertible, @unchecked Sendable, _OcaObjectKeyP
   }
   #endif
 
-  public func propertyKeyPath(for propertyID: OcaPropertyID) async -> AnyKeyPath? {
+  public func propertyKeyPath(for propertyID: OcaPropertyID) -> AnyKeyPath? {
     OcaPropertyKeyPathCache.shared.lookupProperty(byID: propertyID, for: self)
   }
 
-  public func propertyKeyPath(for name: String) async -> AnyKeyPath? {
+  public func propertyKeyPath(for name: String) -> AnyKeyPath? {
     OcaPropertyKeyPathCache.shared.lookupProperty(byName: name, for: self)
   }
 }


### PR DESCRIPTION
## Summary

For every property-change event, `OcaRoot.onPropertyEvent` looked for the property to update by scanning the object:
- It walked all of the object's key paths.
- It read each property through its key path, including the computed class ID, which parses a string literal each time.
- It cast each one to `OcaPropertyChangeEventNotifiable` until one's `propertyIDs` contained the event's property ID.

The key path cache already maps every property ID of a class to its key path. `onPropertyEvent` now looks the property up there: one dictionary lookup and one cast per event.

The cache is also now synchronous and safe to use from any thread. It's protected by a `Mutex` instead of being isolated to `@OcaConnection`.

## Why

A 58-second Instruments trace of `inferno_ui`, a Flutter controller on SwiftOCA `main` (2db6b895, Debug build), showed the cost:
- `onPropertyEvent` accounted for **6.5% of the process's CPU**.
- Most of that was Swift runtime metadata and conformance lookups (`MetadataCacheKey::operator==`, `swift_conformsToProtocol…`, `tryCast`) from the per-property casts.
- Another 1.4% was the `OcaRoot._classID` key-path getter, plus `OcaClassID.init(stringLiteral:)`.

## Changes

- **`onPropertyEvent`:** calls `lookupProperty(byID:for:)` instead of scanning.
  - `OcaPropertyChangeEventNotifiable` refines `OcaPropertySubjectRepresentable`, which is what the cache indexes, so every property the scan could find is in the cache's `propertiesByID`.
  - That includes each ID of properties with several, such as bounded and vector properties.
- **`OcaPropertyKeyPathCache`:** is now a `Sendable` class whose entries are held in a `Mutex`. Its lookups are synchronous and non-isolated.
  - An entry is still built once per class. It's built outside the lock, because it reflects over the object.
  - If two threads build the same class's entry, the first one stored is kept.
  - Building an entry off the connection actor is safe: it reads the object's property wrappers, whose stored fields are constants (`OcaProperty`'s value lives in its `subject`).
- **`allKeyPaths`:** is no longer `@OcaConnection`.
- **`propertyKeyPath(for:)`:** both overloads, by ID and by name, are now synchronous, since the cache is. This is in a second commit.
  - Nothing inside SwiftOCA calls them.
  - Callers that `await` them still compile, with a "no 'async' operations occur within 'await' expression" warning. That's one call in FlutterSwiftOCA (`OcaChannelManager.swift:40`) and three in ocacli (`Setters.swift:33`, `Subscriptions.swift:82`, `Getters.swift:85`).

## Not included

The device-side `OcaDevicePropertyKeyPathCache` is still `@OcaDevice`. It could get the same treatment separately.

## Measurements

OCAPerfBench `notify` mode on macOS (Darwin 24.6.0, arm64, 10 CPUs): 2,000 property changes on an `OcaBlock` on the device, timed until the controller observes the last. This was measured with `compare.sh -m notify -r 5 main property-event-lookup`, release builds, with `main` at 2db6b895, just before this PR was merged, against this branch at 638c9989. Builds ran on the machine during the runs, so expect some noise, but the difference is well beyond it.

| | `main` | this branch | change |
|---|---:|---:|---:|
| ns per property change | 45,551 | 28,553 | −37.3% |

Every run observed all 2,000 changes (1,999–2,001, since the property subject may coalesce values), so no events were lost.

## Test plan

- [x] `swift test` on macOS: 289 tests, 0 failures, including `PropertySubscriptionTests`, `MatrixTests` and `NotificationFanOutTests`
- [ ] Linux CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Fq7ie1LzJERrh9uRuZZWE
