### PR TITLE
Shut a FlyingSocks controller's socket down rather than close it

### DIFF
--- a/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingSocksStreamController.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingSocksStreamController.swift
@@ -47,7 +47,6 @@ package actor Ocp1FlyingSocksStreamController: Ocp1ControllerInternal, CustomStr
   private let address: String
   private let socket: AsyncSocket
   private let _messages: AsyncThrowingStream<Ocp1MessageList, Error>
-  private var socketClosed = false
 
   package var messages: AnyAsyncSequence<Ocp1MessageList> {
     _messages.eraseToAnyAsyncSequence()
@@ -82,14 +81,16 @@ package actor Ocp1FlyingSocksStreamController: Ocp1ControllerInternal, CustomStr
     try await socket.write(data)
   }
 
-  private func closeSocket() throws {
-    guard !socketClosed else { return }
-    try socket.close()
-    socketClosed = true
-  }
-
   package func close() async throws {
-    try closeSocket()
+    // A keepalive expiry closes the controller while its message loop is suspended reading
+    // the socket. Closing the descriptor under that read would never wake it, so shut the
+    // socket down instead: the read sees end of file and the loop ends, as FlyingFox expects
+    // before a socket is closed. The descriptor is closed when the controller is released.
+    #if canImport(WinSDK)
+    _ = shutdown(socket.socket.file.rawValue, SD_BOTH)
+    #else
+    _ = shutdown(socket.socket.file.rawValue, Int32(SHUT_RDWR))
+    #endif
 
     keepAliveTask?.cancel()
     keepAliveTask = nil
@@ -97,6 +98,7 @@ package actor Ocp1FlyingSocksStreamController: Ocp1ControllerInternal, CustomStr
 
   deinit {
     keepAliveTask?.cancel()
+    try? socket.close()
   }
 
   package nonisolated var identifier: String {

--- a/Tests/SwiftOCADeviceTests/BackendConnectionTests.swift
+++ b/Tests/SwiftOCADeviceTests/BackendConnectionTests.swift
@@ -149,6 +149,66 @@ final class FlyingSocksEndpointCancellationTests: XCTestCase {
   }
 }
 
+// MARK: - FlyingSocks controller close
+
+/// Closing a controller while its message loop is reading, as a keepalive expiry does, must
+/// end the loop. The read has to be woken, not left suspended on a closed descriptor that the
+/// socket pool would never report on again. The descriptor is closed once the controller is
+/// released.
+final class FlyingSocksControllerCloseTests: XCTestCase {
+  private actor Flag {
+    var isSet = false
+
+    func set() {
+      isSet = true
+    }
+  }
+
+  func testClosingAControllerWhileItReadsEndsItsMessageLoop() async throws {
+    let device = OcaDevice()
+    let (endpoint, listeningSocket, _) = try await makeTCPEndpoint(device: device)
+    let endpointTask = Task { try await endpoint._run(on: listeningSocket, pool: endpoint.pool) }
+    defer { endpointTask.cancel() }
+
+    var files: [Int32] = [-1, -1]
+    XCTAssertEqual(Darwin.socketpair(AF_UNIX, Darwin.SOCK_STREAM, 0, &files), 0)
+    let peer = Socket(file: .init(rawValue: files[1]))
+    defer { try? peer.close() }
+    let pool = await endpoint.pool
+
+    let loopEnded = Flag()
+    weak var releasedController: Ocp1FlyingSocksStreamController?
+    do {
+      let controller = try Ocp1FlyingSocksStreamController(
+        endpoint: endpoint,
+        socket: AsyncSocket(socket: Socket(file: .init(rawValue: files[0])), pool: pool)
+      )
+      releasedController = controller
+      Task {
+        await controller.handle(for: endpoint)
+        await loopEnded.set()
+      }
+      // long enough for the message loop to be suspended reading the socket
+      try await Task.sleep(for: .milliseconds(200))
+
+      try await controller.close()
+    }
+
+    let deadline = ContinuousClock.now + .seconds(2)
+    while !(await loopEnded.isSet), ContinuousClock.now < deadline {
+      try await Task.sleep(for: .milliseconds(10))
+    }
+    let ended = await loopEnded.isSet
+    XCTAssertTrue(ended, "closing the controller should end its message loop")
+
+    while releasedController != nil, ContinuousClock.now < deadline {
+      try await Task.sleep(for: .milliseconds(10))
+    }
+    XCTAssertNil(releasedController, "the controller should be released once its loop has ended")
+    XCTAssertEqual(fcntl(files[0], F_GETFD), -1, "releasing the controller should close its socket")
+  }
+}
+
 // MARK: - CFSocket TCP connection tests
 
 final class CFSocketConnectionTests: XCTestCase {


### PR DESCRIPTION
Supersedes #71 with a smaller change.

## Summary

When a FlyingSocks controller's keepalive expires, `unlockAndRemove` calls `controller.close()` while the controller's message loop is still suspended reading its socket. `close()` closed the descriptor under that read, and closing a descriptor drops it from kqueue or epoll without waking the read. So:
- the expired controller's loop never ended;
- the socket pool kept the descriptor registered, which can strand a later connection given the same descriptor (swhitty/FlyingFox#244).

FlyingFox itself never closes a socket that is being read. `HTTPServer` closes a connection only after its read loop has ended.

## Change

- `close()` now calls `shutdown(2)` in both directions instead of `close(2)`. That wakes the read with end of file, so the loop ends the way it does when the peer disconnects.
- The controller's `deinit` closes the descriptor. It runs once the loop and its tasks have finished and the endpoint has dropped the controller, so nothing is reading the socket by then.

The only visible difference is a second `onControllerExpiry` when a keepalive expires, because the loop's own end calls `unlockAndRemove` again. The Network.framework and IORing controllers already do this.

## Test

`FlyingSocksControllerCloseTests.testClosingAControllerWhileItReadsEndsItsMessageLoop` does the following:
1. Runs a controller's `handle(for:)` over a `socketpair`.
2. Calls `close()` while the loop is reading.
3. Expects the loop to end, the controller to be released, and its descriptor to be closed, all within 2 s.

On macOS, with the fix it passes in 0.22 s. With the controller change reverted, it fails after 2 s: the loop doesn't end and the controller isn't released.

## Test plan

- [x] macOS: `swift build --build-tests` is clean and the full suite passes (290 tests, 0 failures)
- [x] macOS: the new test fails with the controller change reverted
- [ ] Windows CI builds the `SD_BOTH` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Fq7ie1LzJERrh9uRuZZWE
