### PR TITLE
Cast decoder metatypes out of line to dodge a SIL optimiser assertion

### DIFF
--- a/Sources/SwiftOCA/OCP.2/Ocp2Decoder.swift
+++ b/Sources/SwiftOCA/OCP.2/Ocp2Decoder.swift
@@ -21,6 +21,14 @@ import Foundation
 /// case-insensitively, a single-parameter object is accepted whatever its member is
 /// called, enumerations may be spelled by name or number, and an integer may arrive
 /// as a string.
+/// Casts a metatype to a protocol existential out of line, on the erased type: the
+/// optimiser folds the same cast on a specialised conforming metatype into an
+/// existential with the wrong conformances and asserts (Swift 6.3.3, -O).
+@inline(never)
+private func erasedCast<U>(_ type: Any.Type, to _: U.Type) -> U? {
+  type as? U
+}
+
 public struct Ocp2Decoder {
   public var userInfo: [CodingUserInfoKey: Any] = [:]
 
@@ -55,7 +63,7 @@ public struct Ocp2Decoder {
     if object.count == 1, let json = object.values.first {
       return try state.decode(type, from: json, codingPath: [])
     }
-    if object.isEmpty, let optional = type as? any ExpressibleByNilLiteral.Type {
+    if object.isEmpty, let optional = erasedCast(type, to: (any ExpressibleByNilLiteral.Type).self) {
       return optional.init(nilLiteral: ()) as! T
     }
     throw Ocp1Error.status(.parameterError)
@@ -120,13 +128,15 @@ final class Ocp2DecodingState {
     if type == OcaOrganizationID.self {
       return try OcaOrganizationID(Ocp2JSON.string(from: json)) as! T
     }
-    if let blobType = type as? any Ocp1BlobRepresentable.Type {
+    if let blobType = erasedCast(type, to: (any Ocp1BlobRepresentable.Type).self) {
       return try blobType.init(blobData: Ocp2JSON.data(from: json)) as! T
     }
-    if let mapType = type as? any Ocp1MapRepresentable.Type {
+    if let mapType = erasedCast(type, to: (any Ocp1MapRepresentable.Type).self) {
       return try mapType.init(ocp2State: self, json: json, codingPath: codingPath) as! T
     }
-    if let string = json as? String, let enumType = type as? any CaseIterable.Type {
+    if let string = json as? String,
+       let enumType = erasedCast(type, to: (any CaseIterable.Type).self)
+    {
       // an enumeration spelled by name: match the Swift case name
       if let value = Self.enumCase(named: string, of: enumType) as? T {
         return value


### PR DESCRIPTION
The first aarch64 release build to include OCP.2 code aborts the compiler. Two recipes in the Yocto image (`ocad`, `inferno-ui`) fail identically while compiling the SwiftOCA module:

```
swift-frontend: .../lib/SIL/IR/SILInstructions.cpp:2334: swift::InitExistentialMetatypeInst::InitExistentialMetatypeInst(...):
Assertion `layout.getProtocols().size() == conformances.size()' failed.
4. While running pass SILFunctionTransform "SILCombine" on SILFunction
   generic specialization <Swift.String?> of SwiftOCA.Ocp2Decoder.decodeParameters<A where A: Decodable>(_: A.Type, from: [String : Any]?, parameterNames: [String]?) throws -> A
```

Target `aarch64-oe-linux-gnu`, `-O`, Swift 6.3.3. This is a compiler bug, not a source error: the optimiser folds `type as? any ExpressibleByNilLiteral.Type` on the specialised `Optional` metatype into an `init_existential_metatype` whose conformance list does not match the existential's layout. x86_64 release builds of the same source never aborted all day.

## Change

`Ocp2Decoder.swift` has four casts of a generic metatype to a protocol existential metatype whose result is then used: to `ExpressibleByNilLiteral`, `Ocp1BlobRepresentable`, `Ocp1MapRepresentable` and `CaseIterable`. Any conforming specialisation is foldable the same way, and blobs and enums are decoded constantly. All four now go through one `@inline(never)` helper that performs the cast on the erased `Any.Type`, so the specialised body has nothing to fold. Erasing to `Any.Type` at the call site involves no protocols, so the assertion holds trivially there.

No behaviour change; the cast is dynamic either way.

## Validation

- Applied to the SwiftOCA checkout inside ocad's Yocto work directory and recompiled with the cross toolchain: `Build complete`, no assertion. The identical recipe recompiled twice unpatched aborted deterministically at the same symbol.
- Native: fresh worktree builds; OCP.2, loopback, backend, malformed-PDU, batching and media transport suites pass, 125 tests, no failures.

Worth filing upstream with the assertion and symbol above; this change is the workaround, not the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEp5uMc25rtK6dLRo2ZGaX