### PR TITLE
Log each endpoint's control protocol when it starts

### DIFF
--- a/Sources/SwiftOCADevice/OCP.1/Backend/CF/Ocp1CFDeviceEndpoint.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/CF/Ocp1CFDeviceEndpoint.swift
@@ -148,7 +148,7 @@ public final class Ocp1CFStreamDeviceEndpoint: Ocp1CFDeviceEndpoint,
   }
 
   override public func run() async throws {
-    logger.info("starting \(type(of: self)) on \(address._presentationAddress)")
+    logger.info("starting \(type(of: self)) (\(controlProtocol)) on \(address._presentationAddress)")
     try await super.run()
     socket = try await makeSocketAndListen()
     notificationSocket = try await makeNotificationSocket()
@@ -231,7 +231,7 @@ public class Ocp1CFDatagramDeviceEndpoint: Ocp1CFDeviceEndpoint,
   }
 
   override public func run() async throws {
-    logger.info("starting \(type(of: self)) on \(address._presentationAddress)")
+    logger.info("starting \(type(of: self)) (\(controlProtocol)) on \(address._presentationAddress)")
     try await super.run()
     socket = try await makeSocket()
     repeat {

--- a/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingSocksDatagramDeviceEndpoint.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingSocksDatagramDeviceEndpoint.swift
@@ -144,7 +144,7 @@ public final class Ocp1FlyingSocksDatagramDeviceEndpoint: OcaDeviceEndpointPriva
 
   public func run() async throws {
     let socket = try await preparePoolAndSocket()
-    logger.info("starting \(type(of: self)) on \(presentationAddress)")
+    logger.info("starting \(type(of: self)) (\(controlProtocol)) on \(presentationAddress)")
     do {
       if port != 0 {
         #if canImport(dnssd)

--- a/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingSocksStreamDeviceEndpoint.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/FlyingSocks/Ocp1FlyingSocksStreamDeviceEndpoint.swift
@@ -139,7 +139,7 @@ public final class Ocp1FlyingSocksStreamDeviceEndpoint: OcaDeviceEndpointPrivate
 
   public func run() async throws {
     let socket = try await preparePoolAndSocket()
-    logger.info("starting \(type(of: self)) on \(presentationAddress)")
+    logger.info("starting \(type(of: self)) (\(controlProtocol)) on \(presentationAddress)")
     do {
       if port != 0 {
         #if canImport(dnssd)

--- a/Sources/SwiftOCADevice/OCP.1/Backend/IORing/Ocp1IORingDeviceEndpoint.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/IORing/Ocp1IORingDeviceEndpoint.swift
@@ -176,7 +176,7 @@ public final class Ocp1IORingStreamDeviceEndpoint: Ocp1IORingDeviceEndpoint,
   }
 
   override public func run() async throws {
-    logger.info("starting \(type(of: self)) on \(address._presentationAddress)")
+    logger.info("starting \(type(of: self)) (\(controlProtocol)) on \(address._presentationAddress)")
     try await super.run()
     let socket = try makeSocketAndListen()
     self.socket = socket
@@ -357,7 +357,7 @@ public class Ocp1IORingDatagramDeviceEndpoint: Ocp1IORingDeviceEndpoint,
   }
 
   override public func run() async throws {
-    logger.info("starting \(type(of: self)) on \(address._presentationAddress)")
+    logger.info("starting \(type(of: self)) (\(controlProtocol)) on \(address._presentationAddress)")
     try await super.run()
 
     let socket = try makeSocket()

--- a/Sources/SwiftOCADevice/OCP.1/Backend/Network/Ocp1NWDatagramDeviceEndpoint.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/Network/Ocp1NWDatagramDeviceEndpoint.swift
@@ -146,7 +146,7 @@ open class Ocp1NWDatagramDeviceEndpoint: OcaDeviceEndpointPrivate,
       connections.continuation.yield(connection)
     }
     listener.start(queue: queue)
-    logger.info("starting \(type(of: self)) on port \(_port.rawValue)")
+    logger.info("starting \(type(of: self)) (\(controlProtocol)) on port \(_port.rawValue)")
 
     // Bonjour registration is wired up in `_resolveBoundPort` once the
     // OS-assigned port is known — DNS-SD silently rejects port 0.

--- a/Sources/SwiftOCADevice/OCP.1/Backend/Network/Ocp1NWStreamDeviceEndpoint.swift
+++ b/Sources/SwiftOCADevice/OCP.1/Backend/Network/Ocp1NWStreamDeviceEndpoint.swift
@@ -157,7 +157,7 @@ open class Ocp1NWStreamDeviceEndpoint: OcaDeviceEndpointPrivate,
       connections.continuation.yield(connection)
     }
     listener.start(queue: queue)
-    logger.info("starting \(type(of: self)) on port \(_port.rawValue)")
+    logger.info("starting \(type(of: self)) (\(controlProtocol)) on port \(_port.rawValue)")
 
     // Bonjour registration is wired up in `_resolveBoundPort` once the
     // OS-assigned port is known — DNS-SD silently rejects port 0.

--- a/Sources/SwiftOCASecureDevice/OCP.1/Backend/OpenSSL/Ocp1OpenSSLDTLSDeviceEndpoint.swift
+++ b/Sources/SwiftOCASecureDevice/OCP.1/Backend/OpenSSL/Ocp1OpenSSLDTLSDeviceEndpoint.swift
@@ -186,7 +186,7 @@ public final class Ocp1OpenSSLDTLSDeviceEndpoint: Ocp1IORingDeviceEndpoint,
   }
 
   override public func run() async throws {
-    logger.info("starting \(type(of: self)) on \(address._presentationAddress)")
+    logger.info("starting \(type(of: self)) (\(controlProtocol)) on \(address._presentationAddress)")
     if clientCertificateTrustRoots != nil {
       logger.info("\(type(of: self)) requires client certificates (mTLS)")
     }

--- a/Sources/SwiftOCASecureDevice/OCP.1/Backend/OpenSSL/Ocp1OpenSSLStreamDeviceEndpoint.swift
+++ b/Sources/SwiftOCASecureDevice/OCP.1/Backend/OpenSSL/Ocp1OpenSSLStreamDeviceEndpoint.swift
@@ -151,7 +151,7 @@ public final class Ocp1OpenSSLStreamDeviceEndpoint: Ocp1IORingDeviceEndpoint,
   }
 
   override public func run() async throws {
-    logger.info("starting \(type(of: self)) on \(address._presentationAddress)")
+    logger.info("starting \(type(of: self)) (\(controlProtocol)) on \(address._presentationAddress)")
     if clientCertificateTrustRoots != nil {
       logger.info("\(type(of: self)) requires client certificates (mTLS)")
     }


### PR DESCRIPTION
OCP.1 and OCP.2 endpoints share their type names, so the start log couldn't tell them apart:

```
starting Ocp1IORingStreamDeviceEndpoint on 0.0.0.0:65000
starting Ocp1IORingStreamDeviceEndpoint on 0.0.0.0:65001
```

Each endpoint's start log now includes its control protocol:

```
starting Ocp1IORingStreamDeviceEndpoint (ocp1) on 0.0.0.0:65000
starting Ocp1IORingStreamDeviceEndpoint (ocp2) on 0.0.0.0:65001
```

Covers the IORing, FlyingSocks, Network, CF and OpenSSL endpoints. Built on Linux (IORing, FlyingSocks, OpenSSL); the Network and CF backends are Apple-only and weren't compiled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nh7LMU9iTq4bqbrFrMDB2c