### PR TITLE
Report the matrix's real size bounds

### DIFF
--- a/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/BlocksAndMatrices/Matrix.swift
+++ b/Sources/SwiftOCADevice/OCC/ControlClasses/Workers/BlocksAndMatrices/Matrix.swift
@@ -365,7 +365,9 @@ open class OcaMatrix<Member: OcaRoot>: OcaWorker {
   )
   public var portsPerColumn: OcaUint8 = 0
 
-  /// GetSize's six output parameters (a record, so each is counted and named)
+  /// GetSize's six output parameters, spelled as AES70-2 names them; the client
+  /// decodes the same shape as `OcaBoundedVector2D`. A record, so each parameter is
+  /// counted and named. The size is derived from the grid, so no property holds it.
   struct MatrixSize<T: Codable>: Ocp1ParametersReflectable {
     var xSize: T
     var ySize: T
@@ -387,12 +389,14 @@ open class OcaMatrix<Member: OcaRoot>: OcaWorker {
         x: OcaMatrixCoordinate(members.nX),
         y: OcaMatrixCoordinate(members.nY)
       )
+      // the grid is allocated at construction and SetSize (3.4) is not implemented,
+      // so each axis's bounds are its current extent
       let matrixSize = MatrixSize<OcaMatrixCoordinate>(
         xSize: size.x,
         ySize: size.y,
-        minXSize: 0,
+        minXSize: size.x,
         maxXSize: size.x,
-        minYSize: 0,
+        minYSize: size.y,
         maxYSize: size.y
       )
       return try controller.encodeResponse(matrixSize)

--- a/Tests/SwiftOCADeviceTests/MatrixTests.swift
+++ b/Tests/SwiftOCADeviceTests/MatrixTests.swift
@@ -105,7 +105,8 @@ final class MatrixTests: XCTestCase {
     )
   }
 
-  /// GetSize (3.3) returns six values: the size and each axis's bounds.
+  /// GetSize (3.3) returns six values: the size and each axis's bounds. The grid is
+  /// allocated at construction, so each bound is the axis's current extent.
   func testSizeCarriesEachAxisBounds() async throws {
     let h = try await makeHarness()
     defer { Task { await h.tearDown() } }
@@ -113,10 +114,30 @@ final class MatrixTests: XCTestCase {
     let size = try await h.matrix.$size._getValue(h.matrix, flags: [])
     XCTAssertEqual(size.x, Self.columns)
     XCTAssertEqual(size.y, Self.rows)
-    XCTAssertEqual(size.minX, 0)
+    XCTAssertEqual(size.minX, Self.columns)
     XCTAssertEqual(size.maxX, Self.columns)
-    XCTAssertEqual(size.minY, 0)
+    XCTAssertEqual(size.minY, Self.rows)
     XCTAssertEqual(size.maxY, Self.rows)
+  }
+
+  /// SetSize (3.4) is refused rather than silently ignored, and leaves the size alone.
+  func testResizeIsRefused() async throws {
+    let h = try await makeHarness()
+    defer { Task { await h.tearDown() } }
+
+    do {
+      try await h.matrix.sendCommandRrq(
+        methodID: OcaMethodID("3.4"),
+        parameters: OcaVector2D<OcaMatrixCoordinate>(x: Self.columns + 1, y: Self.rows + 1)
+      )
+      XCTFail("a resize request was accepted")
+    } catch let error as Ocp1Error {
+      XCTAssertEqual(error, .status(.notImplemented))
+    }
+
+    let size = try await h.matrix.$size._getValue(h.matrix, flags: [])
+    XCTAssertEqual(size.x, Self.columns)
+    XCTAssertEqual(size.y, Self.rows)
   }
 
   func testMembers() async throws {


### PR DESCRIPTION
Follow-up to #75, which fixed `OcaMatrix.GetSize` on the client but left two device-side defects.

**The reported bounds were wrong.** AES70-2 defines `3.3 GetSize` as returning `xSize, ySize, minXSize, maxXSize, minYSize, maxYSize`. The device sent a minimum of zero and a maximum of the current size, which tells a controller the matrix may shrink to nothing but never grow. The grid is allocated at construction and `3.4 SetSize` is not implemented, so each axis's bounds are now its current extent.

**A resize attempt is refused, not ignored.** `3.4` has no case in the matrix's handler, so it falls through Worker and Root to the property accessor lookup, which finds no property claiming that method and throws `NotImplemented`. That was already correct; this adds a test pinning it, since the client can now send a well-formed two-value setter.

**No device property wrapper was added, deliberately.** The client decodes six values through the new `OcaBoundedVectorProperty`. The device has no counterpart because device wrappers are stored value holders backed by a subject, while the matrix's size is derived from the `members` grid, which is a plain stored property with no notification hook. A wrapper would duplicate state it could not keep in sync, so the `handleCommand` override stays and the private record keeps the parameter names the standard defines.

Tests: 156 passing, no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEp5uMc25rtK6dLRo2ZGaX
