### PR TITLE
Take IORingSwift 2.0.0 and drop the ECANCELED workarounds

### DIFF
--- a/Examples/OCADevice/DeviceApp.swift
+++ b/Examples/OCADevice/DeviceApp.swift
@@ -15,6 +15,9 @@
 //
 
 import Foundation
+#if canImport(IORing)
+import IORing
+#endif
 import SwiftOCA
 import SwiftOCADevice
 #if NonEmbeddedBuild
@@ -65,6 +68,10 @@ public enum DeviceApp {
   #endif
 
   public static func main() async throws {
+    #if canImport(IORing)
+    // the executor's threads never exit, and every task runs there: see IORingSwift's README
+    try IORing.installExecutor(policy: .global)
+    #endif
     var listenAddress = sockaddr_in()
     listenAddress.sin_family = sa_family_t(AF_INET)
     #if canImport(WinSDK)

--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,8 @@ if EnableASAN {
 }
 
 var PlatformPackageDependencies: [Package.Dependency] = []
+// the executor OCADevice selects, on the platform that has it
+var OCADevicePlatformDependencies: [Target.Dependency] = []
 var PlatformTargetDependencies: [Target.Dependency] = []
 
 // Android NSD support, gated on SWIFTOCA_ANDROID_NSD.
@@ -108,7 +110,8 @@ PlatformTargetDependencies += [
 ]
 
 #if os(Linux)
-PlatformPackageDependencies += [.package(url: "https://github.com/PADL/IORingSwift", from: "1.0.0")]
+PlatformPackageDependencies += [.package(url: "https://github.com/PADL/IORingSwift", from: "2.0.0")]
+OCADevicePlatformDependencies += [.product(name: "IORing", package: "IORingSwift")]
 
 PlatformTargetDependencies += [
   .target(
@@ -335,7 +338,7 @@ let CommonTargets: [Target] = [
       "SwiftOCADevice",
       .target(name: "SwiftOCASecure", condition: .when(traits: ["NonEmbeddedBuild"])),
       .target(name: "SwiftOCASecureDevice", condition: .when(traits: ["NonEmbeddedBuild"])),
-    ],
+    ] + OCADevicePlatformDependencies,
     path: "Examples/OCADevice",
     swiftSettings: [
       .unsafeFlags(ASANSwiftFlags),

--- a/Sources/SwiftOCA/OCF/Errors.swift
+++ b/Sources/SwiftOCA/OCF/Errors.swift
@@ -69,7 +69,6 @@ public enum Ocp1Error: Error, Equatable {
   case remoteDeviceResolutionFailed
   case responseParameterOutOfRange
   case responseTimeout
-  case retryOperation
   case serviceResolutionFailed
   /// service browsing is not available on this platform, or failed to start
   case serviceBrowsingUnavailable

--- a/Sources/SwiftOCA/OCP.1/Backend/Ocp1IORingConnection.swift
+++ b/Sources/SwiftOCA/OCP.1/Backend/Ocp1IORingConnection.swift
@@ -45,8 +45,6 @@ package extension Errno {
     switch self {
     case .connectionRefused, .connectionReset, .brokenPipe:
       Ocp1Error.notConnected
-    case .canceled:
-      Ocp1Error.retryOperation
     default:
       self
     }

--- a/Sources/SwiftOCA/OCP.1/Ocp1Connection+Connect.swift
+++ b/Sources/SwiftOCA/OCP.1/Ocp1Connection+Connect.swift
@@ -60,8 +60,6 @@ private extension Errno {
       fallthrough
     case .brokenPipe:
       fallthrough
-    case .canceled:
-      fallthrough // for IORing
     case .socketShutdown:
       fallthrough
     case .connectionAbort:

--- a/Sources/SwiftOCA/OCP.1/Ocp1ConnectionMonitor.swift
+++ b/Sources/SwiftOCA/OCP.1/Ocp1ConnectionMonitor.swift
@@ -401,9 +401,7 @@ extension Ocp1Connection.Monitor {
           repeat {
             try Task.checkCancellation()
             guard let self else { return }
-            do {
-              try await receiveMessage(connection)
-            } catch Ocp1Error.retryOperation {}
+            try await receiveMessage(connection)
           } while true
         }
         if heartbeatTime > .zero {

--- a/Sources/SwiftOCADevice/OCP.1/Backend/IORing/Ocp1IORingDeviceEndpoint.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/IORing/Ocp1IORingDeviceEndpoint.swift
@@ -185,8 +185,6 @@ public final class Ocp1IORingStreamDeviceEndpoint: Ocp1IORingDeviceEndpoint,
           )
           break
         }
-      } catch let error where error as? Errno == Errno.canceled {
-        logger.debug("received cancelation, trying to accept() again")
       } catch {
         logger.info("received error \(error), bailing")
         break
@@ -368,7 +366,7 @@ public class Ocp1IORingDatagramDeviceEndpoint: Ocp1IORingDeviceEndpoint,
         }
       } catch let error as Errno {
         // if the IORing has not being sized properly we may receive noBufferSpace
-        guard error == Errno.canceled || error == Errno.noBufferSpace else { throw error }
+        guard error == Errno.noBufferSpace else { throw error }
       } catch {
         logger
           .error(

--- a/Sources/SwiftOCASecure/OCP.1/Backend/Ocp1OpenSSLConnection.swift
+++ b/Sources/SwiftOCASecure/OCP.1/Backend/Ocp1OpenSSLConnection.swift
@@ -36,8 +36,6 @@ fileprivate extension Errno {
     switch self {
     case .connectionRefused, .connectionReset, .brokenPipe:
       Ocp1Error.notConnected
-    case .canceled:
-      Ocp1Error.retryOperation
     default:
       self
     }

--- a/Sources/SwiftOCASecure/OCP.1/Backend/Ocp1OpenSSLDTLSConnection.swift
+++ b/Sources/SwiftOCASecure/OCP.1/Backend/Ocp1OpenSSLDTLSConnection.swift
@@ -36,8 +36,6 @@ fileprivate extension Errno {
     switch self {
     case .connectionRefused, .connectionReset, .brokenPipe:
       Ocp1Error.notConnected
-    case .canceled:
-      Ocp1Error.retryOperation
     default:
       self
     }

--- a/Sources/SwiftOCASecureDevice/OCP.1/Backend/OpenSSL/Ocp1OpenSSLDTLSDeviceEndpoint.swift
+++ b/Sources/SwiftOCASecureDevice/OCP.1/Backend/OpenSSL/Ocp1OpenSSLDTLSDeviceEndpoint.swift
@@ -214,7 +214,7 @@ public final class Ocp1OpenSSLDTLSDeviceEndpoint: Ocp1IORingDeviceEndpoint,
           spawnPeerIngest(payload: payload, controller: controller, peerAddress: peerAddress)
         }
       } catch let error as Errno {
-        guard error == .canceled || error == .noBufferSpace else { throw error }
+        guard error == .noBufferSpace else { throw error }
       } catch {
         logger.error(
           "unexpected error \(error) in \(type(of: self)) on \(address._presentationAddress); no longer servicing"

--- a/Sources/SwiftOCASecureDevice/OCP.1/Backend/OpenSSL/Ocp1OpenSSLStreamDeviceEndpoint.swift
+++ b/Sources/SwiftOCASecureDevice/OCP.1/Backend/OpenSSL/Ocp1OpenSSLStreamDeviceEndpoint.swift
@@ -179,8 +179,6 @@ public final class Ocp1OpenSSLStreamDeviceEndpoint: Ocp1IORingDeviceEndpoint,
           )
           break
         }
-      } catch let error where error as? Errno == Errno.canceled {
-        logger.debug("received cancelation, trying to accept() again")
       } catch {
         logger.info("received error \(error), bailing")
         break


### PR DESCRIPTION
IORingSwift 2.0.0 runs requests on threads that never exit, so the kernel no longer cancels one whose submitting thread has gone. This removes the workarounds that grew around that: the accept loops that retried on `ECANCELED`, the datagram loops that swallowed it, the reconnect on it in `_isRecoverableConnectionError`, and `Ocp1Error.retryOperation` with the mappings that produced it. The OCADevice example selects the executor as its global one (`IORing.installExecutor(policy: .global)`, the fast path) before its first ring, as IORingSwift's README asks of I/O-bound programs.

Merge after IORingSwift 2.0.0 is tagged (PADL/IORingSwift#11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SekzA9KbmXB26GUsLuS4PQ