### PR TITLE
Offer the JSON property name as private API

### DIFF
--- a/Sources/SwiftOCA/OCC/ControlClasses/Root.swift
+++ b/Sources/SwiftOCA/OCC/ControlClasses/Root.swift
@@ -188,7 +188,11 @@ open class OcaRoot: CustomStringConvertible, @unchecked Sendable, _OcaObjectKeyP
   /// what AES70-2 calls that property (`ONo` is the model's name for object-number
   /// *parameters* and struct fields, not for this). A property the reflected table
   /// does not know falls back to its property ID.
-  func _jsonPropertyName(for propertyID: OcaPropertyID) -> String {
+  ///
+  /// Private API, so that `ocacli` can name the properties it dumps from the device's own
+  /// OCP.2 responses the same way.
+  @_spi(SwiftOCAPrivate)
+  public func _jsonPropertyName(for propertyID: OcaPropertyID) -> String {
     guard let name = propertyName(for: propertyID) else {
       return propertyID.description
     }


### PR DESCRIPTION
Makes `OcaRoot._jsonPropertyName(for:)` `@_spi(SwiftOCAPrivate) public`.

ocacli's `--ocp2` dump takes the device's own getter responses verbatim, and needs to key each one by its property. It can't use the response parameter's name for that, because those names collide: `GetActionObjects` and `GetDatasetObjects` both answer `Objects`, and `GetMostRecentParamDatasetONo` answers `ONo`. Using the same lookup as the JSON export means OCP.1 and OCP.2 dumps name properties identically, and ocacli doesn't have to copy the naming rule.

No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXw9wXPZmojj2DrARGXYiS