### PR TITLE
CI: build with Swift 6.3, which IORingSwift 2.0.0 needs

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -32,7 +32,7 @@ jobs:
 
   linux:
     runs-on: ubuntu-24.04
-    container: swift:6.2
+    container: swift:6.3
     steps:
       - name: Packages
         run: |


### PR DESCRIPTION
The workflow's `swift:6.2` container cannot resolve IORingSwift 2.0.0 (tools-version 6.3, for its executor SPI): "2.0.0 contains incompatible tools version (6.3.0)". Same change as PADL/IORingSwift#11's CI commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SekzA9KbmXB26GUsLuS4PQ