### PR TITLE
Add BENCH_PROTOCOL to OCAPerfBench, to compare OCP.1 with OCP.2

### DIFF
--- a/Examples/OCAPerfBench/PerfBench.swift
+++ b/Examples/OCAPerfBench/PerfBench.swift
@@ -35,6 +35,12 @@ typealias BenchDatagramDeviceEndpoint = Ocp1IORingDatagramDeviceEndpoint
 typealias BenchDatagramDeviceEndpoint = Ocp1FlyingSocksDatagramDeviceEndpoint
 #endif
 
+/// OCP.1 (default) or OCP.2, selected with BENCH_PROTOCOL=ocp2. Both ends must agree,
+/// so it is threaded into every endpoint and every connection below.
+let benchProtocol: OcaControlProtocol =
+  ProcessInfo.processInfo.environment["BENCH_PROTOCOL"] == "ocp2" ? .ocp2 : .ocp1
+let benchProtocolLabel = benchProtocol == .ocp2 ? "ocp2" : "ocp1"
+
 nonisolated(unsafe) var sink: UInt64 = 0
 
 // MARK: - measurement
@@ -47,7 +53,7 @@ private func nanoseconds(_ d: Duration) -> Double {
 private func report(_ name: String, _ nsPerOp: [Double]) {
   let s = nsPerOp.sorted()
   let figures = [s.first ?? 0, s[s.count / 2], s.last ?? 0].map { String(format: "%.1f", $0) }
-  print((["RESULT", name] + figures + ["\(s.count)"]).joined(separator: "\t"))
+  print((["RESULT", "\(benchProtocolLabel).\(name)"] + figures + ["\(s.count)"]).joined(separator: "\t"))
   // flush every stream: on Glibc `stdout` is a global var, which Swift 6 rejects as a
   // data race to name
   fflush(nil)
@@ -229,14 +235,26 @@ private let getDeviceName = Ocp1Command(
 
 private let benchBlockONo: OcaONo = 0x0001_0001
 
-/// SetLabel on the bench block: a large command, an empty response.
+/// SetLabel on the bench block: a large command, an empty response. The parameters must be
+/// encoded in the protocol the connection speaks: OCP.1 positional bytes cannot be framed as
+/// OCP.2, which rejects them rather than passing a blob through. OcaWorker.label declares no
+/// ocp2SetName, so its wire name is derived from the property: `Label`.
 private func setLabel(_ text: String) throws -> Ocp1Command {
-  try Ocp1Command(
+  let parameters: OcaParameters
+  switch benchProtocol {
+  case .ocp1:
+    parameters = try OcaParameters(parameterCount: 1, parameterData: Ocp1Encoder().encode(text))
+  case .ocp2:
+    parameters = try OcaParameters(
+      ocp2Parameters: Ocp2Encoder().encodeParameters(text, parameterNames: ["Label"])
+    )
+  }
+  return Ocp1Command(
     commandSize: 0,
     handle: 0,
     targetONo: benchBlockONo,
     methodID: OcaMethodID("2.9"),
-    parameters: OcaParameters(parameterCount: 1, parameterData: Ocp1Encoder().encode(text))
+    parameters: parameters
   )
 }
 
@@ -309,10 +327,13 @@ func withConnection(
 ) async throws {
   switch transport {
   case "local":
-    let endpoint = try await OcaLocalDeviceEndpoint(device: device)
+    let endpoint = try await OcaLocalDeviceEndpoint(device: device, controlProtocol: benchProtocol)
     let endpointTask = Task { do { try await endpoint.run() } catch {} }
     defer { endpointTask.cancel() }
-    let connection = await OcaLocalConnection(endpoint)
+    let connection = await OcaLocalConnection(
+      endpoint,
+      options: Ocp1ConnectionOptions(controlProtocol: benchProtocol)
+    )
     try await connection.connect()
     try await body(connection)
     try await connection.disconnect()
@@ -321,14 +342,15 @@ func withConnection(
     let endpoint = try await Ocp1DeviceEndpoint(
       address: localhostAddress(port: port),
       timeout: .seconds(5),
-      device: device
+      device: device,
+      controlProtocol: benchProtocol
     )
     let endpointTask = Task { do { try await endpoint.run() } catch {} }
     defer { endpointTask.cancel() }
     try await Task.sleep(for: .milliseconds(500))
     let connection = try await Ocp1TCPConnection(
       deviceAddress: localhostAddress(port: port),
-      options: Ocp1ConnectionOptions()
+      options: Ocp1ConnectionOptions(controlProtocol: benchProtocol)
     )
     try await connection.connect()
     try await body(connection)
@@ -338,14 +360,15 @@ func withConnection(
     let endpoint = try await BenchDatagramDeviceEndpoint(
       address: localhostAddress(port: port),
       timeout: .seconds(5),
-      device: device
+      device: device,
+      controlProtocol: benchProtocol
     )
     let endpointTask = Task { do { try await endpoint.run() } catch {} }
     defer { endpointTask.cancel() }
     try await Task.sleep(for: .milliseconds(500))
     let connection = try await Ocp1UDPConnection(
       deviceAddress: localhostAddress(port: port),
-      options: Ocp1ConnectionOptions()
+      options: Ocp1ConnectionOptions(controlProtocol: benchProtocol)
     )
     try await connection.connect()
     try await body(connection)
@@ -434,7 +457,7 @@ private func profileLoop(
     inSlice += 1
     total += 1
   }
-  print("PROFILE\t\(total) round trips in \(seconds)s\t\(transport)")
+  print("PROFILE\t\(total) round trips in \(seconds)s\t\(transport)\t\(benchProtocolLabel)")
 }
 
 /// Round-trip time from the moment of connection, in consecutive blocks of
@@ -488,10 +511,15 @@ func runNotificationBenchmark(
   _ deviceBlock: SwiftOCADevice.OcaBlock<SwiftOCADevice.OcaRoot>,
   sets: Int
 ) async throws {
-  let endpoint = try await OcaLocalDeviceEndpoint(device: device)
+  // this benchmark makes its own pair rather than going through withConnection, so it must
+  // select the protocol too, else it silently measures OCP.1 whatever BENCH_PROTOCOL says
+  let endpoint = try await OcaLocalDeviceEndpoint(device: device, controlProtocol: benchProtocol)
   let endpointTask = Task { do { try await endpoint.run() } catch {} }
   defer { endpointTask.cancel() }
-  let connection = await OcaLocalConnection(endpoint)
+  let connection = await OcaLocalConnection(
+    endpoint,
+    options: Ocp1ConnectionOptions(controlProtocol: benchProtocol)
+  )
   try await connection.connect()
 
   let clientBlock: SwiftOCA.OcaBlock = try await connection.resolve(


### PR DESCRIPTION
`OCAPerfBench` spoke OCP.1 only, so there was no way to compare the two protocols. `BENCH_PROTOCOL=ocp2` now selects the protocol on **both** ends — every device endpoint and every connection takes it, including the pair `runNotificationBenchmark` constructs for itself, which otherwise silently measures OCP.1 whatever is asked for. `setLabel` builds its parameters per protocol, since OCP.1 positional bytes cannot be framed as OCP.2: `Ocp2Message.parametersObject` rejects them rather than passing a blob through. Each `RESULT` is labelled with the protocol so two runs can be compared directly.

One file, +41/−13, no library changes.

## Measured

Median ns per round trip, three alternating rounds, pinned to cores 8–15, median of per-run medians. The protocol really switches: the wire prefixes come out balanced, `oca/` for OCP.1 against `ocajson/` for OCP.2.

| benchmark | OCP.1 | OCP.2 | ratio |
|---|---:|---:|---:|
| local `getDeviceName` (scalar) | 17,563 | 69,629 | 3.96x |
| local `getLabel.1k` | 21,758 | 129,229 | 5.94x |
| local `setLabel.1k` | 25,467 | 105,987 | 4.16x |
| local `notify.propertyChanged` | 11,728 | 64,760 | 5.52x |
| tcp `getDeviceName` | 44,288 | 99,474 | 2.25x |
| tcp `getLabel.1k` | 48,752 | 164,984 | 3.38x |
| tcp `setLabel.1k` | 53,540 | 137,305 | 2.56x |
| udp `getDeviceName` | 29,535 | 94,117 | 3.19x |
| udp `getLabel.1k` | 34,022 | 164,641 | 4.84x |
| udp `setLabel.1k` | 38,313 | 130,676 | 3.41x |
| tcp throughput | 23,307 rt/s | 10,437 rt/s | 0.45x |
| peak RSS | 37.2 MiB | 38.9 MiB | 1.05x |

The penalty is largest on the `local` transport (4–6x), which is the coding path with the socket removed, and dilutes to 2.3–3.4x over TCP where syscall cost absorbs it — so roughly 50–60 us of fixed coding overhead per round trip, largely independent of transport. Decoding costs more than encoding: the 1 KB *get* is worse than the 1 KB *set* on every transport. Notifications are among the worst affected, which matters more than the round-trip figures for a device pushing subscriptions. Re-running the whole matrix reproduced these ratios to a median drift of 1.4% (max 3.1%).

## Caveats

- The workload is a scalar string plus 1 KB string get/set. It exercises no lists, vectors or bounded properties, which is where OCP.2's named-member encoding should cost most. Worth adding before treating these as a general verdict — happy to do that as a follow-up.
- Loopback only: on a real network the link latency dilutes the ratios, so the figure to carry across is the ~50–60 us absolute overhead rather than the multiplier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SekzA9KbmXB26GUsLuS4PQ
