### PR TITLE
Carry method parameters in one payload, not one per format

### DIFF
--- a/Sources/SwiftOCA/OCF/Messages/Command.swift
+++ b/Sources/SwiftOCA/OCF/Messages/Command.swift
@@ -25,32 +25,46 @@ import Foundation
 /// values encoded in `parameterData`; for OCP.2, the parsed JSON `Parameters` object,
 /// which `parameterData` serialises on demand, and `parameterCount` is unused.
 public struct Ocp1Parameters: Codable, Sendable {
+  /// One payload rather than one per format, so an OCP.1 connection carries no JSON
+  /// object to initialise, retain and release on every message it decodes.
+  private enum Storage: Sendable {
+    case ocp1(Data)
+    #if NonEmbeddedBuild
+    case ocp2([String: any Sendable])
+    #endif
+  }
+
   public let parameterCount: OcaUint8
-  public let format: OcaParameterFormat
-  private let _ocp1Data: Data
-  #if NonEmbeddedBuild
-  private let _ocp2Object: [String: any Sendable]
-  #endif
+  private let storage: Storage
+
+  public var format: OcaParameterFormat {
+    switch storage {
+    case .ocp1:
+      return .ocp1
+    #if NonEmbeddedBuild
+    case .ocp2:
+      return .ocp2
+    #endif
+    }
+  }
 
   public var parameterData: Data {
-    switch format {
-    case .ocp1:
-      return _ocp1Data
-    case .ocp2:
-      #if NonEmbeddedBuild
+    switch storage {
+    case let .ocp1(data):
+      return data
+    #if NonEmbeddedBuild
+    case let .ocp2(object):
       // the object was parsed or encoded as valid JSON, so serialising cannot fail
-      return _ocp2Object.isEmpty ? Data() : (try? Ocp2JSON.serialize(_ocp2Object)) ?? Data()
-      #else
-      return Data()
-      #endif
+      return object.isEmpty ? Data() : (try? Ocp2JSON.serialize(object)) ?? Data()
+    #endif
     }
   }
 
   /// The OCP.2 `Parameters` object, or `nil` on OCP.1.
   public var ocp2Parameters: [String: Any]? {
     #if NonEmbeddedBuild
-    guard format == .ocp2 else { return nil }
-    return _ocp2Object
+    guard case let .ocp2(object) = storage else { return nil }
+    return object
     #else
     return nil
     #endif
@@ -58,20 +72,14 @@ public struct Ocp1Parameters: Codable, Sendable {
 
   public init(parameterCount: OcaUint8, parameterData: Data) {
     self.parameterCount = parameterCount
-    _ocp1Data = parameterData
-    format = .ocp1
-    #if NonEmbeddedBuild
-    _ocp2Object = [:]
-    #endif
+    storage = .ocp1(parameterData)
   }
 
   #if NonEmbeddedBuild
   /// OCP.2 parameters from the parsed `Parameters` object.
   public init(ocp2Parameters object: [String: Any]) {
     parameterCount = 0
-    _ocp1Data = Data()
-    _ocp2Object = Ocp2JSON.sendableObject(object)
-    format = .ocp2
+    storage = .ocp2(Ocp2JSON.sendableObject(object))
   }
 
   /// OCP.2 parameters from a serialised JSON object; empty data is no parameters.
@@ -86,15 +94,13 @@ public struct Ocp1Parameters: Codable, Sendable {
 
   /// `true` when no parameters are carried, in either format.
   public var isEmpty: Bool {
-    switch format {
-    case .ocp1:
-      return parameterCount == 0 && _ocp1Data.isEmpty
-    case .ocp2:
-      #if NonEmbeddedBuild
-      return _ocp2Object.isEmpty
-      #else
-      return true
-      #endif
+    switch storage {
+    case let .ocp1(data):
+      return parameterCount == 0 && data.isEmpty
+    #if NonEmbeddedBuild
+    case let .ocp2(object):
+      return object.isEmpty
+    #endif
     }
   }
 


### PR DESCRIPTION
`Ocp1Parameters` held the OCP.1 bytes, an OCP.2 object and a `format` field side by
side. Parameters are one of those two things and never both, so the flat layout made
invalid states representable and gave `format` a second source of truth. It also cost:
decoding constructs one of these per message, so every message on an OCP.1 connection
initialised, retained and released a dictionary it never read.

A private `Storage` enum now carries either payload, and `format` follows from the case.
The public surface, the initialisers and the `Codable` conformance are unchanged.

## Measurements

OCAPerfBench, codec mode, 9 rounds, governor `performance`, runs pinned to two physical
cores. `a` is the commit before OCP.2 merged (39522df4).

The OCP.2 merge regressed OCP.1 PDU decoding; all twelve rows were slower:

| benchmark | before this PR |
|---|---|
| decodePdu.response.8.8k | +14.2% |
| decodePdu.command.8.8k | +12.1% |
| decodePdu.command.8.small | +9.2% |
| decodePdu.response.1.small | +8.6% |
| decodePdu.response.8.small | +7.0% |
| decodePdu.response.1.1k | +6.5% |

With this PR, measured directly against that same pre-merge baseline, every one of the
twelve is back inside the noise band, the worst at +4.0% and most under ±2%. Encoding
came out slightly ahead, between -1.6% and -4.3%. End-to-end round trips over local, TCP
and UDP stayed within noise throughout, as did peak memory.

## A note on the blob rows

`decode.blob*` moves by 7-13% whenever this struct is touched. That is not caused by this
change: a control commit that only reorders the existing fields, altering offsets and
nothing else, reproduces it (+12.6%, +10.7%, +7.2%) while leaving the decode regression
in place. A second control that changes only a comment leaves those rows flat. The rows
track this struct's layout under whole-module optimisation, not its semantics.

## Tests

274 passing, no failures, covering the OCP.2 suites, loopback, backends, batching,
malformed PDUs, subscriptions, notifications, matrix and media transport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEp5uMc25rtK6dLRo2ZGaX