### PR TITLE
Shut a FlyingSocks controller's socket down before closing it

### DIFF
--- a/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingSocksStreamController.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingSocksStreamController.swift
@@ -26,7 +26,10 @@ import Foundation
 #endif
 @_spi(SwiftOCAPrivate)
 import SwiftOCA
-#if canImport(Glibc)
+import Synchronization
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
 import Glibc
 #elseif canImport(WinSDK)
 import WinSDK
@@ -46,8 +49,8 @@ package actor Ocp1FlyingSocksStreamController: Ocp1ControllerInternal, CustomStr
 
   private let address: String
   private let socket: AsyncSocket
+  private let lifetime: Ocp1FlyingSocksSocketLifetime
   private let _messages: AsyncThrowingStream<Ocp1MessageList, Error>
-  private var socketClosed = false
 
   package var messages: AnyAsyncSequence<Ocp1MessageList> {
     _messages.eraseToAnyAsyncSequence()
@@ -69,7 +72,13 @@ package actor Ocp1FlyingSocksStreamController: Ocp1ControllerInternal, CustomStr
     address = Self.makeIdentifier(from: socket.socket)
     self.endpoint = endpoint
     self.socket = socket
-    _messages = AsyncThrowingStream.decodingMessages(from: socket.bytes, timeout: endpoint.timeout)
+    let lifetime = Ocp1FlyingSocksSocketLifetime(socket)
+    self.lifetime = lifetime
+    _messages = AsyncThrowingStream.decodingMessages(
+      from: socket.bytes,
+      timeout: endpoint.timeout,
+      onEnd: { lifetime.readEnded() }
+    )
   }
 
   package var heartbeatTime = Duration.seconds(0) {
@@ -82,14 +91,12 @@ package actor Ocp1FlyingSocksStreamController: Ocp1ControllerInternal, CustomStr
     try await socket.write(data)
   }
 
-  private func closeSocket() throws {
-    guard !socketClosed else { return }
-    try socket.close()
-    socketClosed = true
-  }
-
   package func close() async throws {
-    try closeSocket()
+    // Shut the socket down rather than close it. The message loop may be suspended reading
+    // it, as when a keepalive expires, and closing the descriptor under that read would
+    // leave the socket pool waiting on it for good. Shutting it down wakes the read with
+    // end of file, and the descriptor is closed once the message stream has ended.
+    lifetime.shutDown()
 
     keepAliveTask?.cancel()
     keepAliveTask = nil
@@ -109,6 +116,70 @@ package actor Ocp1FlyingSocksStreamController: Ocp1ControllerInternal, CustomStr
 
   private nonisolated var fileDescriptor: Socket.FileDescriptor {
     socket.socket.file
+  }
+}
+
+/// Closes a controller's socket exactly once, and never while its message stream is
+/// suspended reading it. A socket closed under a suspended read leaves the FlyingSocks
+/// socket pool waiting on a descriptor that reports nothing more, and that a socket accepted
+/// later may be given (swhitty/FlyingFox#244). So `shutDown()`, from `close()`, shuts the
+/// socket down, which wakes the read with end of file, and the socket is closed by whichever
+/// comes last of that and the stream ending. The shutdown and the close are both made under
+/// the lock, so neither can reach a descriptor already closed and given to another socket.
+private final class Ocp1FlyingSocksSocketLifetime: Sendable {
+  private struct State {
+    var readEnded = false
+    var shutDown = false
+    var closed = false
+  }
+
+  private let socket: AsyncSocket
+  private let state = Mutex(State())
+
+  init(_ socket: AsyncSocket) {
+    self.socket = socket
+  }
+
+  /// From `close()`: shut the socket down, closing it at once if the stream has ended.
+  func shutDown() {
+    state.withLock { state in
+      guard !state.closed else { return }
+      state.shutDown = true
+      if state.readEnded {
+        state.closed = true
+        try? socket.close()
+      } else {
+        // wakes the read the stream is suspended on; the stream then ends and closes it
+        Self.shutDownBothDirections(socket.socket.file)
+      }
+    }
+  }
+
+  /// From the message stream once it has ended, so that no read is suspended on the socket.
+  func readEnded() {
+    state.withLock { state in
+      state.readEnded = true
+      guard state.shutDown, !state.closed else { return }
+      state.closed = true
+      try? socket.close()
+    }
+  }
+
+  deinit {
+    // if neither got as far as closing it
+    state.withLock { state in
+      guard !state.closed else { return }
+      state.closed = true
+      try? socket.close()
+    }
+  }
+
+  private static func shutDownBothDirections(_ file: Socket.FileDescriptor) {
+    #if canImport(WinSDK)
+    _ = shutdown(file.rawValue, SD_BOTH)
+    #else
+    _ = shutdown(file.rawValue, Int32(SHUT_RDWR))
+    #endif
   }
 }
 
@@ -156,9 +227,11 @@ private extension AsyncThrowingStream
   where Element == Ocp1MessageList,
   Failure == Error
 {
+  /// `onEnd` is called when the stream ends, however it ends, and so has no read suspended.
   static func decodingMessages(
     from bytes: some AsyncBufferedSequence<UInt8>,
-    timeout: Duration
+    timeout: Duration,
+    onEnd: @escaping @Sendable () -> ()
   ) -> Self {
     // one timer for every read on the connection, rather than a sleep per message that the
     // runtime would keep for the whole timeout after the message arrived
@@ -185,10 +258,13 @@ private extension AsyncThrowingStream
           }
         }
       } catch Ocp1Error.pduTooShort {
+        onEnd()
         return nil
       } catch SocketError.disconnected {
+        onEnd()
         throw Ocp1Error.notConnected
       } catch {
+        onEnd()
         throw error
       }
     }

--- a/Tests/SwiftOCADeviceTests/BackendConnectionTests.swift
+++ b/Tests/SwiftOCADeviceTests/BackendConnectionTests.swift
@@ -149,6 +149,56 @@ final class FlyingSocksEndpointCancellationTests: XCTestCase {
   }
 }
 
+// MARK: - FlyingSocks controller close
+
+/// Closing a controller while its message loop is reading, as a keepalive expiry does, must
+/// end the loop. The read has to be woken, not left suspended on a closed descriptor that the
+/// socket pool would never report on again.
+final class FlyingSocksControllerCloseTests: XCTestCase {
+  private actor Flag {
+    var isSet = false
+
+    func set() {
+      isSet = true
+    }
+  }
+
+  func testClosingAControllerWhileItReadsEndsItsMessageLoop() async throws {
+    let device = OcaDevice()
+    let (endpoint, listeningSocket, _) = try await makeTCPEndpoint(device: device)
+    let endpointTask = Task { try await endpoint._run(on: listeningSocket, pool: endpoint.pool) }
+    defer { endpointTask.cancel() }
+
+    var files: [Int32] = [-1, -1]
+    XCTAssertEqual(Darwin.socketpair(AF_UNIX, Darwin.SOCK_STREAM, 0, &files), 0)
+    let peer = Socket(file: .init(rawValue: files[1]))
+    defer { try? peer.close() }
+    let pool = await endpoint.pool
+    let controller = try Ocp1FlyingSocksStreamController(
+      endpoint: endpoint,
+      socket: AsyncSocket(socket: Socket(file: .init(rawValue: files[0])), pool: pool)
+    )
+
+    let loopEnded = Flag()
+    let handling = Task {
+      await controller.handle(for: endpoint)
+      await loopEnded.set()
+    }
+    defer { handling.cancel() }
+    // long enough for the message loop to be suspended reading the socket
+    try await Task.sleep(for: .milliseconds(200))
+
+    try await controller.close()
+
+    let deadline = ContinuousClock.now + .seconds(2)
+    while !(await loopEnded.isSet), ContinuousClock.now < deadline {
+      try await Task.sleep(for: .milliseconds(10))
+    }
+    let ended = await loopEnded.isSet
+    XCTAssertTrue(ended, "closing the controller should end its message loop")
+  }
+}
+
 // MARK: - CFSocket TCP connection tests
 
 final class CFSocketConnectionTests: XCTestCase {


### PR DESCRIPTION
## Summary

When a FlyingSocks controller's keepalive expires, `unlockAndRemove` calls `controller.close()` while the controller's message loop (`handle(for:)`) is suspended reading its socket. `close()` closed the descriptor under that read. Closing a descriptor removes it from kqueue or epoll without waking anyone waiting on it:

- **The expired controller's read never finished.** Neither did its `handle(for:)` task.
- **FlyingFox's socket pool still recorded the descriptor as registered.** So a controller accepted later and given the same descriptor was never woken, and it expired in turn (swhitty/FlyingFox#244). This affects macOS devices, where `Ocp1DeviceEndpoint` is the FlyingSocks stream endpoint.
- **#244 isn't enough on its own.** With it merged, the stale read could be woken by the new controller's data, and consume it.

## Changes

- **`Ocp1FlyingSocksStreamController.close()`** now shuts the socket down with `shutdown(2)`, in both directions, instead of closing it. That wakes the suspended read with end of file, so the message loop ends as it does when the peer closes the connection.
- **The descriptor is closed exactly once,** by whichever comes last:
  - `close()`;
  - the message stream ending, however it ends, which means no read is suspended.

  A small `Mutex`-protected lifetime object tracks this. The `shutdown` and `close` calls are both made while it holds the lock, so neither can reach a descriptor that was already closed and given to another socket. `deinit` closes it if neither got that far.
- **Windows** uses `shutdown(SOCKET, SD_BOTH)`. Everywhere else it's `SHUT_RDWR`.

This works with the FlyingFox we resolve (0.27.1), whether or not #244 is merged.

## Behaviour change

When a keepalive expires, the message loop now ends. `handle(for:)` then calls `unlockAndRemove` for the second time, so `onControllerExpiry` is signalled twice. The Network.framework and IORing controllers already do this, because closing them wakes their pending receive.

## Test

`FlyingSocksControllerCloseTests.testClosingAControllerWhileItReadsEndsItsMessageLoop` does the following:

1. Runs a controller's `handle(for:)` over a `socketpair`, on the endpoint's running socket pool.
2. Calls `close()` while the loop is suspended reading.
3. Expects the loop to end within 2 s.

On macOS, with the fix it passes in 0.23 s. Without it, it fails after 2 s with "closing the controller should end its message loop".

## Test plan

- [x] macOS: `swift build --build-tests` clean, full suite passes (290 tests, 0 failures)
- [x] macOS: the new test fails with the controller change reverted
- [ ] Linux CI (the FlyingSocks controller isn't compiled for non-embedded Linux, which uses IORing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Fq7ie1LzJERrh9uRuZZWE
