### PR TITLE
Protect the device property key path cache with a Mutex

### DIFF
--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Root.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Root.swift
@@ -17,6 +17,7 @@
 import AsyncExtensions
 @_spi(SwiftOCAPrivate)
 import SwiftOCA
+import Synchronization
 
 extension OcaController {
   typealias ID = ObjectIdentifier
@@ -534,7 +535,7 @@ extension OcaRoot: Hashable {
 protocol _OcaObjectKeyPathRepresentable: OcaRoot {}
 
 extension OcaRoot {
-  fileprivate var _metaTypeObjectIdentifier: ObjectIdentifier {
+  fileprivate nonisolated var _metaTypeObjectIdentifier: ObjectIdentifier {
     ObjectIdentifier(type(of: self))
   }
 
@@ -568,16 +569,19 @@ extension OcaRoot {
   }
 }
 
-@OcaDevice
-private final class OcaDevicePropertyKeyPathCache {
+/// Each class's device property key paths and accessor methods, worked out once and shared
+/// by every instance of the class. Synchronous, and safe to use from any thread: building
+/// an entry reads only the property wrappers' metadata, which is set at initialisation
+/// (see `allDevicePropertyKeyPathsUncached`).
+private final class OcaDevicePropertyKeyPathCache: Sendable {
   fileprivate static let shared = OcaDevicePropertyKeyPathCache()
 
-  enum AccessorType {
+  enum AccessorType: Sendable {
     case getter
     case setter
   }
 
-  private struct CacheEntry {
+  private struct CacheEntry: Sendable {
     let keyPaths: [String: AnyKeyPath]
     let methods: [OcaMethodID: (AccessorType, AnyKeyPath)]
 
@@ -596,40 +600,41 @@ private final class OcaDevicePropertyKeyPathCache {
       }
     }
 
-    @OcaDevice
     fileprivate init(object: some OcaRoot) {
       let keyPaths = object.allDevicePropertyKeyPathsUncached
       self.init(keyPaths: keyPaths, object: object)
     }
   }
 
-  private var _cache = [ObjectIdentifier: CacheEntry]()
+  private let _cache = Mutex([ObjectIdentifier: CacheEntry]())
 
-  private func addCacheEntry(for object: some OcaRoot) -> CacheEntry {
-    let cacheEntry = CacheEntry(object: object)
-    _cache[object._metaTypeObjectIdentifier] = cacheEntry
-    return cacheEntry
-  }
-
-  @OcaDevice
-  fileprivate func keyPaths(for object: some OcaRoot) -> [String: AnyKeyPath] {
-    if let cacheEntry = _cache[object._metaTypeObjectIdentifier] {
-      return cacheEntry.keyPaths
+  private func cacheEntry(for object: some OcaRoot) -> CacheEntry {
+    let key = object._metaTypeObjectIdentifier
+    if let cacheEntry = _cache.withLock({ $0[key] }) {
+      return cacheEntry
     }
 
-    return addCacheEntry(for: object).keyPaths
+    // built outside the lock, as it reflects over the object; two threads building the
+    // same class's entry at once build the same thing, and the first stored is kept
+    let cacheEntry = CacheEntry(object: object)
+    return _cache.withLock { cache in
+      if let existing = cache[key] {
+        return existing
+      }
+      cache[key] = cacheEntry
+      return cacheEntry
+    }
   }
 
-  @OcaDevice
+  fileprivate func keyPaths(for object: some OcaRoot) -> [String: AnyKeyPath] {
+    cacheEntry(for: object).keyPaths
+  }
+
   fileprivate func lookupMethod(
     _ methodID: OcaMethodID,
     for object: some OcaRoot
   ) -> (AccessorType, AnyKeyPath)? {
-    if let cacheEntry = _cache[object._metaTypeObjectIdentifier] {
-      return cacheEntry.methods[methodID]
-    }
-
-    return addCacheEntry(for: object).methods[methodID]
+    cacheEntry(for: object).methods[methodID]
   }
 }
 


### PR DESCRIPTION
## Summary

This is the device-side counterpart of #69. `OcaDevicePropertyKeyPathCache`, which maps a device object's class to its property key paths and property accessor method IDs, now works the way the controller's `OcaPropertyKeyPathCache` does.

- **Before:** a class isolated to `@OcaDevice`.
- **Now:** a `Sendable` class whose entries are held in a `Mutex`, with synchronous lookups not isolated to `@OcaDevice`.

## Changes

- **The cache:** `keyPaths(for:)` and `lookupMethod(_:for:)` are synchronous and non-isolated.
  - An entry is still built once per class, outside the lock, because it reflects over the object.
  - If two threads build the same class's entry at once, the first one stored is kept.
- **Why off-actor building is safe:** building an entry reads only the property wrappers' metadata: `propertyID`, `getMethodID`, `setMethodID`. That's set at initialisation. `allDevicePropertyKeyPathsUncached` already relies on this, since it's `nonisolated(unsafe)` for use from `deinit`, and `OcaDevicePropertyRepresentable` is `Sendable` and not isolated.
- **`_metaTypeObjectIdentifier`:** now `nonisolated`, so the cache can key entries by class from outside the actor.
- **Callers:** `handlePropertyAccessor` and `allDevicePropertyKeyPaths` are unchanged. They're on `@OcaDevice` and already called the cache synchronously.

No public API changes.

## Test plan

- [x] `swift test` on macOS: 289 tests, 0 failures
- [ ] Linux CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Fq7ie1LzJERrh9uRuZZWE
